### PR TITLE
[Website] Put block role in correct place in template

### DIFF
--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -4,8 +4,9 @@ This page contains the default Apache Camel Kamelets catalog.
 **We love contributions for this catalog**: you can follow the xref:latest@camel-k::kamelets/kamelets-dev.adoc[Kamelets Developer Guide]
 for information on how to create new Kamelets and contribute them to the official https://github.com/apache/camel-kamelets/[github.com/apache/camel-kamelets] repository.
 
-[.catalog]
-[indexBlock,'xref',relative=!nav.adoc]
+[indexBlock,xref]
 ----
+[.catalog]
 [.item]#{xref}#
+
 ----


### PR DESCRIPTION
I have no idea why the previous way of specifying the 'catalog' role/class worked with Asciidoctor 1.5.9 (Antora 2) but specifying the role inside the template works as expected in both Antora 2 and Antora 3.