### PR TITLE
Added camel:bean dependency to elasticsearch-index-sink.kamelet.yaml

### DIFF
--- a/elasticsearch-index-sink.kamelet.yaml
+++ b/elasticsearch-index-sink.kamelet.yaml
@@ -83,6 +83,7 @@ spec:
     - "mvn:org.apache.camel.k:camel-k-kamelet-reify"
     - "camel:elasticsearch-rest"
     - "camel:gson"
+    - "camel:bean"
   flow:
     from:
       uri: kamelet:source


### PR DESCRIPTION
It is needed by the simple language expressions used.