### PR TITLE
feature(es-sink): Make indexName optional.

### DIFF
--- a/docs/modules/ROOT/pages/elasticsearch-index-sink.adoc
+++ b/docs/modules/ROOT/pages/elasticsearch-index-sink.adoc
@@ -12,6 +12,8 @@ If the *indexId* parameter is set, that value will be used as the document ID on
 If the *indexId* parameter is not set and the source of the kamelet binding is a Kafka broker, it will take the kafka topic, partition and offset of the
 element to generate an automatic ID that warrantees that this element is processed only once.
 
+If the *indexName* parameter is not set and the source of the kamelet binding is a Kafka broker, it will take the kafka topic as the indexName.
+
 == Configuration Options
 
 The following table summarizes the configuration options available for the `elasticsearch-index-sink` Kamelet:

--- a/docs/modules/ROOT/pages/elasticsearch-index-sink.adoc
+++ b/docs/modules/ROOT/pages/elasticsearch-index-sink.adoc
@@ -20,9 +20,9 @@ The following table summarizes the configuration options available for the `elas
 | Property| Name| Description| Type| Default| Example
 | *clusterName {empty}* *| ElasticSearch Cluster Name| Name of the cluster.| string| | `"quickstart"`
 | *hostAddresses {empty}* *| Host Addresses| Comma separated list with ip:port formatted remote transport addresses to use.| string| | `"quickstart-es-http:9200"`
-| *indexName {empty}* *| Index in ElasticSearch| The name of the index to act against.| string| | `"data"`
 | enableSSL| Enable SSL| Do we want to connect using SSL?| boolean| `true`| 
 | indexId| Index ID| None| string| `"NONE"`| 
+| indexName| Index in ElasticSearch| The name of the index to act against.| string| `"NONE"`| `"data"`
 | password| Password| Password to connect to ElasticSearch.| string| | 
 | user| Username| Username to connect to ElasticSearch.| string| | 
 |===
@@ -58,7 +58,6 @@ spec:
     properties:
       clusterName: "quickstart"
       hostAddresses: "quickstart-es-http:9200"
-      indexName: "data"
 
 ----
 

--- a/elasticsearch-index-sink.kamelet.yaml
+++ b/elasticsearch-index-sink.kamelet.yaml
@@ -31,7 +31,6 @@ spec:
       element to generate an automatic ID that warrantees that this element is processed only once.
     required:
       - clusterName
-      - indexName
       - hostAddresses
     type: object
     properties:
@@ -60,6 +59,7 @@ spec:
         description: The name of the index to act against.
         type: string
         example: data
+        default: 'NONE'
       clusterName:
         title: ElasticSearch Cluster Name
         description: Name of the cluster.
@@ -69,7 +69,7 @@ spec:
         title: Index ID
         description: None
         type: string
-        default: "NONE"
+        default: 'NONE'
   types:
     out:
       mediaType: application/json
@@ -97,14 +97,18 @@ spec:
                   - set-header:
                       name: "indexId"
                       simple: "{{indexId}}"
-        - to:
-            uri: "kamelet-reify:elasticsearch-rest:{{clusterName}}"
-            parameters:
-              operation: "INDEX"
-              indexName: "{{indexName}}"
-              hostAddresses: "{{hostAddresses}}"
-              enableSSL: "{{enableSSL}}"
-              user: "{{user}}"
-              password: "{{password}}"
+        - choice:
+            when:
+              - simple: "'{{indexName}}' == 'NONE'"
+                steps:
+                  - set-property:
+                      name: esIndexName
+                      simple: "${header[kafka.TOPIC]}"
+            otherwise:
+              steps:
+                - set-property:
+                    name: esIndexName
+                    simple: "{{indexName}}"
+        - to-d: "kamelet-reify:elasticsearch-rest:{{clusterName}}?hostAddresses=RAW({{hostAddresses}})&operation=INDEX&indexName=${exchangeProperty.esIndexName}&enableSSL={{enableSSL}}&user={{user}}&password={{password}}"
         - marshal:
             json: { }

--- a/elasticsearch-index-sink.kamelet.yaml
+++ b/elasticsearch-index-sink.kamelet.yaml
@@ -29,6 +29,8 @@ spec:
 
       If the *indexId* parameter is not set and the source of the kamelet binding is a Kafka broker, it will take the kafka topic, partition and offset of the
       element to generate an automatic ID that warrantees that this element is processed only once.
+
+      If the *indexName* parameter is not set and the source of the kamelet binding is a Kafka broker, it will take the kafka topic as the indexName.
     required:
       - clusterName
       - hostAddresses


### PR DESCRIPTION
If there is no indexName parameter, try to extract from previous step if previous step is a Kafka source.