### PR TITLE
Space in property "name" of insert-header-action seems to cause java.…

### DIFF
--- a/docs/modules/ROOT/pages/insert-header-action.adoc
+++ b/docs/modules/ROOT/pages/insert-header-action.adoc
@@ -48,7 +48,7 @@ spec:
       apiVersion: camel.apache.org/v1alpha1
       name: insert-header-action
     properties:
-      name: "The Name"
+      name: "TheName"
       value: "The Value"
   sink:
     ref:


### PR DESCRIPTION
…lang.IllegalArgumentException

[1] 2021-06-09 19:43:08,803 INFO  [org.apa.cam.imp.eng.AbstractCamelContext] (main) Apache Camel 3.9.0 (camel-1) started in 269ms (build:0ms init:211ms start:58ms)
[1] 2021-06-09 19:43:08,899 INFO  [io.quarkus] (main) camel-k-integration 1.4.0 on JVM (powered by Quarkus 1.13.0.Final) started in 1.604s. Listening on: http://0.0.0.0:8080
[1] 2021-06-09 19:43:08,900 INFO  [io.quarkus] (main) Profile prod activated. 
[1] 2021-06-09 19:43:08,900 INFO  [io.quarkus] (main) Installed features: [camel-attachments, camel-bean, camel-core, camel-k-cloudevents, camel-k-core, camel-k-knative, camel-k-knative-producer, camel-k-loader-yaml, camel-k-runtime, camel-kamelet, camel-platform-http, camel-support-common, camel-timer, camel-yaml-dsl, cdi, mutiny, smallrye-context-propagation, vertx, vertx-web]
I observed following exception on OCP 4.7, community operator Camel K 1.4:

[1] 2021-06-09 19:43:09,858 WARN  [org.apa.cam.imp.eng.DefaultReactiveExecutor] (Camel (camel-1) thread #0 - timer://tick) Error executing reactive work due to a header name cannot contain the following prohibited characters: =,;: \t\r\n\v\f: The Name. This exception is ignored.: java.lang.IllegalArgumentException: a header name cannot contain the following prohibited characters: =,;: \t\r\n\v\f: The Name
[1]     at io.vertx.core.http.impl.HttpUtils.validateHeaderName(HttpUtils.java:766)
[1]     at io.vertx.core.http.impl.HttpUtils.validateHeader(HttpUtils.java:673)
[1]     at io.vertx.core.http.impl.headers.VertxHttpHeaders.add0(VertxHttpHeaders.java:531)