### PR TITLE
AWS Kinesis Kamelets: Region is not capitalized

### DIFF
--- a/aws-kinesis-sink.kamelet.yaml
+++ b/aws-kinesis-sink.kamelet.yaml
@@ -54,7 +54,7 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:password
       region:
         title: AWS Region
-        description: The AWS region to connect to (capitalized name)
+        description: The AWS region to connect to
         type: string
         example: eu-west-1
   dependencies:

--- a/aws-kinesis-source.kamelet.yaml
+++ b/aws-kinesis-source.kamelet.yaml
@@ -42,7 +42,7 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:password
       region:
         title: AWS Region
-        description: The AWS region to connect to (capitalized name)
+        description: The AWS region to connect to
         type: string
         example: eu-west-1
   dependencies:

--- a/docs/modules/ROOT/pages/aws-kinesis-sink.adoc
+++ b/docs/modules/ROOT/pages/aws-kinesis-sink.adoc
@@ -26,7 +26,7 @@ The following table summarizes the configuration options available for the `aws-
 |===
 | Property| Name| Description| Type| Default| Example
 | *accessKey {empty}* *| Access Key| The access key obtained from AWS| string| | 
-| *region {empty}* *| AWS Region| The AWS region to connect to (capitalized name)| string| | `"eu-west-1"`
+| *region {empty}* *| AWS Region| The AWS region to connect to| string| | `"eu-west-1"`
 | *secretKey {empty}* *| Secret Key| The secret key obtained from AWS| string| | 
 | *stream {empty}* *| Stream Name| The Kinesis stream that you want to access (needs to be created in advance)| string| | 
 |===

--- a/docs/modules/ROOT/pages/aws-kinesis-source.adoc
+++ b/docs/modules/ROOT/pages/aws-kinesis-source.adoc
@@ -14,7 +14,7 @@ The following table summarizes the configuration options available for the `aws-
 |===
 | Property| Name| Description| Type| Default| Example
 | *accessKey {empty}* *| Access Key| The access key obtained from AWS| string| | 
-| *region {empty}* *| AWS Region| The AWS region to connect to (capitalized name)| string| | `"eu-west-1"`
+| *region {empty}* *| AWS Region| The AWS region to connect to| string| | `"eu-west-1"`
 | *secretKey {empty}* *| Secret Key| The secret key obtained from AWS| string| | 
 | *stream {empty}* *| Stream Name| The Kinesis stream that you want to access (needs to be created in advance)| string| | 
 |===

--- a/library/camel-kamelets-catalog/src/main/resources/kamelets/aws-kinesis-sink.kamelet.yaml
+++ b/library/camel-kamelets-catalog/src/main/resources/kamelets/aws-kinesis-sink.kamelet.yaml
@@ -54,7 +54,7 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:password
       region:
         title: AWS Region
-        description: The AWS region to connect to (capitalized name)
+        description: The AWS region to connect to
         type: string
         example: eu-west-1
   dependencies:

--- a/library/camel-kamelets-catalog/src/main/resources/kamelets/aws-kinesis-source.kamelet.yaml
+++ b/library/camel-kamelets-catalog/src/main/resources/kamelets/aws-kinesis-source.kamelet.yaml
@@ -42,7 +42,7 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:password
       region:
         title: AWS Region
-        description: The AWS region to connect to (capitalized name)
+        description: The AWS region to connect to
         type: string
         example: eu-west-1
   dependencies:


### PR DESCRIPTION
Fixes #347 