### PR TITLE
AWS S3 Sink Kamelet: removed Override option for URI

### DIFF
--- a/aws-s3-sink.kamelet.yaml
+++ b/aws-s3-sink.kamelet.yaml
@@ -51,18 +51,6 @@ spec:
         description: The AWS region to connect to.
         type: string
         example: eu-west-1
-      overrideEndpoint:
-        title: Override Endpoint
-        description: Set the need for overidding the endpoint. This option needs to be used in combination with uriEndpointOverride.
-        type: boolean
-        default: false
-        x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
-      uriEndpointOverride:
-        title: Override Endpoint URI
-        description: Set the overriding uri endpoint. This option needs to be used in combination with overrideEndpoint option.
-        type: string
-        example: "http://another-s3-endpoint:9000"
       autoCreateBucket:
         title: Autocreate Bucket
         description: Setting the autocreation of the S3 bucket bucketName.
@@ -100,6 +88,4 @@ spec:
             secretKey: "{{secretKey}}"
             accessKey: "{{accessKey}}"
             region: "{{region}}"
-            uriEndpointOverride: "{{uriEndpointOverride}}"
-            overrideEndpoint: "{{overrideEndpoint}}"
             autoCreateBucket: "{{autoCreateBucket}}"

--- a/docs/modules/ROOT/pages/aws-s3-sink.adoc
+++ b/docs/modules/ROOT/pages/aws-s3-sink.adoc
@@ -24,8 +24,6 @@ The following table summarizes the configuration options available for the `aws-
 | *region {empty}* *| AWS Region| The AWS region to connect to.| string| | `"eu-west-1"`
 | *secretKey {empty}* *| Secret Key| The secret key obtained from AWS.| string| | 
 | autoCreateBucket| Autocreate Bucket| Setting the autocreation of the S3 bucket bucketName.| boolean| `false`| 
-| overrideEndpoint| Override Endpoint| Set the need for overidding the endpoint. This option needs to be used in combination with uriEndpointOverride.| boolean| `false`| 
-| uriEndpointOverride| Override Endpoint URI| Set the overriding uri endpoint. This option needs to be used in combination with overrideEndpoint option.| string| | `"http://another-s3-endpoint:9000"`
 |===
 
 NOTE: Fields marked with ({empty}*) are mandatory.

--- a/library/camel-kamelets-catalog/src/main/resources/kamelets/aws-s3-sink.kamelet.yaml
+++ b/library/camel-kamelets-catalog/src/main/resources/kamelets/aws-s3-sink.kamelet.yaml
@@ -51,18 +51,6 @@ spec:
         description: The AWS region to connect to.
         type: string
         example: eu-west-1
-      overrideEndpoint:
-        title: Override Endpoint
-        description: Set the need for overidding the endpoint. This option needs to be used in combination with uriEndpointOverride.
-        type: boolean
-        default: false
-        x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
-      uriEndpointOverride:
-        title: Override Endpoint URI
-        description: Set the overriding uri endpoint. This option needs to be used in combination with overrideEndpoint option.
-        type: string
-        example: "http://another-s3-endpoint:9000"
       autoCreateBucket:
         title: Autocreate Bucket
         description: Setting the autocreation of the S3 bucket bucketName.
@@ -100,6 +88,4 @@ spec:
             secretKey: "{{secretKey}}"
             accessKey: "{{accessKey}}"
             region: "{{region}}"
-            uriEndpointOverride: "{{uriEndpointOverride}}"
-            overrideEndpoint: "{{overrideEndpoint}}"
             autoCreateBucket: "{{autoCreateBucket}}"


### PR DESCRIPTION
If those are needed for minio, we could use the minio kamelet. Or users can create their own Kamelet