### PR TITLE
Externalize the Kamelet binding template in the Kafka Source

### DIFF
--- a/docs/modules/ROOT/kamelet-binding-sink-source.tmpl
+++ b/docs/modules/ROOT/kamelet-binding-sink-source.tmpl
@@ -1,0 +1,43 @@
+apiVersion: camel.apache.org/v1alpha1
+kind: KameletBinding
+metadata:
+  name: {{ .Kamelet.ObjectMeta.Name }}-binding
+spec:
+  {{ if eq (index .Kamelet.ObjectMeta.Labels "camel.apache.org/kamelet.type") "sink" }}source:
+    ref:
+      kind: {{ .GetVal "RefKind" }}
+      apiVersion: {{ .GetVal "RefApiVersion" }}
+      name: {{ .GetVal "RefName" }}
+  sink:
+    ref:
+      kind: Kamelet
+      apiVersion: camel.apache.org/v1alpha1
+      name: {{ .Kamelet.ObjectMeta.Name }}{{ template "properties-list.tmpl" . }}
+  {{ else if eq (index .Kamelet.ObjectMeta.Labels "camel.apache.org/kamelet.type") "source" }}source:
+    ref:
+      kind: Kamelet
+      apiVersion: camel.apache.org/v1alpha1
+      name: {{ .Kamelet.ObjectMeta.Name }}{{ template "properties-list.tmpl" . }}
+  sink:
+    ref:
+      kind: {{ .GetVal "RefKind" }}
+      apiVersion: {{ .GetVal "RefApiVersion" }}
+      name: {{ .GetVal "RefName" }}
+  {{ else if eq (index .Kamelet.ObjectMeta.Labels "camel.apache.org/kamelet.type") "action" }}source:
+    ref:
+      kind: Kamelet
+      apiVersion: camel.apache.org/v1alpha1
+      name: timer-source
+    properties:
+      message: "Hello"
+  steps:
+  - ref:
+      kind: Kamelet
+      apiVersion: camel.apache.org/v1alpha1
+      name: {{ .Kamelet.ObjectMeta.Name }}{{ template "properties-list.tmpl" . }}
+  sink:
+    ref:
+      kind: {{ .GetVal "RefKind" }}
+      apiVersion: {{ .GetVal "RefApiVersion" }}
+      name: {{ .GetVal "RefName" }}
+{{ end }}

--- a/docs/modules/ROOT/kamelet.adoc.tmpl
+++ b/docs/modules/ROOT/kamelet.adoc.tmpl
@@ -26,7 +26,12 @@ The `{{ .Kamelet.ObjectMeta.Name }}` Kamelet can be used as intermediate step in
 {{ else -}}
 The `{{ .Kamelet.ObjectMeta.Name }}` Kamelet can be used as Knative {{ index .Kamelet.ObjectMeta.Labels "camel.apache.org/kamelet.type" }} by binding it to a Knative object.
 {{ end }}
-{{ .ExampleBinding "messaging.knative.dev/v1" "InMemoryChannel" "mychannel" }}
+{{- .SetVal "RefApiVersion" "messaging.knative.dev/v1" -}}{{- .SetVal "RefKind" "InMemoryChannel" -}}{{- .SetVal "RefName" "mychannel" }}
+.{{ .Kamelet.ObjectMeta.Name }}-binding.yaml
+[source,yaml]
+----
+{{ template "kamelet-binding-sink-source.tmpl" . }}
+----
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `{{ .Kamelet.ObjectMeta.Name }}-binding.yaml` file into your hard drive, then configure it according to your needs.
@@ -55,8 +60,13 @@ This will create the KameletBinding under the hood and apply it to the current n
 The `{{ .Kamelet.ObjectMeta.Name }}` Kamelet can be used as intermediate step in a Kafka binding.
 {{ else -}}
 The `{{ .Kamelet.ObjectMeta.Name }}` Kamelet can be used as Kafka {{ index .Kamelet.ObjectMeta.Labels "camel.apache.org/kamelet.type" }} by binding it to a Kafka topic.
-{{ end }}
-{{ .ExampleBinding "kafka.strimzi.io/v1beta1" "KafkaTopic" "my-topic" }}
+{{ end }} {{- .SetVal "RefApiVersion" "kafka.strimzi.io/v1beta1" -}}{{- .SetVal "RefKind" "KafkaTopic" -}}{{- .SetVal "RefName" "my-topic" }}
+.{{ .Kamelet.ObjectMeta.Name }}-binding.yaml
+[source,yaml]
+----
+{{ template "kamelet-binding-sink-source.tmpl" . }}
+----
+
 Ensure that you've installed https://strimzi.io/[Strimzi] and created a topic named `my-topic` in the current namespace.
 Make also sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 

--- a/docs/modules/ROOT/pages/avro-deserialize-action.adoc
+++ b/docs/modules/ROOT/pages/avro-deserialize-action.adoc
@@ -56,7 +56,6 @@ spec:
       name: mychannel
 
 ----
-
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `avro-deserialize-action-binding.yaml` file into your hard drive, then configure it according to your needs.

--- a/docs/modules/ROOT/pages/avro-serialize-action.adoc
+++ b/docs/modules/ROOT/pages/avro-serialize-action.adoc
@@ -56,7 +56,6 @@ spec:
       name: mychannel
 
 ----
-
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `avro-serialize-action-binding.yaml` file into your hard drive, then configure it according to your needs.

--- a/docs/modules/ROOT/pages/aws-cloudwatch-sink.adoc
+++ b/docs/modules/ROOT/pages/aws-cloudwatch-sink.adoc
@@ -61,9 +61,8 @@ spec:
       cw_namespace: "The Cloud Watch Namespace"
       region: "eu-west-1"
       secretKey: "The Secret Key"
-
+  
 ----
-
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `aws-cloudwatch-sink-binding.yaml` file into your hard drive, then configure it according to your needs.
@@ -113,7 +112,7 @@ spec:
       cw_namespace: "The Cloud Watch Namespace"
       region: "eu-west-1"
       secretKey: "The Secret Key"
-
+  
 ----
 
 Ensure that you've installed https://strimzi.io/[Strimzi] and created a topic named `my-topic` in the current namespace.

--- a/docs/modules/ROOT/pages/aws-ddb-streams-source.adoc
+++ b/docs/modules/ROOT/pages/aws-ddb-streams-source.adoc
@@ -54,9 +54,8 @@ spec:
       kind: InMemoryChannel
       apiVersion: messaging.knative.dev/v1
       name: mychannel
-
+  
 ----
-
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `aws-ddb-streams-source-binding.yaml` file into your hard drive, then configure it according to your needs.
@@ -106,7 +105,7 @@ spec:
       kind: KafkaTopic
       apiVersion: kafka.strimzi.io/v1beta1
       name: my-topic
-
+  
 ----
 
 Ensure that you've installed https://strimzi.io/[Strimzi] and created a topic named `my-topic` in the current namespace.

--- a/docs/modules/ROOT/pages/aws-ec2-sink.adoc
+++ b/docs/modules/ROOT/pages/aws-ec2-sink.adoc
@@ -54,9 +54,8 @@ spec:
       accessKey: "The Access Key"
       region: "eu-west-1"
       secretKey: "The Secret Key"
-
+  
 ----
-
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `aws-ec2-sink-binding.yaml` file into your hard drive, then configure it according to your needs.
@@ -105,7 +104,7 @@ spec:
       accessKey: "The Access Key"
       region: "eu-west-1"
       secretKey: "The Secret Key"
-
+  
 ----
 
 Ensure that you've installed https://strimzi.io/[Strimzi] and created a topic named `my-topic` in the current namespace.

--- a/docs/modules/ROOT/pages/aws-kinesis-firehose-sink.adoc
+++ b/docs/modules/ROOT/pages/aws-kinesis-firehose-sink.adoc
@@ -52,9 +52,8 @@ spec:
       region: "eu-west-1"
       secretKey: "The Secret Key"
       streamName: "The Stream Name"
-
+  
 ----
-
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `aws-kinesis-firehose-sink-binding.yaml` file into your hard drive, then configure it according to your needs.
@@ -104,7 +103,7 @@ spec:
       region: "eu-west-1"
       secretKey: "The Secret Key"
       streamName: "The Stream Name"
-
+  
 ----
 
 Ensure that you've installed https://strimzi.io/[Strimzi] and created a topic named `my-topic` in the current namespace.

--- a/docs/modules/ROOT/pages/aws-kinesis-sink.adoc
+++ b/docs/modules/ROOT/pages/aws-kinesis-sink.adoc
@@ -64,9 +64,8 @@ spec:
       region: "eu-west-1"
       secretKey: "The Secret Key"
       stream: "The Stream Name"
-
+  
 ----
-
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `aws-kinesis-sink-binding.yaml` file into your hard drive, then configure it according to your needs.
@@ -116,7 +115,7 @@ spec:
       region: "eu-west-1"
       secretKey: "The Secret Key"
       stream: "The Stream Name"
-
+  
 ----
 
 Ensure that you've installed https://strimzi.io/[Strimzi] and created a topic named `my-topic` in the current namespace.

--- a/docs/modules/ROOT/pages/aws-kinesis-source.adoc
+++ b/docs/modules/ROOT/pages/aws-kinesis-source.adoc
@@ -52,9 +52,8 @@ spec:
       kind: InMemoryChannel
       apiVersion: messaging.knative.dev/v1
       name: mychannel
-
+  
 ----
-
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `aws-kinesis-source-binding.yaml` file into your hard drive, then configure it according to your needs.
@@ -104,7 +103,7 @@ spec:
       kind: KafkaTopic
       apiVersion: kafka.strimzi.io/v1beta1
       name: my-topic
-
+  
 ----
 
 Ensure that you've installed https://strimzi.io/[Strimzi] and created a topic named `my-topic` in the current namespace.

--- a/docs/modules/ROOT/pages/aws-lambda-sink.adoc
+++ b/docs/modules/ROOT/pages/aws-lambda-sink.adoc
@@ -52,9 +52,8 @@ spec:
       function: "The Function Name"
       region: "eu-west-1"
       secretKey: "The Secret Key"
-
+  
 ----
-
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `aws-lambda-sink-binding.yaml` file into your hard drive, then configure it according to your needs.
@@ -104,7 +103,7 @@ spec:
       function: "The Function Name"
       region: "eu-west-1"
       secretKey: "The Secret Key"
-
+  
 ----
 
 Ensure that you've installed https://strimzi.io/[Strimzi] and created a topic named `my-topic` in the current namespace.

--- a/docs/modules/ROOT/pages/aws-s3-sink.adoc
+++ b/docs/modules/ROOT/pages/aws-s3-sink.adoc
@@ -59,9 +59,8 @@ spec:
       bucketNameOrArn: "The Bucket Name"
       region: "eu-west-1"
       secretKey: "The Secret Key"
-
+  
 ----
-
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `aws-s3-sink-binding.yaml` file into your hard drive, then configure it according to your needs.
@@ -111,7 +110,7 @@ spec:
       bucketNameOrArn: "The Bucket Name"
       region: "eu-west-1"
       secretKey: "The Secret Key"
-
+  
 ----
 
 Ensure that you've installed https://strimzi.io/[Strimzi] and created a topic named `my-topic` in the current namespace.

--- a/docs/modules/ROOT/pages/aws-s3-source.adoc
+++ b/docs/modules/ROOT/pages/aws-s3-source.adoc
@@ -57,9 +57,8 @@ spec:
       kind: InMemoryChannel
       apiVersion: messaging.knative.dev/v1
       name: mychannel
-
+  
 ----
-
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `aws-s3-source-binding.yaml` file into your hard drive, then configure it according to your needs.
@@ -109,7 +108,7 @@ spec:
       kind: KafkaTopic
       apiVersion: kafka.strimzi.io/v1beta1
       name: my-topic
-
+  
 ----
 
 Ensure that you've installed https://strimzi.io/[Strimzi] and created a topic named `my-topic` in the current namespace.

--- a/docs/modules/ROOT/pages/aws-s3-streaming-upload-sink.adoc
+++ b/docs/modules/ROOT/pages/aws-s3-streaming-upload-sink.adoc
@@ -60,9 +60,8 @@ spec:
       keyName: "The Key Name"
       region: "eu-west-1"
       secretKey: "The Secret Key"
-
+  
 ----
-
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `aws-s3-streaming-upload-sink-binding.yaml` file into your hard drive, then configure it according to your needs.
@@ -113,7 +112,7 @@ spec:
       keyName: "The Key Name"
       region: "eu-west-1"
       secretKey: "The Secret Key"
-
+  
 ----
 
 Ensure that you've installed https://strimzi.io/[Strimzi] and created a topic named `my-topic` in the current namespace.

--- a/docs/modules/ROOT/pages/aws-sns-fifo-sink.adoc
+++ b/docs/modules/ROOT/pages/aws-sns-fifo-sink.adoc
@@ -54,9 +54,8 @@ spec:
       region: "eu-west-1"
       secretKey: "The Secret Key"
       topicNameOrArn: "The Topic Name"
-
+  
 ----
-
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `aws-sns-fifo-sink-binding.yaml` file into your hard drive, then configure it according to your needs.
@@ -106,7 +105,7 @@ spec:
       region: "eu-west-1"
       secretKey: "The Secret Key"
       topicNameOrArn: "The Topic Name"
-
+  
 ----
 
 Ensure that you've installed https://strimzi.io/[Strimzi] and created a topic named `my-topic` in the current namespace.

--- a/docs/modules/ROOT/pages/aws-sns-sink.adoc
+++ b/docs/modules/ROOT/pages/aws-sns-sink.adoc
@@ -53,9 +53,8 @@ spec:
       region: "eu-west-1"
       secretKey: "The Secret Key"
       topicNameOrArn: "The Topic Name"
-
+  
 ----
-
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `aws-sns-sink-binding.yaml` file into your hard drive, then configure it according to your needs.
@@ -105,7 +104,7 @@ spec:
       region: "eu-west-1"
       secretKey: "The Secret Key"
       topicNameOrArn: "The Topic Name"
-
+  
 ----
 
 Ensure that you've installed https://strimzi.io/[Strimzi] and created a topic named `my-topic` in the current namespace.

--- a/docs/modules/ROOT/pages/aws-sqs-batch-sink.adoc
+++ b/docs/modules/ROOT/pages/aws-sqs-batch-sink.adoc
@@ -55,9 +55,8 @@ spec:
       queueNameOrArn: "The Queue Name"
       region: "eu-west-1"
       secretKey: "The Secret Key"
-
+  
 ----
-
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `aws-sqs-batch-sink-binding.yaml` file into your hard drive, then configure it according to your needs.
@@ -108,7 +107,7 @@ spec:
       queueNameOrArn: "The Queue Name"
       region: "eu-west-1"
       secretKey: "The Secret Key"
-
+  
 ----
 
 Ensure that you've installed https://strimzi.io/[Strimzi] and created a topic named `my-topic` in the current namespace.

--- a/docs/modules/ROOT/pages/aws-sqs-fifo-sink.adoc
+++ b/docs/modules/ROOT/pages/aws-sqs-fifo-sink.adoc
@@ -54,9 +54,8 @@ spec:
       queueNameOrArn: "The Queue Name"
       region: "eu-west-1"
       secretKey: "The Secret Key"
-
+  
 ----
-
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `aws-sqs-fifo-sink-binding.yaml` file into your hard drive, then configure it according to your needs.
@@ -106,7 +105,7 @@ spec:
       queueNameOrArn: "The Queue Name"
       region: "eu-west-1"
       secretKey: "The Secret Key"
-
+  
 ----
 
 Ensure that you've installed https://strimzi.io/[Strimzi] and created a topic named `my-topic` in the current namespace.

--- a/docs/modules/ROOT/pages/aws-sqs-sink.adoc
+++ b/docs/modules/ROOT/pages/aws-sqs-sink.adoc
@@ -53,9 +53,8 @@ spec:
       queueNameOrArn: "The Queue Name"
       region: "eu-west-1"
       secretKey: "The Secret Key"
-
+  
 ----
-
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `aws-sqs-sink-binding.yaml` file into your hard drive, then configure it according to your needs.
@@ -105,7 +104,7 @@ spec:
       queueNameOrArn: "The Queue Name"
       region: "eu-west-1"
       secretKey: "The Secret Key"
-
+  
 ----
 
 Ensure that you've installed https://strimzi.io/[Strimzi] and created a topic named `my-topic` in the current namespace.

--- a/docs/modules/ROOT/pages/aws-sqs-source.adoc
+++ b/docs/modules/ROOT/pages/aws-sqs-source.adoc
@@ -54,9 +54,8 @@ spec:
       kind: InMemoryChannel
       apiVersion: messaging.knative.dev/v1
       name: mychannel
-
+  
 ----
-
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `aws-sqs-source-binding.yaml` file into your hard drive, then configure it according to your needs.
@@ -106,7 +105,7 @@ spec:
       kind: KafkaTopic
       apiVersion: kafka.strimzi.io/v1beta1
       name: my-topic
-
+  
 ----
 
 Ensure that you've installed https://strimzi.io/[Strimzi] and created a topic named `my-topic` in the current namespace.

--- a/docs/modules/ROOT/pages/aws-translate-action.adoc
+++ b/docs/modules/ROOT/pages/aws-translate-action.adoc
@@ -63,7 +63,6 @@ spec:
       name: mychannel
 
 ----
-
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `aws-translate-action-binding.yaml` file into your hard drive, then configure it according to your needs.

--- a/docs/modules/ROOT/pages/azure-cosmosdb-source.adoc
+++ b/docs/modules/ROOT/pages/azure-cosmosdb-source.adoc
@@ -56,9 +56,8 @@ spec:
       kind: InMemoryChannel
       apiVersion: messaging.knative.dev/v1
       name: mychannel
-
+  
 ----
-
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `azure-cosmosdb-source-binding.yaml` file into your hard drive, then configure it according to your needs.
@@ -108,7 +107,7 @@ spec:
       kind: KafkaTopic
       apiVersion: kafka.strimzi.io/v1beta1
       name: my-topic
-
+  
 ----
 
 Ensure that you've installed https://strimzi.io/[Strimzi] and created a topic named `my-topic` in the current namespace.

--- a/docs/modules/ROOT/pages/azure-eventhubs-sink.adoc
+++ b/docs/modules/ROOT/pages/azure-eventhubs-sink.adoc
@@ -58,9 +58,8 @@ spec:
       namespaceName: "The Eventhubs Namespace"
       sharedAccessKey: "The Share Access Key"
       sharedAccessName: "The Share Access Name"
-
+  
 ----
-
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `azure-eventhubs-sink-binding.yaml` file into your hard drive, then configure it according to your needs.
@@ -110,7 +109,7 @@ spec:
       namespaceName: "The Eventhubs Namespace"
       sharedAccessKey: "The Share Access Key"
       sharedAccessName: "The Share Access Name"
-
+  
 ----
 
 Ensure that you've installed https://strimzi.io/[Strimzi] and created a topic named `my-topic` in the current namespace.

--- a/docs/modules/ROOT/pages/azure-eventhubs-source.adoc
+++ b/docs/modules/ROOT/pages/azure-eventhubs-source.adoc
@@ -58,9 +58,8 @@ spec:
       kind: InMemoryChannel
       apiVersion: messaging.knative.dev/v1
       name: mychannel
-
+  
 ----
-
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `azure-eventhubs-source-binding.yaml` file into your hard drive, then configure it according to your needs.
@@ -113,7 +112,7 @@ spec:
       kind: KafkaTopic
       apiVersion: kafka.strimzi.io/v1beta1
       name: my-topic
-
+  
 ----
 
 Ensure that you've installed https://strimzi.io/[Strimzi] and created a topic named `my-topic` in the current namespace.

--- a/docs/modules/ROOT/pages/azure-storage-blob-sink.adoc
+++ b/docs/modules/ROOT/pages/azure-storage-blob-sink.adoc
@@ -57,9 +57,8 @@ spec:
       accessKey: "The Access Key"
       accountName: "The Account Name"
       containerName: "The Container Name"
-
+  
 ----
-
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `azure-storage-blob-sink-binding.yaml` file into your hard drive, then configure it according to your needs.
@@ -108,7 +107,7 @@ spec:
       accessKey: "The Access Key"
       accountName: "The Account Name"
       containerName: "The Container Name"
-
+  
 ----
 
 Ensure that you've installed https://strimzi.io/[Strimzi] and created a topic named `my-topic` in the current namespace.

--- a/docs/modules/ROOT/pages/azure-storage-blob-source.adoc
+++ b/docs/modules/ROOT/pages/azure-storage-blob-source.adoc
@@ -51,9 +51,8 @@ spec:
       kind: InMemoryChannel
       apiVersion: messaging.knative.dev/v1
       name: mychannel
-
+  
 ----
-
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `azure-storage-blob-source-binding.yaml` file into your hard drive, then configure it according to your needs.
@@ -102,7 +101,7 @@ spec:
       kind: KafkaTopic
       apiVersion: kafka.strimzi.io/v1beta1
       name: my-topic
-
+  
 ----
 
 Ensure that you've installed https://strimzi.io/[Strimzi] and created a topic named `my-topic` in the current namespace.

--- a/docs/modules/ROOT/pages/azure-storage-queue-sink.adoc
+++ b/docs/modules/ROOT/pages/azure-storage-queue-sink.adoc
@@ -58,9 +58,8 @@ spec:
       accessKey: "The Access Key"
       accountName: "The Account Name"
       queueName: "The Queue Name"
-
+  
 ----
-
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `azure-storage-queue-sink-binding.yaml` file into your hard drive, then configure it according to your needs.
@@ -109,7 +108,7 @@ spec:
       accessKey: "The Access Key"
       accountName: "The Account Name"
       queueName: "The Queue Name"
-
+  
 ----
 
 Ensure that you've installed https://strimzi.io/[Strimzi] and created a topic named `my-topic` in the current namespace.

--- a/docs/modules/ROOT/pages/azure-storage-queue-source.adoc
+++ b/docs/modules/ROOT/pages/azure-storage-queue-source.adoc
@@ -51,9 +51,8 @@ spec:
       kind: InMemoryChannel
       apiVersion: messaging.knative.dev/v1
       name: mychannel
-
+  
 ----
-
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `azure-storage-queue-source-binding.yaml` file into your hard drive, then configure it according to your needs.
@@ -102,7 +101,7 @@ spec:
       kind: KafkaTopic
       apiVersion: kafka.strimzi.io/v1beta1
       name: my-topic
-
+  
 ----
 
 Ensure that you've installed https://strimzi.io/[Strimzi] and created a topic named `my-topic` in the current namespace.

--- a/docs/modules/ROOT/pages/bitcoin-source.adoc
+++ b/docs/modules/ROOT/pages/bitcoin-source.adoc
@@ -44,9 +44,8 @@ spec:
       kind: InMemoryChannel
       apiVersion: messaging.knative.dev/v1
       name: mychannel
-
+  
 ----
-
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `bitcoin-source-binding.yaml` file into your hard drive, then configure it according to your needs.
@@ -91,7 +90,7 @@ spec:
       kind: KafkaTopic
       apiVersion: kafka.strimzi.io/v1beta1
       name: my-topic
-
+  
 ----
 
 Ensure that you've installed https://strimzi.io/[Strimzi] and created a topic named `my-topic` in the current namespace.

--- a/docs/modules/ROOT/pages/caffeine-action.adoc
+++ b/docs/modules/ROOT/pages/caffeine-action.adoc
@@ -63,7 +63,6 @@ spec:
       name: mychannel
 
 ----
-
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `caffeine-action-binding.yaml` file into your hard drive, then configure it according to your needs.

--- a/docs/modules/ROOT/pages/cassandra-sink.adoc
+++ b/docs/modules/ROOT/pages/cassandra-sink.adoc
@@ -59,9 +59,8 @@ spec:
       password: "The Password"
       preparedStatement: "The Prepared Statement"
       username: "The Username"
-
+  
 ----
-
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `cassandra-sink-binding.yaml` file into your hard drive, then configure it according to your needs.
@@ -113,7 +112,7 @@ spec:
       password: "The Password"
       preparedStatement: "The Prepared Statement"
       username: "The Username"
-
+  
 ----
 
 Ensure that you've installed https://strimzi.io/[Strimzi] and created a topic named `my-topic` in the current namespace.

--- a/docs/modules/ROOT/pages/cassandra-source.adoc
+++ b/docs/modules/ROOT/pages/cassandra-source.adoc
@@ -58,9 +58,8 @@ spec:
       kind: InMemoryChannel
       apiVersion: messaging.knative.dev/v1
       name: mychannel
-
+  
 ----
-
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `cassandra-source-binding.yaml` file into your hard drive, then configure it according to your needs.
@@ -112,7 +111,7 @@ spec:
       kind: KafkaTopic
       apiVersion: kafka.strimzi.io/v1beta1
       name: my-topic
-
+  
 ----
 
 Ensure that you've installed https://strimzi.io/[Strimzi] and created a topic named `my-topic` in the current namespace.

--- a/docs/modules/ROOT/pages/chuck-norris-source.adoc
+++ b/docs/modules/ROOT/pages/chuck-norris-source.adoc
@@ -44,9 +44,8 @@ spec:
       kind: InMemoryChannel
       apiVersion: messaging.knative.dev/v1
       name: mychannel
-
+  
 ----
-
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `chuck-norris-source-binding.yaml` file into your hard drive, then configure it according to your needs.
@@ -91,7 +90,7 @@ spec:
       kind: KafkaTopic
       apiVersion: kafka.strimzi.io/v1beta1
       name: my-topic
-
+  
 ----
 
 Ensure that you've installed https://strimzi.io/[Strimzi] and created a topic named `my-topic` in the current namespace.

--- a/docs/modules/ROOT/pages/chunk-template-action.adoc
+++ b/docs/modules/ROOT/pages/chunk-template-action.adoc
@@ -57,7 +57,6 @@ spec:
       name: mychannel
 
 ----
-
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `chunk-template-action-binding.yaml` file into your hard drive, then configure it according to your needs.

--- a/docs/modules/ROOT/pages/cron-source.adoc
+++ b/docs/modules/ROOT/pages/cron-source.adoc
@@ -48,9 +48,8 @@ spec:
       kind: InMemoryChannel
       apiVersion: messaging.knative.dev/v1
       name: mychannel
-
+  
 ----
-
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `cron-source-binding.yaml` file into your hard drive, then configure it according to your needs.
@@ -98,7 +97,7 @@ spec:
       kind: KafkaTopic
       apiVersion: kafka.strimzi.io/v1beta1
       name: my-topic
-
+  
 ----
 
 Ensure that you've installed https://strimzi.io/[Strimzi] and created a topic named `my-topic` in the current namespace.

--- a/docs/modules/ROOT/pages/dns-dig-action.adoc
+++ b/docs/modules/ROOT/pages/dns-dig-action.adoc
@@ -56,7 +56,6 @@ spec:
       name: mychannel
 
 ----
-
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `dns-dig-action-binding.yaml` file into your hard drive, then configure it according to your needs.

--- a/docs/modules/ROOT/pages/dns-ip-action.adoc
+++ b/docs/modules/ROOT/pages/dns-ip-action.adoc
@@ -52,7 +52,6 @@ spec:
       name: mychannel
 
 ----
-
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `dns-ip-action-binding.yaml` file into your hard drive, then configure it according to your needs.

--- a/docs/modules/ROOT/pages/dns-lookup-action.adoc
+++ b/docs/modules/ROOT/pages/dns-lookup-action.adoc
@@ -52,7 +52,6 @@ spec:
       name: mychannel
 
 ----
-
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `dns-lookup-action-binding.yaml` file into your hard drive, then configure it according to your needs.

--- a/docs/modules/ROOT/pages/dropbox-sink.adoc
+++ b/docs/modules/ROOT/pages/dropbox-sink.adoc
@@ -57,9 +57,8 @@ spec:
       accessToken: "The Dropbox Access Token"
       clientIdentifier: "The Client Identifier"
       remotePath: "The Remote Path"
-
+  
 ----
-
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `dropbox-sink-binding.yaml` file into your hard drive, then configure it according to your needs.
@@ -108,7 +107,7 @@ spec:
       accessToken: "The Dropbox Access Token"
       clientIdentifier: "The Client Identifier"
       remotePath: "The Remote Path"
-
+  
 ----
 
 Ensure that you've installed https://strimzi.io/[Strimzi] and created a topic named `my-topic` in the current namespace.

--- a/docs/modules/ROOT/pages/dropbox-source.adoc
+++ b/docs/modules/ROOT/pages/dropbox-source.adoc
@@ -53,9 +53,8 @@ spec:
       kind: InMemoryChannel
       apiVersion: messaging.knative.dev/v1
       name: mychannel
-
+  
 ----
-
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `dropbox-source-binding.yaml` file into your hard drive, then configure it according to your needs.
@@ -105,7 +104,7 @@ spec:
       kind: KafkaTopic
       apiVersion: kafka.strimzi.io/v1beta1
       name: my-topic
-
+  
 ----
 
 Ensure that you've installed https://strimzi.io/[Strimzi] and created a topic named `my-topic` in the current namespace.

--- a/docs/modules/ROOT/pages/earthquake-source.adoc
+++ b/docs/modules/ROOT/pages/earthquake-source.adoc
@@ -45,9 +45,8 @@ spec:
       kind: InMemoryChannel
       apiVersion: messaging.knative.dev/v1
       name: mychannel
-
+  
 ----
-
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `earthquake-source-binding.yaml` file into your hard drive, then configure it according to your needs.
@@ -92,7 +91,7 @@ spec:
       kind: KafkaTopic
       apiVersion: kafka.strimzi.io/v1beta1
       name: my-topic
-
+  
 ----
 
 Ensure that you've installed https://strimzi.io/[Strimzi] and created a topic named `my-topic` in the current namespace.

--- a/docs/modules/ROOT/pages/elasticsearch-index-sink.adoc
+++ b/docs/modules/ROOT/pages/elasticsearch-index-sink.adoc
@@ -62,9 +62,8 @@ spec:
     properties:
       clusterName: "quickstart"
       hostAddresses: "quickstart-es-http:9200"
-
+  
 ----
-
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `elasticsearch-index-sink-binding.yaml` file into your hard drive, then configure it according to your needs.
@@ -112,7 +111,7 @@ spec:
     properties:
       clusterName: "quickstart"
       hostAddresses: "quickstart-es-http:9200"
-
+  
 ----
 
 Ensure that you've installed https://strimzi.io/[Strimzi] and created a topic named `my-topic` in the current namespace.

--- a/docs/modules/ROOT/pages/elasticsearch-search-source.adoc
+++ b/docs/modules/ROOT/pages/elasticsearch-search-source.adoc
@@ -56,9 +56,8 @@ spec:
       kind: InMemoryChannel
       apiVersion: messaging.knative.dev/v1
       name: mychannel
-
+  
 ----
-
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `elasticsearch-search-source-binding.yaml` file into your hard drive, then configure it according to your needs.
@@ -108,7 +107,7 @@ spec:
       kind: KafkaTopic
       apiVersion: kafka.strimzi.io/v1beta1
       name: my-topic
-
+  
 ----
 
 Ensure that you've installed https://strimzi.io/[Strimzi] and created a topic named `my-topic` in the current namespace.

--- a/docs/modules/ROOT/pages/exec-sink.adoc
+++ b/docs/modules/ROOT/pages/exec-sink.adoc
@@ -52,9 +52,8 @@ spec:
       name: exec-sink
     properties:
       executable: "The Executable Command"
-
+  
 ----
-
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `exec-sink-binding.yaml` file into your hard drive, then configure it according to your needs.
@@ -101,7 +100,7 @@ spec:
       name: exec-sink
     properties:
       executable: "The Executable Command"
-
+  
 ----
 
 Ensure that you've installed https://strimzi.io/[Strimzi] and created a topic named `my-topic` in the current namespace.

--- a/docs/modules/ROOT/pages/extract-field-action.adoc
+++ b/docs/modules/ROOT/pages/extract-field-action.adoc
@@ -55,7 +55,6 @@ spec:
       name: mychannel
 
 ----
-
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `extract-field-action-binding.yaml` file into your hard drive, then configure it according to your needs.

--- a/docs/modules/ROOT/pages/fhir-source.adoc
+++ b/docs/modules/ROOT/pages/fhir-source.adoc
@@ -54,9 +54,8 @@ spec:
       kind: InMemoryChannel
       apiVersion: messaging.knative.dev/v1
       name: mychannel
-
+  
 ----
-
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `fhir-source-binding.yaml` file into your hard drive, then configure it according to your needs.
@@ -105,7 +104,7 @@ spec:
       kind: KafkaTopic
       apiVersion: kafka.strimzi.io/v1beta1
       name: my-topic
-
+  
 ----
 
 Ensure that you've installed https://strimzi.io/[Strimzi] and created a topic named `my-topic` in the current namespace.

--- a/docs/modules/ROOT/pages/file-watch-source.adoc
+++ b/docs/modules/ROOT/pages/file-watch-source.adoc
@@ -47,9 +47,8 @@ spec:
       kind: InMemoryChannel
       apiVersion: messaging.knative.dev/v1
       name: mychannel
-
+  
 ----
-
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `file-watch-source-binding.yaml` file into your hard drive, then configure it according to your needs.
@@ -96,7 +95,7 @@ spec:
       kind: KafkaTopic
       apiVersion: kafka.strimzi.io/v1beta1
       name: my-topic
-
+  
 ----
 
 Ensure that you've installed https://strimzi.io/[Strimzi] and created a topic named `my-topic` in the current namespace.

--- a/docs/modules/ROOT/pages/freemarker-template-action.adoc
+++ b/docs/modules/ROOT/pages/freemarker-template-action.adoc
@@ -57,7 +57,6 @@ spec:
       name: mychannel
 
 ----
-
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `freemarker-template-action-binding.yaml` file into your hard drive, then configure it according to your needs.

--- a/docs/modules/ROOT/pages/ftp-sink.adoc
+++ b/docs/modules/ROOT/pages/ftp-sink.adoc
@@ -61,9 +61,8 @@ spec:
       directoryName: "The Directory Name"
       password: "The Password"
       username: "The Username"
-
+  
 ----
-
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `ftp-sink-binding.yaml` file into your hard drive, then configure it according to your needs.
@@ -113,7 +112,7 @@ spec:
       directoryName: "The Directory Name"
       password: "The Password"
       username: "The Username"
-
+  
 ----
 
 Ensure that you've installed https://strimzi.io/[Strimzi] and created a topic named `my-topic` in the current namespace.

--- a/docs/modules/ROOT/pages/ftp-source.adoc
+++ b/docs/modules/ROOT/pages/ftp-source.adoc
@@ -56,9 +56,8 @@ spec:
       kind: InMemoryChannel
       apiVersion: messaging.knative.dev/v1
       name: mychannel
-
+  
 ----
-
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `ftp-source-binding.yaml` file into your hard drive, then configure it according to your needs.
@@ -108,7 +107,7 @@ spec:
       kind: KafkaTopic
       apiVersion: kafka.strimzi.io/v1beta1
       name: my-topic
-
+  
 ----
 
 Ensure that you've installed https://strimzi.io/[Strimzi] and created a topic named `my-topic` in the current namespace.

--- a/docs/modules/ROOT/pages/ftps-sink.adoc
+++ b/docs/modules/ROOT/pages/ftps-sink.adoc
@@ -61,9 +61,8 @@ spec:
       directoryName: "The Directory Name"
       password: "The Password"
       username: "The Username"
-
+  
 ----
-
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `ftps-sink-binding.yaml` file into your hard drive, then configure it according to your needs.
@@ -113,7 +112,7 @@ spec:
       directoryName: "The Directory Name"
       password: "The Password"
       username: "The Username"
-
+  
 ----
 
 Ensure that you've installed https://strimzi.io/[Strimzi] and created a topic named `my-topic` in the current namespace.

--- a/docs/modules/ROOT/pages/ftps-source.adoc
+++ b/docs/modules/ROOT/pages/ftps-source.adoc
@@ -56,9 +56,8 @@ spec:
       kind: InMemoryChannel
       apiVersion: messaging.knative.dev/v1
       name: mychannel
-
+  
 ----
-
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `ftps-source-binding.yaml` file into your hard drive, then configure it according to your needs.
@@ -108,7 +107,7 @@ spec:
       kind: KafkaTopic
       apiVersion: kafka.strimzi.io/v1beta1
       name: my-topic
-
+  
 ----
 
 Ensure that you've installed https://strimzi.io/[Strimzi] and created a topic named `my-topic` in the current namespace.

--- a/docs/modules/ROOT/pages/github-source.adoc
+++ b/docs/modules/ROOT/pages/github-source.adoc
@@ -51,9 +51,8 @@ spec:
       kind: InMemoryChannel
       apiVersion: messaging.knative.dev/v1
       name: mychannel
-
+  
 ----
-
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `github-source-binding.yaml` file into your hard drive, then configure it according to your needs.
@@ -102,7 +101,7 @@ spec:
       kind: KafkaTopic
       apiVersion: kafka.strimzi.io/v1beta1
       name: my-topic
-
+  
 ----
 
 Ensure that you've installed https://strimzi.io/[Strimzi] and created a topic named `my-topic` in the current namespace.

--- a/docs/modules/ROOT/pages/google-calendar-source.adoc
+++ b/docs/modules/ROOT/pages/google-calendar-source.adoc
@@ -61,9 +61,8 @@ spec:
       kind: InMemoryChannel
       apiVersion: messaging.knative.dev/v1
       name: mychannel
-
+  
 ----
-
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `google-calendar-source-binding.yaml` file into your hard drive, then configure it according to your needs.
@@ -116,7 +115,7 @@ spec:
       kind: KafkaTopic
       apiVersion: kafka.strimzi.io/v1beta1
       name: my-topic
-
+  
 ----
 
 Ensure that you've installed https://strimzi.io/[Strimzi] and created a topic named `my-topic` in the current namespace.

--- a/docs/modules/ROOT/pages/google-mail-source.adoc
+++ b/docs/modules/ROOT/pages/google-mail-source.adoc
@@ -60,9 +60,8 @@ spec:
       kind: InMemoryChannel
       apiVersion: messaging.knative.dev/v1
       name: mychannel
-
+  
 ----
-
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `google-mail-source-binding.yaml` file into your hard drive, then configure it according to your needs.
@@ -114,7 +113,7 @@ spec:
       kind: KafkaTopic
       apiVersion: kafka.strimzi.io/v1beta1
       name: my-topic
-
+  
 ----
 
 Ensure that you've installed https://strimzi.io/[Strimzi] and created a topic named `my-topic` in the current namespace.

--- a/docs/modules/ROOT/pages/google-sheets-source.adoc
+++ b/docs/modules/ROOT/pages/google-sheets-source.adoc
@@ -61,9 +61,8 @@ spec:
       kind: InMemoryChannel
       apiVersion: messaging.knative.dev/v1
       name: mychannel
-
+  
 ----
-
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `google-sheets-source-binding.yaml` file into your hard drive, then configure it according to your needs.
@@ -116,7 +115,7 @@ spec:
       kind: KafkaTopic
       apiVersion: kafka.strimzi.io/v1beta1
       name: my-topic
-
+  
 ----
 
 Ensure that you've installed https://strimzi.io/[Strimzi] and created a topic named `my-topic` in the current namespace.

--- a/docs/modules/ROOT/pages/has-header-filter-action.adoc
+++ b/docs/modules/ROOT/pages/has-header-filter-action.adoc
@@ -55,7 +55,6 @@ spec:
       name: mychannel
 
 ----
-
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `has-header-filter-action-binding.yaml` file into your hard drive, then configure it according to your needs.

--- a/docs/modules/ROOT/pages/header-matches-filter-action.adoc
+++ b/docs/modules/ROOT/pages/header-matches-filter-action.adoc
@@ -56,7 +56,6 @@ spec:
       name: mychannel
 
 ----
-
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `header-matches-filter-action-binding.yaml` file into your hard drive, then configure it according to your needs.

--- a/docs/modules/ROOT/pages/hoist-field-action.adoc
+++ b/docs/modules/ROOT/pages/hoist-field-action.adoc
@@ -55,7 +55,6 @@ spec:
       name: mychannel
 
 ----
-
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `hoist-field-action-binding.yaml` file into your hard drive, then configure it according to your needs.

--- a/docs/modules/ROOT/pages/http-secured-sink.adoc
+++ b/docs/modules/ROOT/pages/http-secured-sink.adoc
@@ -51,9 +51,8 @@ spec:
       name: http-secured-sink
     properties:
       url: "https://my-service/path"
-
+  
 ----
-
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `http-secured-sink-binding.yaml` file into your hard drive, then configure it according to your needs.
@@ -100,7 +99,7 @@ spec:
       name: http-secured-sink
     properties:
       url: "https://my-service/path"
-
+  
 ----
 
 Ensure that you've installed https://strimzi.io/[Strimzi] and created a topic named `my-topic` in the current namespace.

--- a/docs/modules/ROOT/pages/http-secured-source.adoc
+++ b/docs/modules/ROOT/pages/http-secured-source.adoc
@@ -52,9 +52,8 @@ spec:
       kind: InMemoryChannel
       apiVersion: messaging.knative.dev/v1
       name: mychannel
-
+  
 ----
-
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `http-secured-source-binding.yaml` file into your hard drive, then configure it according to your needs.
@@ -101,7 +100,7 @@ spec:
       kind: KafkaTopic
       apiVersion: kafka.strimzi.io/v1beta1
       name: my-topic
-
+  
 ----
 
 Ensure that you've installed https://strimzi.io/[Strimzi] and created a topic named `my-topic` in the current namespace.

--- a/docs/modules/ROOT/pages/http-sink.adoc
+++ b/docs/modules/ROOT/pages/http-sink.adoc
@@ -47,9 +47,8 @@ spec:
       name: http-sink
     properties:
       url: "https://my-service/path"
-
+  
 ----
-
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `http-sink-binding.yaml` file into your hard drive, then configure it according to your needs.
@@ -96,7 +95,7 @@ spec:
       name: http-sink
     properties:
       url: "https://my-service/path"
-
+  
 ----
 
 Ensure that you've installed https://strimzi.io/[Strimzi] and created a topic named `my-topic` in the current namespace.

--- a/docs/modules/ROOT/pages/http-source.adoc
+++ b/docs/modules/ROOT/pages/http-source.adoc
@@ -48,9 +48,8 @@ spec:
       kind: InMemoryChannel
       apiVersion: messaging.knative.dev/v1
       name: mychannel
-
+  
 ----
-
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `http-source-binding.yaml` file into your hard drive, then configure it according to your needs.
@@ -97,7 +96,7 @@ spec:
       kind: KafkaTopic
       apiVersion: kafka.strimzi.io/v1beta1
       name: my-topic
-
+  
 ----
 
 Ensure that you've installed https://strimzi.io/[Strimzi] and created a topic named `my-topic` in the current namespace.

--- a/docs/modules/ROOT/pages/infinispan-source.adoc
+++ b/docs/modules/ROOT/pages/infinispan-source.adoc
@@ -57,9 +57,8 @@ spec:
       kind: InMemoryChannel
       apiVersion: messaging.knative.dev/v1
       name: mychannel
-
+  
 ----
-
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `infinispan-source-binding.yaml` file into your hard drive, then configure it according to your needs.
@@ -109,7 +108,7 @@ spec:
       kind: KafkaTopic
       apiVersion: kafka.strimzi.io/v1beta1
       name: my-topic
-
+  
 ----
 
 Ensure that you've installed https://strimzi.io/[Strimzi] and created a topic named `my-topic` in the current namespace.

--- a/docs/modules/ROOT/pages/insert-field-action.adoc
+++ b/docs/modules/ROOT/pages/insert-field-action.adoc
@@ -57,7 +57,6 @@ spec:
       name: mychannel
 
 ----
-
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `insert-field-action-binding.yaml` file into your hard drive, then configure it according to your needs.

--- a/docs/modules/ROOT/pages/insert-header-action.adoc
+++ b/docs/modules/ROOT/pages/insert-header-action.adoc
@@ -57,7 +57,6 @@ spec:
       name: mychannel
 
 ----
-
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `insert-header-action-binding.yaml` file into your hard drive, then configure it according to your needs.

--- a/docs/modules/ROOT/pages/is-tombstone-filter-action.adoc
+++ b/docs/modules/ROOT/pages/is-tombstone-filter-action.adoc
@@ -46,7 +46,6 @@ spec:
       name: mychannel
 
 ----
-
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `is-tombstone-filter-action-binding.yaml` file into your hard drive, then configure it according to your needs.

--- a/docs/modules/ROOT/pages/jira-source.adoc
+++ b/docs/modules/ROOT/pages/jira-source.adoc
@@ -51,9 +51,8 @@ spec:
       kind: InMemoryChannel
       apiVersion: messaging.knative.dev/v1
       name: mychannel
-
+  
 ----
-
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `jira-source-binding.yaml` file into your hard drive, then configure it according to your needs.
@@ -102,7 +101,7 @@ spec:
       kind: KafkaTopic
       apiVersion: kafka.strimzi.io/v1beta1
       name: my-topic
-
+  
 ----
 
 Ensure that you've installed https://strimzi.io/[Strimzi] and created a topic named `my-topic` in the current namespace.

--- a/docs/modules/ROOT/pages/jms-amqp-10-sink.adoc
+++ b/docs/modules/ROOT/pages/jms-amqp-10-sink.adoc
@@ -49,9 +49,8 @@ spec:
     properties:
       destinationName: "The Destination Name"
       remoteURI: "amqp://my-host:31616"
-
+  
 ----
-
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `jms-amqp-10-sink-binding.yaml` file into your hard drive, then configure it according to your needs.
@@ -99,7 +98,7 @@ spec:
     properties:
       destinationName: "The Destination Name"
       remoteURI: "amqp://my-host:31616"
-
+  
 ----
 
 Ensure that you've installed https://strimzi.io/[Strimzi] and created a topic named `my-topic` in the current namespace.

--- a/docs/modules/ROOT/pages/jms-amqp-10-source.adoc
+++ b/docs/modules/ROOT/pages/jms-amqp-10-source.adoc
@@ -49,9 +49,8 @@ spec:
       kind: InMemoryChannel
       apiVersion: messaging.knative.dev/v1
       name: mychannel
-
+  
 ----
-
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `jms-amqp-10-source-binding.yaml` file into your hard drive, then configure it according to your needs.
@@ -99,7 +98,7 @@ spec:
       kind: KafkaTopic
       apiVersion: kafka.strimzi.io/v1beta1
       name: my-topic
-
+  
 ----
 
 Ensure that you've installed https://strimzi.io/[Strimzi] and created a topic named `my-topic` in the current namespace.

--- a/docs/modules/ROOT/pages/jms-apache-artemis-sink.adoc
+++ b/docs/modules/ROOT/pages/jms-apache-artemis-sink.adoc
@@ -49,9 +49,8 @@ spec:
     properties:
       brokerURL: "tcp://my-host:61616"
       destinationName: "person"
-
+  
 ----
-
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `jms-apache-artemis-sink-binding.yaml` file into your hard drive, then configure it according to your needs.
@@ -99,7 +98,7 @@ spec:
     properties:
       brokerURL: "tcp://my-host:61616"
       destinationName: "person"
-
+  
 ----
 
 Ensure that you've installed https://strimzi.io/[Strimzi] and created a topic named `my-topic` in the current namespace.

--- a/docs/modules/ROOT/pages/jms-apache-artemis-source.adoc
+++ b/docs/modules/ROOT/pages/jms-apache-artemis-source.adoc
@@ -49,9 +49,8 @@ spec:
       kind: InMemoryChannel
       apiVersion: messaging.knative.dev/v1
       name: mychannel
-
+  
 ----
-
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `jms-apache-artemis-source-binding.yaml` file into your hard drive, then configure it according to your needs.
@@ -99,7 +98,7 @@ spec:
       kind: KafkaTopic
       apiVersion: kafka.strimzi.io/v1beta1
       name: my-topic
-
+  
 ----
 
 Ensure that you've installed https://strimzi.io/[Strimzi] and created a topic named `my-topic` in the current namespace.

--- a/docs/modules/ROOT/pages/json-deserialize-action.adoc
+++ b/docs/modules/ROOT/pages/json-deserialize-action.adoc
@@ -46,7 +46,6 @@ spec:
       name: mychannel
 
 ----
-
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `json-deserialize-action-binding.yaml` file into your hard drive, then configure it according to your needs.

--- a/docs/modules/ROOT/pages/json-schema-validator-action.adoc
+++ b/docs/modules/ROOT/pages/json-schema-validator-action.adoc
@@ -57,7 +57,6 @@ spec:
       name: mychannel
 
 ----
-
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `json-schema-validator-action-binding.yaml` file into your hard drive, then configure it according to your needs.

--- a/docs/modules/ROOT/pages/json-serialize-action.adoc
+++ b/docs/modules/ROOT/pages/json-serialize-action.adoc
@@ -46,7 +46,6 @@ spec:
       name: mychannel
 
 ----
-
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `json-serialize-action-binding.yaml` file into your hard drive, then configure it according to your needs.

--- a/docs/modules/ROOT/pages/jsonata-action.adoc
+++ b/docs/modules/ROOT/pages/jsonata-action.adoc
@@ -57,7 +57,6 @@ spec:
       name: mychannel
 
 ----
-
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `jsonata-action-binding.yaml` file into your hard drive, then configure it according to your needs.

--- a/docs/modules/ROOT/pages/kafka-manual-commit-action.adoc
+++ b/docs/modules/ROOT/pages/kafka-manual-commit-action.adoc
@@ -46,7 +46,6 @@ spec:
       name: mychannel
 
 ----
-
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `kafka-manual-commit-action-binding.yaml` file into your hard drive, then configure it according to your needs.

--- a/docs/modules/ROOT/pages/kafka-not-secured-sink.adoc
+++ b/docs/modules/ROOT/pages/kafka-not-secured-sink.adoc
@@ -56,9 +56,8 @@ spec:
     properties:
       brokers: "The Brokers"
       topic: "The Topic Names"
-
+  
 ----
-
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `kafka-not-secured-sink-binding.yaml` file into your hard drive, then configure it according to your needs.
@@ -106,7 +105,7 @@ spec:
     properties:
       brokers: "The Brokers"
       topic: "The Topic Names"
-
+  
 ----
 
 Ensure that you've installed https://strimzi.io/[Strimzi] and created a topic named `my-topic` in the current namespace.

--- a/docs/modules/ROOT/pages/kafka-not-secured-source.adoc
+++ b/docs/modules/ROOT/pages/kafka-not-secured-source.adoc
@@ -52,9 +52,8 @@ spec:
       kind: InMemoryChannel
       apiVersion: messaging.knative.dev/v1
       name: mychannel
-
+  
 ----
-
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `kafka-not-secured-source-binding.yaml` file into your hard drive, then configure it according to your needs.
@@ -102,7 +101,7 @@ spec:
       kind: KafkaTopic
       apiVersion: kafka.strimzi.io/v1beta1
       name: my-topic
-
+  
 ----
 
 Ensure that you've installed https://strimzi.io/[Strimzi] and created a topic named `my-topic` in the current namespace.

--- a/docs/modules/ROOT/pages/kafka-sink.adoc
+++ b/docs/modules/ROOT/pages/kafka-sink.adoc
@@ -62,9 +62,8 @@ spec:
       password: "The Password"
       topic: "The Topic Names"
       user: "The Username"
-
+  
 ----
-
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `kafka-sink-binding.yaml` file into your hard drive, then configure it according to your needs.
@@ -114,7 +113,7 @@ spec:
       password: "The Password"
       topic: "The Topic Names"
       user: "The Username"
-
+  
 ----
 
 Ensure that you've installed https://strimzi.io/[Strimzi] and created a topic named `my-topic` in the current namespace.

--- a/docs/modules/ROOT/pages/kafka-source.adoc
+++ b/docs/modules/ROOT/pages/kafka-source.adoc
@@ -58,9 +58,8 @@ spec:
       kind: InMemoryChannel
       apiVersion: messaging.knative.dev/v1
       name: mychannel
-
+  
 ----
-
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `kafka-source-binding.yaml` file into your hard drive, then configure it according to your needs.
@@ -110,7 +109,7 @@ spec:
       kind: KafkaTopic
       apiVersion: kafka.strimzi.io/v1beta1
       name: my-topic
-
+  
 ----
 
 Ensure that you've installed https://strimzi.io/[Strimzi] and created a topic named `my-topic` in the current namespace.

--- a/docs/modules/ROOT/pages/log-sink.adoc
+++ b/docs/modules/ROOT/pages/log-sink.adoc
@@ -45,9 +45,8 @@ spec:
       kind: Kamelet
       apiVersion: camel.apache.org/v1alpha1
       name: log-sink
-
+  
 ----
-
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `log-sink-binding.yaml` file into your hard drive, then configure it according to your needs.
@@ -92,7 +91,7 @@ spec:
       kind: Kamelet
       apiVersion: camel.apache.org/v1alpha1
       name: log-sink
-
+  
 ----
 
 Ensure that you've installed https://strimzi.io/[Strimzi] and created a topic named `my-topic` in the current namespace.

--- a/docs/modules/ROOT/pages/mail-imap-source.adoc
+++ b/docs/modules/ROOT/pages/mail-imap-source.adoc
@@ -53,9 +53,8 @@ spec:
       kind: InMemoryChannel
       apiVersion: messaging.knative.dev/v1
       name: mychannel
-
+  
 ----
-
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `mail-imap-source-binding.yaml` file into your hard drive, then configure it according to your needs.
@@ -104,7 +103,7 @@ spec:
       kind: KafkaTopic
       apiVersion: kafka.strimzi.io/v1beta1
       name: my-topic
-
+  
 ----
 
 Ensure that you've installed https://strimzi.io/[Strimzi] and created a topic named `my-topic` in the current namespace.

--- a/docs/modules/ROOT/pages/mariadb-sink.adoc
+++ b/docs/modules/ROOT/pages/mariadb-sink.adoc
@@ -67,9 +67,8 @@ spec:
       query: "INSERT INTO accounts (username,city) VALUES (:#username,:#city)"
       serverName: "localhost"
       username: "The Username"
-
+  
 ----
-
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `mariadb-sink-binding.yaml` file into your hard drive, then configure it according to your needs.
@@ -120,7 +119,7 @@ spec:
       query: "INSERT INTO accounts (username,city) VALUES (:#username,:#city)"
       serverName: "localhost"
       username: "The Username"
-
+  
 ----
 
 Ensure that you've installed https://strimzi.io/[Strimzi] and created a topic named `my-topic` in the current namespace.

--- a/docs/modules/ROOT/pages/mariadb-source.adoc
+++ b/docs/modules/ROOT/pages/mariadb-source.adoc
@@ -60,9 +60,8 @@ spec:
       kind: InMemoryChannel
       apiVersion: messaging.knative.dev/v1
       name: mychannel
-
+  
 ----
-
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `mariadb-source-binding.yaml` file into your hard drive, then configure it according to your needs.
@@ -113,7 +112,7 @@ spec:
       kind: KafkaTopic
       apiVersion: kafka.strimzi.io/v1beta1
       name: my-topic
-
+  
 ----
 
 Ensure that you've installed https://strimzi.io/[Strimzi] and created a topic named `my-topic` in the current namespace.

--- a/docs/modules/ROOT/pages/mask-field-action.adoc
+++ b/docs/modules/ROOT/pages/mask-field-action.adoc
@@ -57,7 +57,6 @@ spec:
       name: mychannel
 
 ----
-
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `mask-field-action-binding.yaml` file into your hard drive, then configure it according to your needs.

--- a/docs/modules/ROOT/pages/message-timestamp-router-action.adoc
+++ b/docs/modules/ROOT/pages/message-timestamp-router-action.adoc
@@ -58,7 +58,6 @@ spec:
       name: mychannel
 
 ----
-
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `message-timestamp-router-action-binding.yaml` file into your hard drive, then configure it according to your needs.

--- a/docs/modules/ROOT/pages/minio-sink.adoc
+++ b/docs/modules/ROOT/pages/minio-sink.adoc
@@ -59,9 +59,8 @@ spec:
       bucketName: "The Bucket Name"
       endpoint: "http://localhost:9000"
       secretKey: "The Secret Key"
-
+  
 ----
-
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `minio-sink-binding.yaml` file into your hard drive, then configure it according to your needs.
@@ -111,7 +110,7 @@ spec:
       bucketName: "The Bucket Name"
       endpoint: "http://localhost:9000"
       secretKey: "The Secret Key"
-
+  
 ----
 
 Ensure that you've installed https://strimzi.io/[Strimzi] and created a topic named `my-topic` in the current namespace.

--- a/docs/modules/ROOT/pages/minio-source.adoc
+++ b/docs/modules/ROOT/pages/minio-source.adoc
@@ -54,9 +54,8 @@ spec:
       kind: InMemoryChannel
       apiVersion: messaging.knative.dev/v1
       name: mychannel
-
+  
 ----
-
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `minio-source-binding.yaml` file into your hard drive, then configure it according to your needs.
@@ -106,7 +105,7 @@ spec:
       kind: KafkaTopic
       apiVersion: kafka.strimzi.io/v1beta1
       name: my-topic
-
+  
 ----
 
 Ensure that you've installed https://strimzi.io/[Strimzi] and created a topic named `my-topic` in the current namespace.

--- a/docs/modules/ROOT/pages/mongodb-sink.adoc
+++ b/docs/modules/ROOT/pages/mongodb-sink.adoc
@@ -62,9 +62,8 @@ spec:
       hosts: "The MongoDB Hosts"
       password: "The MongoDB Password"
       username: "The MongoDB Username"
-
+  
 ----
-
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `mongodb-sink-binding.yaml` file into your hard drive, then configure it according to your needs.
@@ -115,7 +114,7 @@ spec:
       hosts: "The MongoDB Hosts"
       password: "The MongoDB Password"
       username: "The MongoDB Username"
-
+  
 ----
 
 Ensure that you've installed https://strimzi.io/[Strimzi] and created a topic named `my-topic` in the current namespace.

--- a/docs/modules/ROOT/pages/mongodb-source.adoc
+++ b/docs/modules/ROOT/pages/mongodb-source.adoc
@@ -60,9 +60,8 @@ spec:
       kind: InMemoryChannel
       apiVersion: messaging.knative.dev/v1
       name: mychannel
-
+  
 ----
-
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `mongodb-source-binding.yaml` file into your hard drive, then configure it according to your needs.
@@ -113,7 +112,7 @@ spec:
       kind: KafkaTopic
       apiVersion: kafka.strimzi.io/v1beta1
       name: my-topic
-
+  
 ----
 
 Ensure that you've installed https://strimzi.io/[Strimzi] and created a topic named `my-topic` in the current namespace.

--- a/docs/modules/ROOT/pages/mqtt-source.adoc
+++ b/docs/modules/ROOT/pages/mqtt-source.adoc
@@ -49,9 +49,8 @@ spec:
       kind: InMemoryChannel
       apiVersion: messaging.knative.dev/v1
       name: mychannel
-
+  
 ----
-
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `mqtt-source-binding.yaml` file into your hard drive, then configure it according to your needs.
@@ -99,7 +98,7 @@ spec:
       kind: KafkaTopic
       apiVersion: kafka.strimzi.io/v1beta1
       name: my-topic
-
+  
 ----
 
 Ensure that you've installed https://strimzi.io/[Strimzi] and created a topic named `my-topic` in the current namespace.

--- a/docs/modules/ROOT/pages/mustache-template-action.adoc
+++ b/docs/modules/ROOT/pages/mustache-template-action.adoc
@@ -57,7 +57,6 @@ spec:
       name: mychannel
 
 ----
-
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `mustache-template-action-binding.yaml` file into your hard drive, then configure it according to your needs.

--- a/docs/modules/ROOT/pages/mvel-template-action.adoc
+++ b/docs/modules/ROOT/pages/mvel-template-action.adoc
@@ -57,7 +57,6 @@ spec:
       name: mychannel
 
 ----
-
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `mvel-template-action-binding.yaml` file into your hard drive, then configure it according to your needs.

--- a/docs/modules/ROOT/pages/mysql-sink.adoc
+++ b/docs/modules/ROOT/pages/mysql-sink.adoc
@@ -67,9 +67,8 @@ spec:
       query: "INSERT INTO accounts (username,city) VALUES (:#username,:#city)"
       serverName: "localhost"
       username: "The Username"
-
+  
 ----
-
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `mysql-sink-binding.yaml` file into your hard drive, then configure it according to your needs.
@@ -120,7 +119,7 @@ spec:
       query: "INSERT INTO accounts (username,city) VALUES (:#username,:#city)"
       serverName: "localhost"
       username: "The Username"
-
+  
 ----
 
 Ensure that you've installed https://strimzi.io/[Strimzi] and created a topic named `my-topic` in the current namespace.

--- a/docs/modules/ROOT/pages/mysql-source.adoc
+++ b/docs/modules/ROOT/pages/mysql-source.adoc
@@ -60,9 +60,8 @@ spec:
       kind: InMemoryChannel
       apiVersion: messaging.knative.dev/v1
       name: mychannel
-
+  
 ----
-
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `mysql-source-binding.yaml` file into your hard drive, then configure it according to your needs.
@@ -113,7 +112,7 @@ spec:
       kind: KafkaTopic
       apiVersion: kafka.strimzi.io/v1beta1
       name: my-topic
-
+  
 ----
 
 Ensure that you've installed https://strimzi.io/[Strimzi] and created a topic named `my-topic` in the current namespace.

--- a/docs/modules/ROOT/pages/nats-sink.adoc
+++ b/docs/modules/ROOT/pages/nats-sink.adoc
@@ -48,9 +48,8 @@ spec:
     properties:
       servers: "The Servers"
       topic: "The Topic"
-
+  
 ----
-
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `nats-sink-binding.yaml` file into your hard drive, then configure it according to your needs.
@@ -98,7 +97,7 @@ spec:
     properties:
       servers: "The Servers"
       topic: "The Topic"
-
+  
 ----
 
 Ensure that you've installed https://strimzi.io/[Strimzi] and created a topic named `my-topic` in the current namespace.

--- a/docs/modules/ROOT/pages/nats-source.adoc
+++ b/docs/modules/ROOT/pages/nats-source.adoc
@@ -48,9 +48,8 @@ spec:
       kind: InMemoryChannel
       apiVersion: messaging.knative.dev/v1
       name: mychannel
-
+  
 ----
-
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `nats-source-binding.yaml` file into your hard drive, then configure it according to your needs.
@@ -98,7 +97,7 @@ spec:
       kind: KafkaTopic
       apiVersion: kafka.strimzi.io/v1beta1
       name: my-topic
-
+  
 ----
 
 Ensure that you've installed https://strimzi.io/[Strimzi] and created a topic named `my-topic` in the current namespace.

--- a/docs/modules/ROOT/pages/openai-classification-action.adoc
+++ b/docs/modules/ROOT/pages/openai-classification-action.adoc
@@ -68,7 +68,6 @@ spec:
       name: mychannel
 
 ----
-
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `openai-classification-action-binding.yaml` file into your hard drive, then configure it according to your needs.

--- a/docs/modules/ROOT/pages/openai-completion-action.adoc
+++ b/docs/modules/ROOT/pages/openai-completion-action.adoc
@@ -65,7 +65,6 @@ spec:
       name: mychannel
 
 ----
-
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `openai-completion-action-binding.yaml` file into your hard drive, then configure it according to your needs.

--- a/docs/modules/ROOT/pages/pdf-action.adoc
+++ b/docs/modules/ROOT/pages/pdf-action.adoc
@@ -55,7 +55,6 @@ spec:
       name: mychannel
 
 ----
-
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `pdf-action-binding.yaml` file into your hard drive, then configure it according to your needs.

--- a/docs/modules/ROOT/pages/postgresql-sink.adoc
+++ b/docs/modules/ROOT/pages/postgresql-sink.adoc
@@ -63,9 +63,8 @@ spec:
       query: "INSERT INTO accounts (username,city) VALUES (:#username,:#city)"
       serverName: "localhost"
       username: "The Username"
-
+  
 ----
-
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `postgresql-sink-binding.yaml` file into your hard drive, then configure it according to your needs.
@@ -116,7 +115,7 @@ spec:
       query: "INSERT INTO accounts (username,city) VALUES (:#username,:#city)"
       serverName: "localhost"
       username: "The Username"
-
+  
 ----
 
 Ensure that you've installed https://strimzi.io/[Strimzi] and created a topic named `my-topic` in the current namespace.

--- a/docs/modules/ROOT/pages/postgresql-source.adoc
+++ b/docs/modules/ROOT/pages/postgresql-source.adoc
@@ -56,9 +56,8 @@ spec:
       kind: InMemoryChannel
       apiVersion: messaging.knative.dev/v1
       name: mychannel
-
+  
 ----
-
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `postgresql-source-binding.yaml` file into your hard drive, then configure it according to your needs.
@@ -109,7 +108,7 @@ spec:
       kind: KafkaTopic
       apiVersion: kafka.strimzi.io/v1beta1
       name: my-topic
-
+  
 ----
 
 Ensure that you've installed https://strimzi.io/[Strimzi] and created a topic named `my-topic` in the current namespace.

--- a/docs/modules/ROOT/pages/predicate-filter-action.adoc
+++ b/docs/modules/ROOT/pages/predicate-filter-action.adoc
@@ -55,7 +55,6 @@ spec:
       name: mychannel
 
 ----
-
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `predicate-filter-action-binding.yaml` file into your hard drive, then configure it according to your needs.

--- a/docs/modules/ROOT/pages/protobuf-deserialize-action.adoc
+++ b/docs/modules/ROOT/pages/protobuf-deserialize-action.adoc
@@ -55,7 +55,6 @@ spec:
       name: mychannel
 
 ----
-
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `protobuf-deserialize-action-binding.yaml` file into your hard drive, then configure it according to your needs.

--- a/docs/modules/ROOT/pages/protobuf-serialize-action.adoc
+++ b/docs/modules/ROOT/pages/protobuf-serialize-action.adoc
@@ -55,7 +55,6 @@ spec:
       name: mychannel
 
 ----
-
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `protobuf-serialize-action-binding.yaml` file into your hard drive, then configure it according to your needs.

--- a/docs/modules/ROOT/pages/rabbitmq-source.adoc
+++ b/docs/modules/ROOT/pages/rabbitmq-source.adoc
@@ -53,9 +53,8 @@ spec:
       kind: InMemoryChannel
       apiVersion: messaging.knative.dev/v1
       name: mychannel
-
+  
 ----
-
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `rabbitmq-source-binding.yaml` file into your hard drive, then configure it according to your needs.
@@ -105,7 +104,7 @@ spec:
       kind: KafkaTopic
       apiVersion: kafka.strimzi.io/v1beta1
       name: my-topic
-
+  
 ----
 
 Ensure that you've installed https://strimzi.io/[Strimzi] and created a topic named `my-topic` in the current namespace.

--- a/docs/modules/ROOT/pages/regex-router-action.adoc
+++ b/docs/modules/ROOT/pages/regex-router-action.adoc
@@ -57,7 +57,6 @@ spec:
       name: mychannel
 
 ----
-
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `regex-router-action-binding.yaml` file into your hard drive, then configure it according to your needs.

--- a/docs/modules/ROOT/pages/replace-field-action.adoc
+++ b/docs/modules/ROOT/pages/replace-field-action.adoc
@@ -59,7 +59,6 @@ spec:
       name: mychannel
 
 ----
-
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `replace-field-action-binding.yaml` file into your hard drive, then configure it according to your needs.

--- a/docs/modules/ROOT/pages/salesforce-source.adoc
+++ b/docs/modules/ROOT/pages/salesforce-source.adoc
@@ -57,9 +57,8 @@ spec:
       kind: InMemoryChannel
       apiVersion: messaging.knative.dev/v1
       name: mychannel
-
+  
 ----
-
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `salesforce-source-binding.yaml` file into your hard drive, then configure it according to your needs.
@@ -111,7 +110,7 @@ spec:
       kind: KafkaTopic
       apiVersion: kafka.strimzi.io/v1beta1
       name: my-topic
-
+  
 ----
 
 Ensure that you've installed https://strimzi.io/[Strimzi] and created a topic named `my-topic` in the current namespace.

--- a/docs/modules/ROOT/pages/sftp-sink.adoc
+++ b/docs/modules/ROOT/pages/sftp-sink.adoc
@@ -61,9 +61,8 @@ spec:
       directoryName: "The Directory Name"
       password: "The Password"
       username: "The Username"
-
+  
 ----
-
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `sftp-sink-binding.yaml` file into your hard drive, then configure it according to your needs.
@@ -113,7 +112,7 @@ spec:
       directoryName: "The Directory Name"
       password: "The Password"
       username: "The Username"
-
+  
 ----
 
 Ensure that you've installed https://strimzi.io/[Strimzi] and created a topic named `my-topic` in the current namespace.

--- a/docs/modules/ROOT/pages/sftp-source.adoc
+++ b/docs/modules/ROOT/pages/sftp-source.adoc
@@ -56,9 +56,8 @@ spec:
       kind: InMemoryChannel
       apiVersion: messaging.knative.dev/v1
       name: mychannel
-
+  
 ----
-
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `sftp-source-binding.yaml` file into your hard drive, then configure it according to your needs.
@@ -108,7 +107,7 @@ spec:
       kind: KafkaTopic
       apiVersion: kafka.strimzi.io/v1beta1
       name: my-topic
-
+  
 ----
 
 Ensure that you've installed https://strimzi.io/[Strimzi] and created a topic named `my-topic` in the current namespace.

--- a/docs/modules/ROOT/pages/slack-sink.adoc
+++ b/docs/modules/ROOT/pages/slack-sink.adoc
@@ -51,9 +51,8 @@ spec:
     properties:
       channel: "#myroom"
       webhookUrl: "The Webhook URL"
-
+  
 ----
-
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `slack-sink-binding.yaml` file into your hard drive, then configure it according to your needs.
@@ -101,7 +100,7 @@ spec:
     properties:
       channel: "#myroom"
       webhookUrl: "The Webhook URL"
-
+  
 ----
 
 Ensure that you've installed https://strimzi.io/[Strimzi] and created a topic named `my-topic` in the current namespace.

--- a/docs/modules/ROOT/pages/slack-source.adoc
+++ b/docs/modules/ROOT/pages/slack-source.adoc
@@ -48,9 +48,8 @@ spec:
       kind: InMemoryChannel
       apiVersion: messaging.knative.dev/v1
       name: mychannel
-
+  
 ----
-
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `slack-source-binding.yaml` file into your hard drive, then configure it according to your needs.
@@ -98,7 +97,7 @@ spec:
       kind: KafkaTopic
       apiVersion: kafka.strimzi.io/v1beta1
       name: my-topic
-
+  
 ----
 
 Ensure that you've installed https://strimzi.io/[Strimzi] and created a topic named `my-topic` in the current namespace.

--- a/docs/modules/ROOT/pages/sqlserver-sink.adoc
+++ b/docs/modules/ROOT/pages/sqlserver-sink.adoc
@@ -67,9 +67,8 @@ spec:
       query: "INSERT INTO accounts (username,city) VALUES (:#username,:#city)"
       serverName: "localhost"
       username: "The Username"
-
+  
 ----
-
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `sqlserver-sink-binding.yaml` file into your hard drive, then configure it according to your needs.
@@ -120,7 +119,7 @@ spec:
       query: "INSERT INTO accounts (username,city) VALUES (:#username,:#city)"
       serverName: "localhost"
       username: "The Username"
-
+  
 ----
 
 Ensure that you've installed https://strimzi.io/[Strimzi] and created a topic named `my-topic` in the current namespace.

--- a/docs/modules/ROOT/pages/sqlserver-source.adoc
+++ b/docs/modules/ROOT/pages/sqlserver-source.adoc
@@ -60,9 +60,8 @@ spec:
       kind: InMemoryChannel
       apiVersion: messaging.knative.dev/v1
       name: mychannel
-
+  
 ----
-
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `sqlserver-source-binding.yaml` file into your hard drive, then configure it according to your needs.
@@ -113,7 +112,7 @@ spec:
       kind: KafkaTopic
       apiVersion: kafka.strimzi.io/v1beta1
       name: my-topic
-
+  
 ----
 
 Ensure that you've installed https://strimzi.io/[Strimzi] and created a topic named `my-topic` in the current namespace.

--- a/docs/modules/ROOT/pages/ssh-source.adoc
+++ b/docs/modules/ROOT/pages/ssh-source.adoc
@@ -54,9 +54,8 @@ spec:
       kind: InMemoryChannel
       apiVersion: messaging.knative.dev/v1
       name: mychannel
-
+  
 ----
-
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `ssh-source-binding.yaml` file into your hard drive, then configure it according to your needs.
@@ -106,7 +105,7 @@ spec:
       kind: KafkaTopic
       apiVersion: kafka.strimzi.io/v1beta1
       name: my-topic
-
+  
 ----
 
 Ensure that you've installed https://strimzi.io/[Strimzi] and created a topic named `my-topic` in the current namespace.

--- a/docs/modules/ROOT/pages/string-template-action.adoc
+++ b/docs/modules/ROOT/pages/string-template-action.adoc
@@ -57,7 +57,6 @@ spec:
       name: mychannel
 
 ----
-
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `string-template-action-binding.yaml` file into your hard drive, then configure it according to your needs.

--- a/docs/modules/ROOT/pages/telegram-sink.adoc
+++ b/docs/modules/ROOT/pages/telegram-sink.adoc
@@ -60,9 +60,8 @@ spec:
       name: telegram-sink
     properties:
       authorizationToken: "The Token"
-
+  
 ----
-
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `telegram-sink-binding.yaml` file into your hard drive, then configure it according to your needs.
@@ -109,7 +108,7 @@ spec:
       name: telegram-sink
     properties:
       authorizationToken: "The Token"
-
+  
 ----
 
 Ensure that you've installed https://strimzi.io/[Strimzi] and created a topic named `my-topic` in the current namespace.

--- a/docs/modules/ROOT/pages/telegram-source.adoc
+++ b/docs/modules/ROOT/pages/telegram-source.adoc
@@ -48,9 +48,8 @@ spec:
       kind: InMemoryChannel
       apiVersion: messaging.knative.dev/v1
       name: mychannel
-
+  
 ----
-
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `telegram-source-binding.yaml` file into your hard drive, then configure it according to your needs.
@@ -97,7 +96,7 @@ spec:
       kind: KafkaTopic
       apiVersion: kafka.strimzi.io/v1beta1
       name: my-topic
-
+  
 ----
 
 Ensure that you've installed https://strimzi.io/[Strimzi] and created a topic named `my-topic` in the current namespace.

--- a/docs/modules/ROOT/pages/timer-source.adoc
+++ b/docs/modules/ROOT/pages/timer-source.adoc
@@ -48,9 +48,8 @@ spec:
       kind: InMemoryChannel
       apiVersion: messaging.knative.dev/v1
       name: mychannel
-
+  
 ----
-
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `timer-source-binding.yaml` file into your hard drive, then configure it according to your needs.
@@ -97,7 +96,7 @@ spec:
       kind: KafkaTopic
       apiVersion: kafka.strimzi.io/v1beta1
       name: my-topic
-
+  
 ----
 
 Ensure that you've installed https://strimzi.io/[Strimzi] and created a topic named `my-topic` in the current namespace.

--- a/docs/modules/ROOT/pages/timestamp-router-action.adoc
+++ b/docs/modules/ROOT/pages/timestamp-router-action.adoc
@@ -55,7 +55,6 @@ spec:
       name: mychannel
 
 ----
-
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `timestamp-router-action-binding.yaml` file into your hard drive, then configure it according to your needs.

--- a/docs/modules/ROOT/pages/topic-name-matches-filter-action.adoc
+++ b/docs/modules/ROOT/pages/topic-name-matches-filter-action.adoc
@@ -55,7 +55,6 @@ spec:
       name: mychannel
 
 ----
-
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `topic-name-matches-filter-action-binding.yaml` file into your hard drive, then configure it according to your needs.

--- a/docs/modules/ROOT/pages/twitter-directmessage-source.adoc
+++ b/docs/modules/ROOT/pages/twitter-directmessage-source.adoc
@@ -57,9 +57,8 @@ spec:
       kind: InMemoryChannel
       apiVersion: messaging.knative.dev/v1
       name: mychannel
-
+  
 ----
-
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `twitter-directmessage-source-binding.yaml` file into your hard drive, then configure it according to your needs.
@@ -110,7 +109,7 @@ spec:
       kind: KafkaTopic
       apiVersion: kafka.strimzi.io/v1beta1
       name: my-topic
-
+  
 ----
 
 Ensure that you've installed https://strimzi.io/[Strimzi] and created a topic named `my-topic` in the current namespace.

--- a/docs/modules/ROOT/pages/twitter-search-source.adoc
+++ b/docs/modules/ROOT/pages/twitter-search-source.adoc
@@ -57,9 +57,8 @@ spec:
       kind: InMemoryChannel
       apiVersion: messaging.knative.dev/v1
       name: mychannel
-
+  
 ----
-
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `twitter-search-source-binding.yaml` file into your hard drive, then configure it according to your needs.
@@ -110,7 +109,7 @@ spec:
       kind: KafkaTopic
       apiVersion: kafka.strimzi.io/v1beta1
       name: my-topic
-
+  
 ----
 
 Ensure that you've installed https://strimzi.io/[Strimzi] and created a topic named `my-topic` in the current namespace.

--- a/docs/modules/ROOT/pages/twitter-timeline-source.adoc
+++ b/docs/modules/ROOT/pages/twitter-timeline-source.adoc
@@ -57,9 +57,8 @@ spec:
       kind: InMemoryChannel
       apiVersion: messaging.knative.dev/v1
       name: mychannel
-
+  
 ----
-
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `twitter-timeline-source-binding.yaml` file into your hard drive, then configure it according to your needs.
@@ -110,7 +109,7 @@ spec:
       kind: KafkaTopic
       apiVersion: kafka.strimzi.io/v1beta1
       name: my-topic
-
+  
 ----
 
 Ensure that you've installed https://strimzi.io/[Strimzi] and created a topic named `my-topic` in the current namespace.

--- a/docs/modules/ROOT/pages/value-to-key-action.adoc
+++ b/docs/modules/ROOT/pages/value-to-key-action.adoc
@@ -55,7 +55,6 @@ spec:
       name: mychannel
 
 ----
-
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `value-to-key-action-binding.yaml` file into your hard drive, then configure it according to your needs.

--- a/docs/modules/ROOT/pages/velocity-template-action.adoc
+++ b/docs/modules/ROOT/pages/velocity-template-action.adoc
@@ -57,7 +57,6 @@ spec:
       name: mychannel
 
 ----
-
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `velocity-template-action-binding.yaml` file into your hard drive, then configure it according to your needs.

--- a/docs/modules/ROOT/pages/webhook-source.adoc
+++ b/docs/modules/ROOT/pages/webhook-source.adoc
@@ -50,9 +50,8 @@ spec:
       kind: InMemoryChannel
       apiVersion: messaging.knative.dev/v1
       name: mychannel
-
+  
 ----
-
 Make sure you have xref:latest@camel-k::installation/installation.adoc[Camel K installed] into the Kubernetes cluster you're connected to.
 
 Save the `webhook-source-binding.yaml` file into your hard drive, then configure it according to your needs.
@@ -97,7 +96,7 @@ spec:
       kind: KafkaTopic
       apiVersion: kafka.strimzi.io/v1beta1
       name: my-topic
-
+  
 ----
 
 Ensure that you've installed https://strimzi.io/[Strimzi] and created a topic named `my-topic` in the current namespace.

--- a/docs/modules/ROOT/properties-list.tmpl
+++ b/docs/modules/ROOT/properties-list.tmpl
@@ -1,0 +1,1 @@
+{{ if .HasRequiredProperties }}{{ .PropertyList }}{{ end }}


### PR DESCRIPTION
Move most of the code that generates documentation for bindings into external templates. 

I plan to re-use them to support a new feature for Camel JBang that creates the file for the user.