### PR TITLE
Exclude explicit quotes for chuck-norris source

### DIFF
--- a/chuck-norris-source.kamelet.yaml
+++ b/chuck-norris-source.kamelet.yaml
@@ -14,7 +14,7 @@ spec:
   definition:
     title: "Chuck Norris Source"
     description: |-
-      Gets peridically Chuck Norris jokes from http://www.icndb.com/
+      Gets periodically Chuck Norris jokes from http://www.icndb.com/
     type: object
     properties:
       period:
@@ -36,7 +36,7 @@ spec:
       parameters:
         period: "{{period}}"
       steps:
-        - to: "http://api.icndb.com/jokes/random"
+        - to: "http://api.icndb.com/jokes/random?exclude=[explicit]"
         - set-body:
             jsonpath: "$.value.joke"
         - to: "kamelet:sink"


### PR DESCRIPTION
A future extension could add a parameter to re-enable explicite qoutes,
but for now I think it is safer to disable to avoid offending
people when using the source in demos.

Fixes #511.