### PR TITLE
[Website] Put block role in correct place in template.

### DIFF
--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -4,8 +4,11 @@ This page contains the default Apache Camel Kamelets catalog.
 **We love contributions for this catalog**: you can follow the xref:latest@camel-k::kamelets/kamelets-dev.adoc[Kamelets Developer Guide]
 for information on how to create new Kamelets and contribute them to the official https://github.com/apache/camel-kamelets/[github.com/apache/camel-kamelets] repository.
 
-[.catalog]
-[indexBlock,'xref',relative=!nav.adoc]
+//The `relative=!nav.adoc` filter is needed only to work around a bug or limitation in xref-checker.
+//The filter should be removed when xref-checker is no longer used (i.e. Antora 3 alpha.9 upgrade is complete).
+[indexBlock,xref,relative=!nav.adoc]
 ----
+[.catalog]
 [.item]#{xref}#
+
 ----


### PR DESCRIPTION
This includes a workaround for a bug or limitation in xref-checker that should be removed when xref-checker is no longer used.

I checked locally that check:xref passes with this change. I can't run deadlinks-linux locally.