### PR TITLE
Fix #513: use valid CloudEvents attributes

### DIFF
--- a/aws-cloudwatch-sink.kamelet.yaml
+++ b/aws-cloudwatch-sink.kamelet.yaml
@@ -18,12 +18,12 @@ spec:
 
       There are several properties you can set in the headers, such as:
 
-      `metric-name` / `ce-metric-name` for the metric name.
-      `metric-value` / `ce-metric-value` for the metric value.
-      `metric-unit` / `ce-metric-unit` for the metric unit.
-      `metric-timestamp` / `ce-metric-timestamp` for the metric timestamp.
-      `metric-dimension-name` / `ce-metric-dimension-name` for the dimension name.
-      `metric-dimension-value` / `ce-metric-dimension-value` for the dimension value.
+      `metric-name` / `ce-metricname` for the metric name.
+      `metric-value` / `ce-metricvalue` for the metric value.
+      `metric-unit` / `ce-metricunit` for the metric unit.
+      `metric-timestamp` / `ce-metrictimestamp` for the metric timestamp.
+      `metric-dimension-name` / `ce-metricdimensionname` for the dimension name.
+      `metric-dimension-value` / `ce-metricdimensionvalue` for the dimension value.
     required:
       - cw_namespace
       - accessKey
@@ -68,11 +68,11 @@ spec:
             - set-header:
                 name: CamelAwsCwMetricName
                 simple: "${header[metric-name]}"             
-          - simple: "${header[ce-metric-name]}"
+          - simple: "${header[ce-metricname]}"
             steps:
             - set-header:
                 name: CamelAwsCwMetricName
-                simple: "${header[ce-metric-name]}"
+                simple: "${header[ce-metricname]}"
       - choice:
           when:                
           - simple: "${header[metric-value]}"
@@ -80,11 +80,11 @@ spec:
             - set-header:
                 name: CamelAwsCwMetricValue
                 simple: "${header[metric-value]}"              
-          - simple: "${header[ce-metric-value]}"
+          - simple: "${header[ce-metricvalue]}"
             steps:
             - set-header:
                 name: CamelAwsCwMetricValue
-                simple: "${header[ce-metric-value]}"
+                simple: "${header[ce-metricvalue]}"
       - choice:
           when:                
           - simple: "${header[metric-unit]}"
@@ -92,11 +92,11 @@ spec:
             - set-header:
                 name: CamelAwsCwMetricUnit
                 simple: "${header[metric-unit]}"              
-          - simple: "${header[ce-metric-unit]}"
+          - simple: "${header[ce-metricunit]}"
             steps:
             - set-header:
                 name: CamelAwsCwMetricUnit
-                simple: "${header[ce-metric-unit]}"
+                simple: "${header[ce-metricunit]}"
       - choice:
           when:                
           - simple: "${header[metric-timestamp]}"
@@ -104,11 +104,11 @@ spec:
             - set-header:
                 name: CamelAwsCwMetricTimestamp
                 simple: "${header[metric-timestamp]}"               
-          - simple: "${header[ce-metric-timestamp]}"
+          - simple: "${header[ce-metrictimestamp]}"
             steps:
             - set-header:
                 name: CamelAwsCwMetricTimestamp
-                simple: "${header[ce-metric-timestamp]}"
+                simple: "${header[ce-metrictimestamp]}"
       - choice:
           when:                
           - simple: "${header[metric-dimension-name]}"
@@ -116,11 +116,11 @@ spec:
             - set-header:
                 name: CamelAwsCwMetricDimensionName
                 simple: "${header[metric-dimension-name]}"
-          - simple: "${header[ce-metric-dimension-name]}"
+          - simple: "${header[ce-metricdimensionname]}"
             steps:
             - set-header:
                 name: CamelAwsCwMetricDimensionName
-                simple: "${header[ce-metric-dimension-name]}"
+                simple: "${header[ce-metricdimensionname]}"
       - choice:
           when:                
           - simple: "${header[metric-dimension-value]}"
@@ -128,11 +128,11 @@ spec:
             - set-header:
                 name: CamelAwsCwMetricDimensionValue
                 simple: "${header[metric-dimension-value]}"
-          - simple: "${header[ce-metric-dimension-value]}"
+          - simple: "${header[ce-metricdimensionvalue]}"
             steps:
             - set-header:
                 name: CamelAwsCwMetricDimensionValue
-                simple: "${header[ce-metric-dimension-value]}"
+                simple: "${header[ce-metricdimensionvalue]}"
       - to:
           uri: "aws2-cw:{{cw_namespace}}"
           parameters:

--- a/aws-ec2-sink.kamelet.yaml
+++ b/aws-ec2-sink.kamelet.yaml
@@ -18,7 +18,7 @@ spec:
 
       The Kamelet expects the following headers to be set:
 
-      - `instanceIds` / `ce-instanceIds`: as a comma separated list of EC2 instance ids.
+      - `instanceIds` / `ce-instanceids`: as a comma separated list of EC2 instance ids.
     required:
       - accessKey
       - secretKey
@@ -58,11 +58,11 @@ spec:
             - set-header:
                 name: CamelAwsEC2InstancesIds
                 simple: "${header[instanceIds]}"
-          - simple: "${header[ce-instanceIds]}"
+          - simple: "${header[ce-instanceids]}"
             steps:
             - set-header:
                 name: CamelAwsEC2InstancesIds
-                simple: "${header[ce-instanceIds]}"
+                simple: "${header[ce-instanceids]}"
       - to:
           uri: "aws2-ec2:ec2-route"
           parameters:

--- a/aws-kinesis-sink.kamelet.yaml
+++ b/aws-kinesis-sink.kamelet.yaml
@@ -24,7 +24,7 @@ spec:
 
       The Kamelet is also able to recognize the following header:
 
-      - `sequence-number` / `ce-sequence-number`: to set the Sequence number
+      - `sequence-number` / `ce-sequencenumber`: to set the Sequence number
 
       This header is optional.
     required:
@@ -88,11 +88,11 @@ spec:
             - set-header:
                 name: CamelAwsKinesisSequenceNumber
                 simple: "${header[sequence-number]}"
-          - simple: "${header[ce-sequence-number]}"
+          - simple: "${header[ce-sequencenumber]}"
             steps:
             - set-header:
                 name: CamelAwsKinesisSequenceNumber
-                simple: "${header[ce-sequence-number]}"
+                simple: "${header[ce-sequencenumber]}"
       - to:
           uri: "aws2-kinesis:{{stream}}"
           parameters:

--- a/caffeine-action.kamelet.yaml
+++ b/caffeine-action.kamelet.yaml
@@ -18,9 +18,9 @@ spec:
 
       The Kamelet expects the following headers to be set:
 
-      - `caffeine-key` / `ce-caffeine-key`: as the cache key used in the operation
+      - `caffeine-key` / `ce-caffeinekey`: as the cache key used in the operation
 
-      - `caffeine-operation` / `ce-caffeine-operation`: as the operation to perform. It can be PUT, GET, INVALIDATE and CLEANUP.
+      - `caffeine-operation` / `ce-caffeineoperation`: as the operation to perform. It can be PUT, GET, INVALIDATE and CLEANUP.
 
       If the caffeine-key header won't be set the exchange ID will be used as key.
 
@@ -48,11 +48,11 @@ spec:
             - set-header:
                 name: CamelCaffeineKey
                 simple: "${header[caffeine-key]}"
-          - simple: "${header[ce-caffeine-key]}"
+          - simple: "${header[ce-caffeinekey]}"
             steps:
             - set-header:
                 name: CamelCaffeineKey
-                simple: "${header[ce-caffeine-key]}"
+                simple: "${header[ce-caffeinekey]}"
           otherwise:
             steps:
             - set-header:
@@ -65,11 +65,11 @@ spec:
             - set-header:
                 name: CamelCaffeineAction
                 simple: "${header[caffeine-operation]}"
-          - simple: "${header[ce-caffeine-operation]}"
+          - simple: "${header[ce-caffeineoperation]}"
             steps:
             - set-header:
                 name: CamelCaffeineAction
-                simple: "${header[ce-caffeine-operation]}"
+                simple: "${header[ce-caffeineoperation]}"
           otherwise:
             steps:
             - set-header:

--- a/dns-dig-action.kamelet.yaml
+++ b/dns-dig-action.kamelet.yaml
@@ -18,9 +18,9 @@ spec:
 
       The Kamelet expects the following headers to be set:
 
-      - `domain-name` / `ce-domain-name`: as the domain for which we are querying the DNS
+      - `domain-name` / `ce-domainname`: as the domain for which we are querying the DNS
 
-      - `dns-type` / `ce-dns-type`: as the DNS type
+      - `dns-type` / `ce-dnstype`: as the DNS type
 
       If the domain-name header won't be set the body will be used as domain name.
 
@@ -40,11 +40,11 @@ spec:
             - set-header:
                 name: dns.name
                 simple: "${header[domain-name]}"
-          - simple: "${header[ce-domain-name]}"
+          - simple: "${header[ce-domainname]}"
             steps:
             - set-header:
                 name: dns.name
-                simple: "${header[ce-domain-name]}"
+                simple: "${header[ce-domainname]}"
           otherwise:
             steps:
             - set-header:
@@ -57,11 +57,11 @@ spec:
             - set-header:
                 name: dns.type
                 simple: "${header[dns-type]}"
-          - simple: "${header[ce-dns-type]}"
+          - simple: "${header[ce-dnstype]}"
             steps:
             - set-header:
                 name: dns.type
-                simple: "${header[ce-dns-type]}"
+                simple: "${header[ce-dnstype]}"
           otherwise:
             steps:
             - set-header:

--- a/dns-lookup-action.kamelet.yaml
+++ b/dns-lookup-action.kamelet.yaml
@@ -18,7 +18,7 @@ spec:
 
       The Kamelet expects the following headers to be set:
 
-      - `domain-name` / `ce-domain-name`: as the domain for which we are looking up
+      - `domain-name` / `ce-domainname`: as the domain for which we are looking up
 
       If the domain-name header won't be set the body will be used as domain name.
     type: object
@@ -40,11 +40,11 @@ spec:
             - set-header:
                 name: dns.domain
                 simple: "${header[domain-name]}"
-          - simple: "${header[ce-domain-name]}"
+          - simple: "${header[ce-domainname]}"
             steps:
             - set-header:
                 name: dns.domain
-                simple: "${header[ce-domain-name]}"
+                simple: "${header[ce-domainname]}"
           otherwise:
             steps:
             - set-header:

--- a/docs/modules/ROOT/pages/aws-cloudwatch-sink.adoc
+++ b/docs/modules/ROOT/pages/aws-cloudwatch-sink.adoc
@@ -9,12 +9,12 @@ Send messages to AWS CloudWatch metrics.
 
 There are several properties you can set in the headers, such as:
 
-`metric-name` / `ce-metric-name` for the metric name.
-`metric-value` / `ce-metric-value` for the metric value.
-`metric-unit` / `ce-metric-unit` for the metric unit.
-`metric-timestamp` / `ce-metric-timestamp` for the metric timestamp.
-`metric-dimension-name` / `ce-metric-dimension-name` for the dimension name.
-`metric-dimension-value` / `ce-metric-dimension-value` for the dimension value.
+`metric-name` / `ce-metricname` for the metric name.
+`metric-value` / `ce-metricvalue` for the metric value.
+`metric-unit` / `ce-metricunit` for the metric unit.
+`metric-timestamp` / `ce-metrictimestamp` for the metric timestamp.
+`metric-dimension-name` / `ce-metricdimensionname` for the dimension name.
+`metric-dimension-value` / `ce-metricdimensionvalue` for the dimension value.
 
 == Configuration Options
 

--- a/docs/modules/ROOT/pages/aws-ec2-sink.adoc
+++ b/docs/modules/ROOT/pages/aws-ec2-sink.adoc
@@ -9,7 +9,7 @@ Check the status of EC2 instances
 
 The Kamelet expects the following headers to be set:
 
-- `instanceIds` / `ce-instanceIds`: as a comma separated list of EC2 instance ids.
+- `instanceIds` / `ce-instanceids`: as a comma separated list of EC2 instance ids.
 
 == Configuration Options
 

--- a/docs/modules/ROOT/pages/aws-kinesis-sink.adoc
+++ b/docs/modules/ROOT/pages/aws-kinesis-sink.adoc
@@ -15,7 +15,7 @@ If the header won't be set the exchange ID will be used.
 
 The Kamelet is also able to recognize the following header:
 
-- `sequence-number` / `ce-sequence-number`: to set the Sequence number
+- `sequence-number` / `ce-sequencenumber`: to set the Sequence number
 
 This header is optional.
 

--- a/docs/modules/ROOT/pages/caffeine-action.adoc
+++ b/docs/modules/ROOT/pages/caffeine-action.adoc
@@ -9,9 +9,9 @@ Perform operations on a caffeine cache
 
 The Kamelet expects the following headers to be set:
 
-- `caffeine-key` / `ce-caffeine-key`: as the cache key used in the operation
+- `caffeine-key` / `ce-caffeinekey`: as the cache key used in the operation
 
-- `caffeine-operation` / `ce-caffeine-operation`: as the operation to perform. It can be PUT, GET, INVALIDATE and CLEANUP.
+- `caffeine-operation` / `ce-caffeineoperation`: as the operation to perform. It can be PUT, GET, INVALIDATE and CLEANUP.
 
 If the caffeine-key header won't be set the exchange ID will be used as key.
 

--- a/docs/modules/ROOT/pages/dns-dig-action.adoc
+++ b/docs/modules/ROOT/pages/dns-dig-action.adoc
@@ -9,9 +9,9 @@ Query a DNS through Dig
 
 The Kamelet expects the following headers to be set:
 
-- `domain-name` / `ce-domain-name`: as the domain for which we are querying the DNS
+- `domain-name` / `ce-domainname`: as the domain for which we are querying the DNS
 
-- `dns-type` / `ce-dns-type`: as the DNS type
+- `dns-type` / `ce-dnstype`: as the DNS type
 
 If the domain-name header won't be set the body will be used as domain name.
 

--- a/docs/modules/ROOT/pages/dns-lookup-action.adoc
+++ b/docs/modules/ROOT/pages/dns-lookup-action.adoc
@@ -9,7 +9,7 @@ Lookup for a domain
 
 The Kamelet expects the following headers to be set:
 
-- `domain-name` / `ce-domain-name`: as the domain for which we are looking up
+- `domain-name` / `ce-domainname`: as the domain for which we are looking up
 
 If the domain-name header won't be set the body will be used as domain name.
 

--- a/docs/modules/ROOT/pages/elasticsearch-index-sink.adoc
+++ b/docs/modules/ROOT/pages/elasticsearch-index-sink.adoc
@@ -9,11 +9,11 @@ This sink stores documents into ElasticSearch.
 
 Input data must have JSON format according to the index used.
 
-- `indexId` / `ce-indexId`: as the index ID for Elasticsearch
+- `indexId` / `ce-indexid`: as the index ID for Elasticsearch
 
 If the header won't be set the exchange ID will be used as index.
 
-- `indexName` / `ce-indexName`: as the index Name for Elasticsearch
+- `indexName` / `ce-indexname`: as the index Name for Elasticsearch
 
 If the header won't be set the exchange ID will be used as index name.
 

--- a/docs/modules/ROOT/pages/kafka-not-secured-sink.adoc
+++ b/docs/modules/ROOT/pages/kafka-not-secured-sink.adoc
@@ -11,7 +11,7 @@ The Kamelet is able to understand the following headers to be set:
 
 - `key` / `ce-key`: as message key
 
-- `partition-key` / `ce-partition-key`: as message partition key
+- `partition-key` / `ce-partitionkey`: as message partition key
 
 Both the headers are optional.
 

--- a/docs/modules/ROOT/pages/kafka-sink.adoc
+++ b/docs/modules/ROOT/pages/kafka-sink.adoc
@@ -11,7 +11,7 @@ The Kamelet is able to understand the following headers to be set:
 
 - `key` / `ce-key`: as message key
 
-- `partition-key` / `ce-partition-key`: as message partition key
+- `partition-key` / `ce-partitionkey`: as message partition key
 
 Both the headers are optional.
 

--- a/docs/modules/ROOT/pages/mail-imap-source.adoc
+++ b/docs/modules/ROOT/pages/mail-imap-source.adoc
@@ -7,6 +7,16 @@
 
 Receive unread emails from an IMAP mail server, marking them as read once they are received.
 
+The Kamelet generates the following headers:
+
+- `subject` / `ce-subject`: the subject of the incoming mail
+
+- `from` / `ce-from`: the `from` field of the incoming mail
+
+- `to` / `ce-to`: the `to` field of the incoming mail
+
+- `cc` / `ce-cc`: the `cc` field of the incoming mail
+
 == Configuration Options
 
 The following table summarizes the configuration options available for the `mail-imap-source` Kamelet:

--- a/docs/modules/ROOT/pages/mongodb-sink.adoc
+++ b/docs/modules/ROOT/pages/mongodb-sink.adoc
@@ -11,7 +11,7 @@ This Kamelet expects a JSON as body.
 
 Properties you can as headers:
 
-`db-upsert` / `ce-db-upsert` If the database should create the element if it does not exist. Boolean value.
+`db-upsert` / `ce-dbupsert` If the database should create the element if it does not exist. Boolean value.
 
 == Configuration Options
 

--- a/docs/modules/ROOT/pages/telegram-sink.adoc
+++ b/docs/modules/ROOT/pages/telegram-sink.adoc
@@ -18,7 +18,7 @@ This sink supports the following message types:
 This following message headers are also supported:
 
 - `text` / `ce-text`: when sending an image, the image caption
-- `chat-id` / `ce-chat-id`: to override the default chat where messages are sent to
+- `chat-id` / `ce-chatid`: to override the default chat where messages are sent to
 
 == Configuration Options
 

--- a/docs/modules/ROOT/pages/telegram-source.adoc
+++ b/docs/modules/ROOT/pages/telegram-source.adoc
@@ -11,7 +11,7 @@ To create a bot, contact the @botfather account using the Telegram app.
 
 The source attaches the following headers to the messages:
 
-- `chat-id` / `ce-chat-id`: the ID of the chat where the message comes from
+- `chat-id` / `ce-chatid`: the ID of the chat where the message comes from
 
 == Configuration Options
 

--- a/elasticsearch-index-sink.kamelet.yaml
+++ b/elasticsearch-index-sink.kamelet.yaml
@@ -27,11 +27,11 @@ spec:
 
       Input data must have JSON format according to the index used.
 
-      - `indexId` / `ce-indexId`: as the index ID for Elasticsearch
+      - `indexId` / `ce-indexid`: as the index ID for Elasticsearch
 
       If the header won't be set the exchange ID will be used as index.
 
-      - `indexName` / `ce-indexName`: as the index Name for Elasticsearch
+      - `indexName` / `ce-indexname`: as the index Name for Elasticsearch
 
       If the header won't be set the exchange ID will be used as index name.
     required:
@@ -95,11 +95,11 @@ spec:
             - set-header:
                 name: "indexId"
                 simple: "${header[indexId]}"
-          - simple: "${header[ce-indexId]}"
+          - simple: "${header[ce-indexid]}"
             steps:
             - set-header:
                 name: "indexId"
-                simple: "${header[ce-indexId]}"
+                simple: "${header[ce-indexid]}"
           otherwise:
             steps:
             - set-header:
@@ -112,11 +112,11 @@ spec:
             - set-header:
                 name: "indexName"
                 simple: "${header[indexName]}"
-          - simple: "${header[ce-indexName]}"
+          - simple: "${header[ce-indexname]}"
             steps:
             - set-header:
                 name: "indexName"
-                simple: "${header[ce-indexName]}"
+                simple: "${header[ce-indexname]}"
       - to:
           uri: "kamelet-reify:elasticsearch-rest:{{clusterName}}"
           parameters:

--- a/kafka-not-secured-sink.kamelet.yaml
+++ b/kafka-not-secured-sink.kamelet.yaml
@@ -20,7 +20,7 @@ spec:
 
       - `key` / `ce-key`: as message key
     
-      - `partition-key` / `ce-partition-key`: as message partition key
+      - `partition-key` / `ce-partitionkey`: as message partition key
 
       Both the headers are optional.
     required:
@@ -62,11 +62,11 @@ spec:
             - set-header:
                 name: kafka.PARTITION_KEY
                 simple: "${header[partition-key]}"
-          - simple: "${header[ce-partition-key]}"
+          - simple: "${header[ce-partitionkey]}"
             steps:
             - set-header:
                 name: kafka.PARTITION_KEY
-                simple: "${header[ce-partition-key]}"
+                simple: "${header[ce-partitionkey]}"
       - to:
           uri: "kafka:{{topic}}"
           parameters:

--- a/kafka-sink.kamelet.yaml
+++ b/kafka-sink.kamelet.yaml
@@ -20,7 +20,7 @@ spec:
 
       - `key` / `ce-key`: as message key
     
-      - `partition-key` / `ce-partition-key`: as message partition key
+      - `partition-key` / `ce-partitionkey`: as message partition key
 
       Both the headers are optional.
     required:
@@ -85,11 +85,11 @@ spec:
             - set-header:
                 name: kafka.PARTITION_KEY
                 simple: "${header[partition-key]}"
-          - simple: "${header[ce-partition-key]}"
+          - simple: "${header[ce-partitionkey]}"
             steps:
             - set-header:
                 name: kafka.PARTITION_KEY
-                simple: "${header[ce-partition-key]}"
+                simple: "${header[ce-partitionkey]}"
       - to:
           uri: "kafka:{{topic}}"
           parameters:

--- a/library/camel-kamelets/src/main/resources/kamelets/aws-cloudwatch-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/aws-cloudwatch-sink.kamelet.yaml
@@ -18,12 +18,12 @@ spec:
 
       There are several properties you can set in the headers, such as:
 
-      `metric-name` / `ce-metric-name` for the metric name.
-      `metric-value` / `ce-metric-value` for the metric value.
-      `metric-unit` / `ce-metric-unit` for the metric unit.
-      `metric-timestamp` / `ce-metric-timestamp` for the metric timestamp.
-      `metric-dimension-name` / `ce-metric-dimension-name` for the dimension name.
-      `metric-dimension-value` / `ce-metric-dimension-value` for the dimension value.
+      `metric-name` / `ce-metricname` for the metric name.
+      `metric-value` / `ce-metricvalue` for the metric value.
+      `metric-unit` / `ce-metricunit` for the metric unit.
+      `metric-timestamp` / `ce-metrictimestamp` for the metric timestamp.
+      `metric-dimension-name` / `ce-metricdimensionname` for the dimension name.
+      `metric-dimension-value` / `ce-metricdimensionvalue` for the dimension value.
     required:
       - cw_namespace
       - accessKey
@@ -68,11 +68,11 @@ spec:
             - set-header:
                 name: CamelAwsCwMetricName
                 simple: "${header[metric-name]}"             
-          - simple: "${header[ce-metric-name]}"
+          - simple: "${header[ce-metricname]}"
             steps:
             - set-header:
                 name: CamelAwsCwMetricName
-                simple: "${header[ce-metric-name]}"
+                simple: "${header[ce-metricname]}"
       - choice:
           when:                
           - simple: "${header[metric-value]}"
@@ -80,11 +80,11 @@ spec:
             - set-header:
                 name: CamelAwsCwMetricValue
                 simple: "${header[metric-value]}"              
-          - simple: "${header[ce-metric-value]}"
+          - simple: "${header[ce-metricvalue]}"
             steps:
             - set-header:
                 name: CamelAwsCwMetricValue
-                simple: "${header[ce-metric-value]}"
+                simple: "${header[ce-metricvalue]}"
       - choice:
           when:                
           - simple: "${header[metric-unit]}"
@@ -92,11 +92,11 @@ spec:
             - set-header:
                 name: CamelAwsCwMetricUnit
                 simple: "${header[metric-unit]}"              
-          - simple: "${header[ce-metric-unit]}"
+          - simple: "${header[ce-metricunit]}"
             steps:
             - set-header:
                 name: CamelAwsCwMetricUnit
-                simple: "${header[ce-metric-unit]}"
+                simple: "${header[ce-metricunit]}"
       - choice:
           when:                
           - simple: "${header[metric-timestamp]}"
@@ -104,11 +104,11 @@ spec:
             - set-header:
                 name: CamelAwsCwMetricTimestamp
                 simple: "${header[metric-timestamp]}"               
-          - simple: "${header[ce-metric-timestamp]}"
+          - simple: "${header[ce-metrictimestamp]}"
             steps:
             - set-header:
                 name: CamelAwsCwMetricTimestamp
-                simple: "${header[ce-metric-timestamp]}"
+                simple: "${header[ce-metrictimestamp]}"
       - choice:
           when:                
           - simple: "${header[metric-dimension-name]}"
@@ -116,11 +116,11 @@ spec:
             - set-header:
                 name: CamelAwsCwMetricDimensionName
                 simple: "${header[metric-dimension-name]}"
-          - simple: "${header[ce-metric-dimension-name]}"
+          - simple: "${header[ce-metricdimensionname]}"
             steps:
             - set-header:
                 name: CamelAwsCwMetricDimensionName
-                simple: "${header[ce-metric-dimension-name]}"
+                simple: "${header[ce-metricdimensionname]}"
       - choice:
           when:                
           - simple: "${header[metric-dimension-value]}"
@@ -128,11 +128,11 @@ spec:
             - set-header:
                 name: CamelAwsCwMetricDimensionValue
                 simple: "${header[metric-dimension-value]}"
-          - simple: "${header[ce-metric-dimension-value]}"
+          - simple: "${header[ce-metricdimensionvalue]}"
             steps:
             - set-header:
                 name: CamelAwsCwMetricDimensionValue
-                simple: "${header[ce-metric-dimension-value]}"
+                simple: "${header[ce-metricdimensionvalue]}"
       - to:
           uri: "aws2-cw:{{cw_namespace}}"
           parameters:

--- a/library/camel-kamelets/src/main/resources/kamelets/aws-ec2-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/aws-ec2-sink.kamelet.yaml
@@ -18,7 +18,7 @@ spec:
 
       The Kamelet expects the following headers to be set:
 
-      - `instanceIds` / `ce-instanceIds`: as a comma separated list of EC2 instance ids.
+      - `instanceIds` / `ce-instanceids`: as a comma separated list of EC2 instance ids.
     required:
       - accessKey
       - secretKey
@@ -58,11 +58,11 @@ spec:
             - set-header:
                 name: CamelAwsEC2InstancesIds
                 simple: "${header[instanceIds]}"
-          - simple: "${header[ce-instanceIds]}"
+          - simple: "${header[ce-instanceids]}"
             steps:
             - set-header:
                 name: CamelAwsEC2InstancesIds
-                simple: "${header[ce-instanceIds]}"
+                simple: "${header[ce-instanceids]}"
       - to:
           uri: "aws2-ec2:ec2-route"
           parameters:

--- a/library/camel-kamelets/src/main/resources/kamelets/aws-kinesis-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/aws-kinesis-sink.kamelet.yaml
@@ -24,7 +24,7 @@ spec:
 
       The Kamelet is also able to recognize the following header:
 
-      - `sequence-number` / `ce-sequence-number`: to set the Sequence number
+      - `sequence-number` / `ce-sequencenumber`: to set the Sequence number
 
       This header is optional.
     required:
@@ -88,11 +88,11 @@ spec:
             - set-header:
                 name: CamelAwsKinesisSequenceNumber
                 simple: "${header[sequence-number]}"
-          - simple: "${header[ce-sequence-number]}"
+          - simple: "${header[ce-sequencenumber]}"
             steps:
             - set-header:
                 name: CamelAwsKinesisSequenceNumber
-                simple: "${header[ce-sequence-number]}"
+                simple: "${header[ce-sequencenumber]}"
       - to:
           uri: "aws2-kinesis:{{stream}}"
           parameters:

--- a/library/camel-kamelets/src/main/resources/kamelets/caffeine-action.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/caffeine-action.kamelet.yaml
@@ -18,9 +18,9 @@ spec:
 
       The Kamelet expects the following headers to be set:
 
-      - `caffeine-key` / `ce-caffeine-key`: as the cache key used in the operation
+      - `caffeine-key` / `ce-caffeinekey`: as the cache key used in the operation
 
-      - `caffeine-operation` / `ce-caffeine-operation`: as the operation to perform. It can be PUT, GET, INVALIDATE and CLEANUP.
+      - `caffeine-operation` / `ce-caffeineoperation`: as the operation to perform. It can be PUT, GET, INVALIDATE and CLEANUP.
 
       If the caffeine-key header won't be set the exchange ID will be used as key.
 
@@ -48,11 +48,11 @@ spec:
             - set-header:
                 name: CamelCaffeineKey
                 simple: "${header[caffeine-key]}"
-          - simple: "${header[ce-caffeine-key]}"
+          - simple: "${header[ce-caffeinekey]}"
             steps:
             - set-header:
                 name: CamelCaffeineKey
-                simple: "${header[ce-caffeine-key]}"
+                simple: "${header[ce-caffeinekey]}"
           otherwise:
             steps:
             - set-header:
@@ -65,11 +65,11 @@ spec:
             - set-header:
                 name: CamelCaffeineAction
                 simple: "${header[caffeine-operation]}"
-          - simple: "${header[ce-caffeine-operation]}"
+          - simple: "${header[ce-caffeineoperation]}"
             steps:
             - set-header:
                 name: CamelCaffeineAction
-                simple: "${header[ce-caffeine-operation]}"
+                simple: "${header[ce-caffeineoperation]}"
           otherwise:
             steps:
             - set-header:

--- a/library/camel-kamelets/src/main/resources/kamelets/dns-dig-action.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/dns-dig-action.kamelet.yaml
@@ -18,9 +18,9 @@ spec:
 
       The Kamelet expects the following headers to be set:
 
-      - `domain-name` / `ce-domain-name`: as the domain for which we are querying the DNS
+      - `domain-name` / `ce-domainname`: as the domain for which we are querying the DNS
 
-      - `dns-type` / `ce-dns-type`: as the DNS type
+      - `dns-type` / `ce-dnstype`: as the DNS type
 
       If the domain-name header won't be set the body will be used as domain name.
 
@@ -40,11 +40,11 @@ spec:
             - set-header:
                 name: dns.name
                 simple: "${header[domain-name]}"
-          - simple: "${header[ce-domain-name]}"
+          - simple: "${header[ce-domainname]}"
             steps:
             - set-header:
                 name: dns.name
-                simple: "${header[ce-domain-name]}"
+                simple: "${header[ce-domainname]}"
           otherwise:
             steps:
             - set-header:
@@ -57,11 +57,11 @@ spec:
             - set-header:
                 name: dns.type
                 simple: "${header[dns-type]}"
-          - simple: "${header[ce-dns-type]}"
+          - simple: "${header[ce-dnstype]}"
             steps:
             - set-header:
                 name: dns.type
-                simple: "${header[ce-dns-type]}"
+                simple: "${header[ce-dnstype]}"
           otherwise:
             steps:
             - set-header:

--- a/library/camel-kamelets/src/main/resources/kamelets/dns-lookup-action.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/dns-lookup-action.kamelet.yaml
@@ -18,7 +18,7 @@ spec:
 
       The Kamelet expects the following headers to be set:
 
-      - `domain-name` / `ce-domain-name`: as the domain for which we are looking up
+      - `domain-name` / `ce-domainname`: as the domain for which we are looking up
 
       If the domain-name header won't be set the body will be used as domain name.
     type: object
@@ -40,11 +40,11 @@ spec:
             - set-header:
                 name: dns.domain
                 simple: "${header[domain-name]}"
-          - simple: "${header[ce-domain-name]}"
+          - simple: "${header[ce-domainname]}"
             steps:
             - set-header:
                 name: dns.domain
-                simple: "${header[ce-domain-name]}"
+                simple: "${header[ce-domainname]}"
           otherwise:
             steps:
             - set-header:

--- a/library/camel-kamelets/src/main/resources/kamelets/elasticsearch-index-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/elasticsearch-index-sink.kamelet.yaml
@@ -27,11 +27,11 @@ spec:
 
       Input data must have JSON format according to the index used.
 
-      - `indexId` / `ce-indexId`: as the index ID for Elasticsearch
+      - `indexId` / `ce-indexid`: as the index ID for Elasticsearch
 
       If the header won't be set the exchange ID will be used as index.
 
-      - `indexName` / `ce-indexName`: as the index Name for Elasticsearch
+      - `indexName` / `ce-indexname`: as the index Name for Elasticsearch
 
       If the header won't be set the exchange ID will be used as index name.
     required:
@@ -95,11 +95,11 @@ spec:
             - set-header:
                 name: "indexId"
                 simple: "${header[indexId]}"
-          - simple: "${header[ce-indexId]}"
+          - simple: "${header[ce-indexid]}"
             steps:
             - set-header:
                 name: "indexId"
-                simple: "${header[ce-indexId]}"
+                simple: "${header[ce-indexid]}"
           otherwise:
             steps:
             - set-header:
@@ -112,11 +112,11 @@ spec:
             - set-header:
                 name: "indexName"
                 simple: "${header[indexName]}"
-          - simple: "${header[ce-indexName]}"
+          - simple: "${header[ce-indexname]}"
             steps:
             - set-header:
                 name: "indexName"
-                simple: "${header[ce-indexName]}"
+                simple: "${header[ce-indexname]}"
       - to:
           uri: "kamelet-reify:elasticsearch-rest:{{clusterName}}"
           parameters:

--- a/library/camel-kamelets/src/main/resources/kamelets/kafka-not-secured-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/kafka-not-secured-sink.kamelet.yaml
@@ -20,7 +20,7 @@ spec:
 
       - `key` / `ce-key`: as message key
     
-      - `partition-key` / `ce-partition-key`: as message partition key
+      - `partition-key` / `ce-partitionkey`: as message partition key
 
       Both the headers are optional.
     required:
@@ -62,11 +62,11 @@ spec:
             - set-header:
                 name: kafka.PARTITION_KEY
                 simple: "${header[partition-key]}"
-          - simple: "${header[ce-partition-key]}"
+          - simple: "${header[ce-partitionkey]}"
             steps:
             - set-header:
                 name: kafka.PARTITION_KEY
-                simple: "${header[ce-partition-key]}"
+                simple: "${header[ce-partitionkey]}"
       - to:
           uri: "kafka:{{topic}}"
           parameters:

--- a/library/camel-kamelets/src/main/resources/kamelets/kafka-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/kafka-sink.kamelet.yaml
@@ -20,7 +20,7 @@ spec:
 
       - `key` / `ce-key`: as message key
     
-      - `partition-key` / `ce-partition-key`: as message partition key
+      - `partition-key` / `ce-partitionkey`: as message partition key
 
       Both the headers are optional.
     required:
@@ -85,11 +85,11 @@ spec:
             - set-header:
                 name: kafka.PARTITION_KEY
                 simple: "${header[partition-key]}"
-          - simple: "${header[ce-partition-key]}"
+          - simple: "${header[ce-partitionkey]}"
             steps:
             - set-header:
                 name: kafka.PARTITION_KEY
-                simple: "${header[ce-partition-key]}"
+                simple: "${header[ce-partitionkey]}"
       - to:
           uri: "kafka:{{topic}}"
           parameters:

--- a/library/camel-kamelets/src/main/resources/kamelets/mail-imap-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/mail-imap-source.kamelet.yaml
@@ -15,6 +15,17 @@ spec:
     title: "Mail IMAP Source"
     description: |-
       Receive unread emails from an IMAP mail server, marking them as read once they are received.
+
+      The Kamelet generates the following headers:
+
+      - `subject` / `ce-subject`: the subject of the incoming mail
+
+      - `from` / `ce-from`: the `from` field of the incoming mail
+
+      - `to` / `ce-to`: the `to` field of the incoming mail
+
+      - `cc` / `ce-cc`: the `cc` field of the incoming mail
+
     required:
     - connectionHost
     - connectionPort

--- a/library/camel-kamelets/src/main/resources/kamelets/mongodb-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/mongodb-sink.kamelet.yaml
@@ -20,7 +20,7 @@ spec:
 
       Properties you can as headers:
 
-      `db-upsert` / `ce-db-upsert` If the database should create the element if it does not exist. Boolean value.
+      `db-upsert` / `ce-dbupsert` If the database should create the element if it does not exist. Boolean value.
     required:
       - hosts
       - collection
@@ -82,11 +82,11 @@ spec:
             - set-header:
                 name: CamelMongoDbUpsert
                 simple: "${header[db-upsert]}"
-          - simple: "${header[ce-db-upsert]}"
+          - simple: "${header[ce-dbupsert]}"
             steps:
             - set-header:
                 name: CamelMongoDbUpsert
-                simple: "${header[ce-db-upsert]}"
+                simple: "${header[ce-dbupsert]}"
       - to: 
           uri: "{{local-mongodb}}:test"
           parameters:

--- a/library/camel-kamelets/src/main/resources/kamelets/telegram-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/telegram-sink.kamelet.yaml
@@ -27,7 +27,7 @@ spec:
       This following message headers are also supported:
 
       - `text` / `ce-text`: when sending an image, the image caption
-      - `chat-id` / `ce-chat-id`: to override the default chat where messages are sent to
+      - `chat-id` / `ce-chatid`: to override the default chat where messages are sent to
     required:
       - authorizationToken
     type: object
@@ -93,11 +93,11 @@ spec:
             - set-header:
                 name: CamelTelegramChatId
                 simple: "${header[chat-id]}"
-          - simple: "${header[ce-chat-id]}"
+          - simple: "${header[ce-chatid]}"
             steps:
             - set-header:
                 name: CamelTelegramChatId
-                simple: "${header[ce-chat-id]}"
+                simple: "${header[ce-chatid]}"
       - to:
           uri: "telegram:bots"
           parameters:

--- a/library/camel-kamelets/src/main/resources/kamelets/telegram-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/telegram-source.kamelet.yaml
@@ -20,7 +20,7 @@ spec:
 
       The source attaches the following headers to the messages:
 
-      - `chat-id` / `ce-chat-id`: the ID of the chat where the message comes from
+      - `chat-id` / `ce-chatid`: the ID of the chat where the message comes from
 
     required:
       - authorizationToken
@@ -51,7 +51,7 @@ spec:
           name: chat-id
           simple: "${header[CamelTelegramChatId]}"
       - set-header:
-          name: ce-chat-id
+          name: ce-chatid
           simple: "${header[CamelTelegramChatId]}"
       - marshal:
           json: {}

--- a/mail-imap-source.kamelet.yaml
+++ b/mail-imap-source.kamelet.yaml
@@ -15,6 +15,17 @@ spec:
     title: "Mail IMAP Source"
     description: |-
       Receive unread emails from an IMAP mail server, marking them as read once they are received.
+
+      The Kamelet generates the following headers:
+
+      - `subject` / `ce-subject`: the subject of the incoming mail
+
+      - `from` / `ce-from`: the `from` field of the incoming mail
+
+      - `to` / `ce-to`: the `to` field of the incoming mail
+
+      - `cc` / `ce-cc`: the `cc` field of the incoming mail
+
     required:
     - connectionHost
     - connectionPort

--- a/mongodb-sink.kamelet.yaml
+++ b/mongodb-sink.kamelet.yaml
@@ -20,7 +20,7 @@ spec:
 
       Properties you can as headers:
 
-      `db-upsert` / `ce-db-upsert` If the database should create the element if it does not exist. Boolean value.
+      `db-upsert` / `ce-dbupsert` If the database should create the element if it does not exist. Boolean value.
     required:
       - hosts
       - collection
@@ -82,11 +82,11 @@ spec:
             - set-header:
                 name: CamelMongoDbUpsert
                 simple: "${header[db-upsert]}"
-          - simple: "${header[ce-db-upsert]}"
+          - simple: "${header[ce-dbupsert]}"
             steps:
             - set-header:
                 name: CamelMongoDbUpsert
-                simple: "${header[ce-db-upsert]}"
+                simple: "${header[ce-dbupsert]}"
       - to: 
           uri: "{{local-mongodb}}:test"
           parameters:

--- a/telegram-sink.kamelet.yaml
+++ b/telegram-sink.kamelet.yaml
@@ -27,7 +27,7 @@ spec:
       This following message headers are also supported:
 
       - `text` / `ce-text`: when sending an image, the image caption
-      - `chat-id` / `ce-chat-id`: to override the default chat where messages are sent to
+      - `chat-id` / `ce-chatid`: to override the default chat where messages are sent to
     required:
       - authorizationToken
     type: object
@@ -93,11 +93,11 @@ spec:
             - set-header:
                 name: CamelTelegramChatId
                 simple: "${header[chat-id]}"
-          - simple: "${header[ce-chat-id]}"
+          - simple: "${header[ce-chatid]}"
             steps:
             - set-header:
                 name: CamelTelegramChatId
-                simple: "${header[ce-chat-id]}"
+                simple: "${header[ce-chatid]}"
       - to:
           uri: "telegram:bots"
           parameters:

--- a/telegram-source.kamelet.yaml
+++ b/telegram-source.kamelet.yaml
@@ -20,7 +20,7 @@ spec:
 
       The source attaches the following headers to the messages:
 
-      - `chat-id` / `ce-chat-id`: the ID of the chat where the message comes from
+      - `chat-id` / `ce-chatid`: the ID of the chat where the message comes from
 
     required:
       - authorizationToken
@@ -51,7 +51,7 @@ spec:
           name: chat-id
           simple: "${header[CamelTelegramChatId]}"
       - set-header:
-          name: ce-chat-id
+          name: ce-chatid
           simple: "${header[CamelTelegramChatId]}"
       - marshal:
           json: {}


### PR DESCRIPTION
Fix #513

Using dashes or upper case to separate words is not valid according to [cloudevents specs](https://github.com/cloudevents/spec/blob/v1.0.1/spec.md#attribute-naming-convention). It's ugly but we need to stick with it.

I've only renamed the cloudevents headers used by the kamelets, we keep kebab case in other scenarios.