### PR TITLE
Remove wrong type in aws-sqs-source

### DIFF
--- a/aws-sqs-source.kamelet.yaml
+++ b/aws-sqs-source.kamelet.yaml
@@ -59,9 +59,6 @@ spec:
         x-descriptors:
         - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
-  types:
-    out:
-      mediaType: application/json
   dependencies:
     - "camel:aws2-sqs"
     - "camel:kamelet"


### PR DESCRIPTION
That kamelet produces the source data, not json