### PR TITLE
Minio Sink Kamelet: The exchangeId as object Name should be set as header and not as property

### DIFF
--- a/library/camel-kamelets/src/main/resources/kamelets/minio-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/minio-sink.kamelet.yaml
@@ -79,7 +79,7 @@ spec:
                 simple: "${header[ce-file]}"
           otherwise:
             steps:
-            - set-property:
+            - set-header:
                 name: CamelMinioObjectName
                 simple: "${exchangeId}"
       - to:

--- a/minio-sink.kamelet.yaml
+++ b/minio-sink.kamelet.yaml
@@ -79,7 +79,7 @@ spec:
                 simple: "${header[ce-file]}"
           otherwise:
             steps:
-            - set-property:
+            - set-header:
                 name: CamelMinioObjectName
                 simple: "${exchangeId}"
       - to:


### PR DESCRIPTION
Fixes #495 Minio Sink Kamelet: The exchangeId as object Name should be set as header and not as property