### PR TITLE
Update kamelets

### DIFF
--- a/has-header-filter-action.kamelet.yaml
+++ b/has-header-filter-action.kamelet.yaml
@@ -22,6 +22,11 @@ spec:
         description: The header name to evaluate
         type: string
         example: headerName
+      value:
+        title: Header Value
+        description: An optional header value to compare the header to
+        type: string
+        example: headerValue
     type: object
   dependencies:
   - "camel:core"
@@ -30,7 +35,20 @@ spec:
     from:
       uri: kamelet:source
       steps:
-      - filter:
-          simple: "${header[{{name}}]} == null"
-          steps:
-            - stop: {}
+      - set-property:
+          name: hasHeaderFilterActionValue
+          constant: "{{value:}}"
+      - choice:
+          when:
+          - simple: "${exchangeProperty[hasHeaderFilterActionValue]} != ''"
+            steps:
+            - filter:
+                simple: "${header[{{name}}]} != ${exchangeProperty[hasHeaderFilterActionValue]}"
+                steps:
+                  - stop: {}
+          otherwise:
+            steps:
+            - filter:
+                simple: "${header[{{name}}]} == null"
+                steps:
+                  - stop: {}

--- a/kafka-not-secured-source.kamelet.yaml
+++ b/kafka-not-secured-source.kamelet.yaml
@@ -52,6 +52,11 @@ spec:
         description: What to do when there is no initial offset. There are 3 enums and the value can be one of latest, earliest, none
         type: string
         default: "latest"
+      consumerGroup:
+        title: Consumer Group
+        description: A string that uniquely identifies the group of consumers to which this source belongs
+        type: string
+        example: "my-group-id"
   dependencies:
     - "camel:kafka"
     - "camel:kamelet"
@@ -64,5 +69,6 @@ spec:
         allowManualCommit: "{{allowManualCommit}}"
         pollOnError: "{{pollOnError}}"
         autoOffsetReset: "{{autoOffsetReset}}"
+        groupId: "{{?consumerGroup}}"
       steps:
       - to: "kamelet:sink"

--- a/kafka-source.kamelet.yaml
+++ b/kafka-source.kamelet.yaml
@@ -75,6 +75,11 @@ spec:
         description: What to do when there is no initial offset. There are 3 enums and the value can be one of latest, earliest, none
         type: string
         default: "latest"
+      consumerGroup:
+        title: Consumer Group
+        description: A string that uniquely identifies the group of consumers to which this source belongs
+        type: string
+        example: "my-group-id"
   dependencies:
     - "camel:kafka"
     - "camel:kamelet"
@@ -90,5 +95,6 @@ spec:
         allowManualCommit: "{{allowManualCommit}}"
         pollOnError: "{{pollOnError}}"
         autoOffsetReset: "{{autoOffsetReset}}"
+        groupId: "{{?consumerGroup}}"
       steps:
       - to: "kamelet:sink"

--- a/library/camel-kamelets/src/main/resources/kamelets/has-header-filter-action.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/has-header-filter-action.kamelet.yaml
@@ -22,6 +22,11 @@ spec:
         description: The header name to evaluate
         type: string
         example: headerName
+      value:
+        title: Header Value
+        description: An optional header value to compare the header to
+        type: string
+        example: headerValue
     type: object
   dependencies:
   - "camel:core"
@@ -30,7 +35,20 @@ spec:
     from:
       uri: kamelet:source
       steps:
-      - filter:
-          simple: "${header[{{name}}]} == null"
-          steps:
-            - stop: {}
+      - set-property:
+          name: hasHeaderFilterActionValue
+          constant: "{{value:}}"
+      - choice:
+          when:
+          - simple: "${exchangeProperty[hasHeaderFilterActionValue]} != ''"
+            steps:
+            - filter:
+                simple: "${header[{{name}}]} != ${exchangeProperty[hasHeaderFilterActionValue]}"
+                steps:
+                  - stop: {}
+          otherwise:
+            steps:
+            - filter:
+                simple: "${header[{{name}}]} == null"
+                steps:
+                  - stop: {}

--- a/library/camel-kamelets/src/main/resources/kamelets/kafka-not-secured-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/kafka-not-secured-source.kamelet.yaml
@@ -52,6 +52,11 @@ spec:
         description: What to do when there is no initial offset. There are 3 enums and the value can be one of latest, earliest, none
         type: string
         default: "latest"
+      consumerGroup:
+        title: Consumer Group
+        description: A string that uniquely identifies the group of consumers to which this source belongs
+        type: string
+        example: "my-group-id"
   dependencies:
     - "camel:kafka"
     - "camel:kamelet"
@@ -64,5 +69,6 @@ spec:
         allowManualCommit: "{{allowManualCommit}}"
         pollOnError: "{{pollOnError}}"
         autoOffsetReset: "{{autoOffsetReset}}"
+        groupId: "{{?consumerGroup}}"
       steps:
       - to: "kamelet:sink"

--- a/library/camel-kamelets/src/main/resources/kamelets/kafka-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/kafka-source.kamelet.yaml
@@ -75,6 +75,11 @@ spec:
         description: What to do when there is no initial offset. There are 3 enums and the value can be one of latest, earliest, none
         type: string
         default: "latest"
+      consumerGroup:
+        title: Consumer Group
+        description: A string that uniquely identifies the group of consumers to which this source belongs
+        type: string
+        example: "my-group-id"
   dependencies:
     - "camel:kafka"
     - "camel:kamelet"
@@ -90,5 +95,6 @@ spec:
         allowManualCommit: "{{allowManualCommit}}"
         pollOnError: "{{pollOnError}}"
         autoOffsetReset: "{{autoOffsetReset}}"
+        groupId: "{{?consumerGroup}}"
       steps:
       - to: "kamelet:sink"

--- a/library/camel-kamelets/src/main/resources/kamelets/telegram-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/telegram-source.kamelet.yaml
@@ -17,6 +17,11 @@ spec:
       Receive all messages that people send to your Telegram bot.
 
       To create a bot, contact the @botfather account using the Telegram app.
+
+      The source attaches the following headers to the messages:
+
+      - `chat-id` / `ce-chat-id`: the ID of the chat where the message comes from
+
     required:
       - authorizationToken
     type: object

--- a/telegram-source.kamelet.yaml
+++ b/telegram-source.kamelet.yaml
@@ -17,6 +17,11 @@ spec:
       Receive all messages that people send to your Telegram bot.
 
       To create a bot, contact the @botfather account using the Telegram app.
+
+      The source attaches the following headers to the messages:
+
+      - `chat-id` / `ce-chat-id`: the ID of the chat where the message comes from
+
     required:
       - authorizationToken
     type: object


### PR DESCRIPTION
This adds the following improvements:

- Add the possibility to match to a specific header value (if provided) in the has-header-filter-action
- Add the consumerGroup property in the Kafka source Kamelets
- Document the `chat-id` header in the Telegram source Kamelet