### PR TITLE
Rename bootstrap server properties

### DIFF
--- a/docs/modules/ROOT/pages/kafka-not-secured-sink.adoc
+++ b/docs/modules/ROOT/pages/kafka-not-secured-sink.adoc
@@ -22,7 +22,7 @@ The following table summarizes the configuration options available for the `kafk
 [width="100%",cols="2,^2,3,^2,^2,^3",options="header"]
 |===
 | Property| Name| Description| Type| Default| Example
-| *brokers {empty}* *| Brokers| Comma separated list of Kafka Broker URLs| string| | 
+| *bootstrapServers {empty}* *| Bootstrap Servers| Comma separated list of Kafka Broker URLs| string| | 
 | *topic {empty}* *| Topic Names| Comma separated list of Kafka topic names| string| | 
 |===
 
@@ -63,7 +63,7 @@ spec:
       apiVersion: camel.apache.org/v1alpha1
       name: kafka-not-secured-sink
     properties:
-      brokers: "The Brokers"
+      bootstrapServers: "The Bootstrap Servers"
       topic: "The Topic Names"
   
 ----
@@ -89,7 +89,7 @@ Configure and run the sink by using the following command:
 
 [source,shell]
 ----
-kamel bind channel:mychannel kafka-not-secured-sink -p "sink.brokers=The Brokers" -p "sink.topic=The Topic Names"
+kamel bind channel:mychannel kafka-not-secured-sink -p "sink.bootstrapServers=The Bootstrap Servers" -p "sink.topic=The Topic Names"
 ----
 
 This command creates the KameletBinding in the current namespace on the cluster.
@@ -117,7 +117,7 @@ spec:
       apiVersion: camel.apache.org/v1alpha1
       name: kafka-not-secured-sink
     properties:
-      brokers: "The Brokers"
+      bootstrapServers: "The Bootstrap Servers"
       topic: "The Topic Names"
   
 ----
@@ -145,7 +145,7 @@ Configure and run the sink by using the following command:
 
 [source,shell]
 ----
-kamel bind kafka.strimzi.io/v1beta1:KafkaTopic:my-topic kafka-not-secured-sink -p "sink.brokers=The Brokers" -p "sink.topic=The Topic Names"
+kamel bind kafka.strimzi.io/v1beta1:KafkaTopic:my-topic kafka-not-secured-sink -p "sink.bootstrapServers=The Bootstrap Servers" -p "sink.topic=The Topic Names"
 ----
 
 This command creates the KameletBinding in the current namespace on the cluster.

--- a/docs/modules/ROOT/pages/kafka-not-secured-source.adoc
+++ b/docs/modules/ROOT/pages/kafka-not-secured-source.adoc
@@ -14,7 +14,7 @@ The following table summarizes the configuration options available for the `kafk
 [width="100%",cols="2,^2,3,^2,^2,^3",options="header"]
 |===
 | Property| Name| Description| Type| Default| Example
-| *brokers {empty}* *| Brokers| Comma separated list of Kafka Broker URLs| string| | 
+| *bootstrapServers {empty}* *| Bootstrap Servers| Comma separated list of Kafka Broker URLs| string| | 
 | *topic {empty}* *| Topic Names| Comma separated list of Kafka topic names| string| | 
 | allowManualCommit| Allow Manual Commit| Whether to allow doing manual commits| boolean| `false`| 
 | autoCommitEnable| Auto Commit Enable| If true, periodically commit to ZooKeeper the offset of messages already fetched by the consumer| boolean| `true`| 
@@ -55,7 +55,7 @@ spec:
       apiVersion: camel.apache.org/v1alpha1
       name: kafka-not-secured-source
     properties:
-      brokers: "The Brokers"
+      bootstrapServers: "The Bootstrap Servers"
       topic: "The Topic Names"
   sink:
     ref:
@@ -86,7 +86,7 @@ Configure and run the source by using the following command:
 
 [source,shell]
 ----
-kamel bind kafka-not-secured-source -p "source.brokers=The Brokers" -p "source.topic=The Topic Names" channel:mychannel
+kamel bind kafka-not-secured-source -p "source.bootstrapServers=The Bootstrap Servers" -p "source.topic=The Topic Names" channel:mychannel
 ----
 
 This command creates the KameletBinding in the current namespace on the cluster.
@@ -109,7 +109,7 @@ spec:
       apiVersion: camel.apache.org/v1alpha1
       name: kafka-not-secured-source
     properties:
-      brokers: "The Brokers"
+      bootstrapServers: "The Bootstrap Servers"
       topic: "The Topic Names"
   sink:
     ref:
@@ -142,7 +142,7 @@ Configure and run the source by using the following command:
 
 [source,shell]
 ----
-kamel bind kafka-not-secured-source -p "source.brokers=The Brokers" -p "source.topic=The Topic Names" kafka.strimzi.io/v1beta1:KafkaTopic:my-topic
+kamel bind kafka-not-secured-source -p "source.bootstrapServers=The Bootstrap Servers" -p "source.topic=The Topic Names" kafka.strimzi.io/v1beta1:KafkaTopic:my-topic
 ----
 
 This command creates the KameletBinding in the current namespace on the cluster.

--- a/docs/modules/ROOT/pages/kafka-sink.adoc
+++ b/docs/modules/ROOT/pages/kafka-sink.adoc
@@ -22,7 +22,7 @@ The following table summarizes the configuration options available for the `kafk
 [width="100%",cols="2,^2,3,^2,^2,^3",options="header"]
 |===
 | Property| Name| Description| Type| Default| Example
-| *bootstrapServers {empty}* *| Brokers| Comma separated list of Kafka Broker URLs| string| | 
+| *bootstrapServers {empty}* *| Bootstrap Servers| Comma separated list of Kafka Broker URLs| string| | 
 | *password {empty}* *| Password| Password to authenticate to kafka| string| | 
 | *topic {empty}* *| Topic Names| Comma separated list of Kafka topic names| string| | 
 | *user {empty}* *| Username| Username to authenticate to Kafka| string| | 
@@ -67,7 +67,7 @@ spec:
       apiVersion: camel.apache.org/v1alpha1
       name: kafka-sink
     properties:
-      bootstrapServers: "The Brokers"
+      bootstrapServers: "The Bootstrap Servers"
       password: "The Password"
       topic: "The Topic Names"
       user: "The Username"
@@ -95,7 +95,7 @@ Configure and run the sink by using the following command:
 
 [source,shell]
 ----
-kamel bind channel:mychannel kafka-sink -p "sink.bootstrapServers=The Brokers" -p "sink.password=The Password" -p "sink.topic=The Topic Names" -p "sink.user=The Username"
+kamel bind channel:mychannel kafka-sink -p "sink.bootstrapServers=The Bootstrap Servers" -p "sink.password=The Password" -p "sink.topic=The Topic Names" -p "sink.user=The Username"
 ----
 
 This command creates the KameletBinding in the current namespace on the cluster.
@@ -123,7 +123,7 @@ spec:
       apiVersion: camel.apache.org/v1alpha1
       name: kafka-sink
     properties:
-      bootstrapServers: "The Brokers"
+      bootstrapServers: "The Bootstrap Servers"
       password: "The Password"
       topic: "The Topic Names"
       user: "The Username"
@@ -153,7 +153,7 @@ Configure and run the sink by using the following command:
 
 [source,shell]
 ----
-kamel bind kafka.strimzi.io/v1beta1:KafkaTopic:my-topic kafka-sink -p "sink.bootstrapServers=The Brokers" -p "sink.password=The Password" -p "sink.topic=The Topic Names" -p "sink.user=The Username"
+kamel bind kafka.strimzi.io/v1beta1:KafkaTopic:my-topic kafka-sink -p "sink.bootstrapServers=The Bootstrap Servers" -p "sink.password=The Password" -p "sink.topic=The Topic Names" -p "sink.user=The Username"
 ----
 
 This command creates the KameletBinding in the current namespace on the cluster.

--- a/docs/modules/ROOT/pages/kafka-source.adoc
+++ b/docs/modules/ROOT/pages/kafka-source.adoc
@@ -14,7 +14,7 @@ The following table summarizes the configuration options available for the `kafk
 [width="100%",cols="2,^2,3,^2,^2,^3",options="header"]
 |===
 | Property| Name| Description| Type| Default| Example
-| *bootstrapServers {empty}* *| Brokers| Comma separated list of Kafka Broker URLs| string| | 
+| *bootstrapServers {empty}* *| Bootstrap Servers| Comma separated list of Kafka Broker URLs| string| | 
 | *password {empty}* *| Password| Password to authenticate to kafka| string| | 
 | *topic {empty}* *| Topic Names| Comma separated list of Kafka topic names| string| | 
 | *user {empty}* *| Username| Username to authenticate to Kafka| string| | 
@@ -59,7 +59,7 @@ spec:
       apiVersion: camel.apache.org/v1alpha1
       name: kafka-source
     properties:
-      bootstrapServers: "The Brokers"
+      bootstrapServers: "The Bootstrap Servers"
       password: "The Password"
       topic: "The Topic Names"
       user: "The Username"
@@ -92,7 +92,7 @@ Configure and run the source by using the following command:
 
 [source,shell]
 ----
-kamel bind kafka-source -p "source.bootstrapServers=The Brokers" -p "source.password=The Password" -p "source.topic=The Topic Names" -p "source.user=The Username" channel:mychannel
+kamel bind kafka-source -p "source.bootstrapServers=The Bootstrap Servers" -p "source.password=The Password" -p "source.topic=The Topic Names" -p "source.user=The Username" channel:mychannel
 ----
 
 This command creates the KameletBinding in the current namespace on the cluster.
@@ -115,7 +115,7 @@ spec:
       apiVersion: camel.apache.org/v1alpha1
       name: kafka-source
     properties:
-      bootstrapServers: "The Brokers"
+      bootstrapServers: "The Bootstrap Servers"
       password: "The Password"
       topic: "The Topic Names"
       user: "The Username"
@@ -150,7 +150,7 @@ Configure and run the source by using the following command:
 
 [source,shell]
 ----
-kamel bind kafka-source -p "source.bootstrapServers=The Brokers" -p "source.password=The Password" -p "source.topic=The Topic Names" -p "source.user=The Username" kafka.strimzi.io/v1beta1:KafkaTopic:my-topic
+kamel bind kafka-source -p "source.bootstrapServers=The Bootstrap Servers" -p "source.password=The Password" -p "source.topic=The Topic Names" -p "source.user=The Username" kafka.strimzi.io/v1beta1:KafkaTopic:my-topic
 ----
 
 This command creates the KameletBinding in the current namespace on the cluster.

--- a/kamelets/kafka-not-secured-sink.kamelet.yaml
+++ b/kamelets/kafka-not-secured-sink.kamelet.yaml
@@ -41,15 +41,15 @@ spec:
       Both the headers are optional.
     required:
       - topic
-      - brokers
+      - bootstrapServers
     type: object
     properties:
       topic:
         title: Topic Names
         description: Comma separated list of Kafka topic names
         type: string
-      brokers:
-        title: Brokers
+      bootstrapServers:
+        title: Bootstrap Servers
         description: Comma separated list of Kafka Broker URLs
         type: string
   dependencies:
@@ -86,4 +86,4 @@ spec:
       - to:
           uri: "kafka:{{topic}}"
           parameters:
-            brokers: "{{brokers}}"
+            brokers: "{{bootstrapServers}}"

--- a/kamelets/kafka-not-secured-source.kamelet.yaml
+++ b/kamelets/kafka-not-secured-source.kamelet.yaml
@@ -33,15 +33,15 @@ spec:
       Receive data from Kafka topics on an insecure broker.
     required:
       - topic
-      - brokers
+      - bootstrapServers
     type: object
     properties:
       topic:
         title: Topic Names
         description: Comma separated list of Kafka topic names
         type: string
-      brokers:
-        title: Brokers
+      bootstrapServers:
+        title: Bootstrap Servers
         description: Comma separated list of Kafka Broker URLs
         type: string
       autoCommitEnable:
@@ -80,7 +80,7 @@ spec:
     from:
       uri: "kafka:{{topic}}"
       parameters:
-        brokers: "{{brokers}}"
+        brokers: "{{bootstrapServers}}"
         autoCommitEnable: "{{autoCommitEnable}}"
         allowManualCommit: "{{allowManualCommit}}"
         pollOnError: "{{pollOnError}}"

--- a/kamelets/kafka-sink.kamelet.yaml
+++ b/kamelets/kafka-sink.kamelet.yaml
@@ -51,7 +51,7 @@ spec:
         description: Comma separated list of Kafka topic names
         type: string
       bootstrapServers:
-        title: Brokers
+        title: Bootstrap Servers
         description: Comma separated list of Kafka Broker URLs
         type: string
       securityProtocol:

--- a/kamelets/kafka-source.kamelet.yaml
+++ b/kamelets/kafka-source.kamelet.yaml
@@ -43,7 +43,7 @@ spec:
         description: Comma separated list of Kafka topic names
         type: string
       bootstrapServers:
-        title: Brokers
+        title: Bootstrap Servers
         description: Comma separated list of Kafka Broker URLs
         type: string
       securityProtocol:

--- a/library/camel-kamelets/src/main/resources/kamelets/kafka-not-secured-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/kafka-not-secured-sink.kamelet.yaml
@@ -41,15 +41,15 @@ spec:
       Both the headers are optional.
     required:
       - topic
-      - brokers
+      - bootstrapServers
     type: object
     properties:
       topic:
         title: Topic Names
         description: Comma separated list of Kafka topic names
         type: string
-      brokers:
-        title: Brokers
+      bootstrapServers:
+        title: Bootstrap Servers
         description: Comma separated list of Kafka Broker URLs
         type: string
   dependencies:
@@ -86,4 +86,4 @@ spec:
       - to:
           uri: "kafka:{{topic}}"
           parameters:
-            brokers: "{{brokers}}"
+            brokers: "{{bootstrapServers}}"

--- a/library/camel-kamelets/src/main/resources/kamelets/kafka-not-secured-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/kafka-not-secured-source.kamelet.yaml
@@ -33,15 +33,15 @@ spec:
       Receive data from Kafka topics on an insecure broker.
     required:
       - topic
-      - brokers
+      - bootstrapServers
     type: object
     properties:
       topic:
         title: Topic Names
         description: Comma separated list of Kafka topic names
         type: string
-      brokers:
-        title: Brokers
+      bootstrapServers:
+        title: Bootstrap Servers
         description: Comma separated list of Kafka Broker URLs
         type: string
       autoCommitEnable:
@@ -80,7 +80,7 @@ spec:
     from:
       uri: "kafka:{{topic}}"
       parameters:
-        brokers: "{{brokers}}"
+        brokers: "{{bootstrapServers}}"
         autoCommitEnable: "{{autoCommitEnable}}"
         allowManualCommit: "{{allowManualCommit}}"
         pollOnError: "{{pollOnError}}"

--- a/library/camel-kamelets/src/main/resources/kamelets/kafka-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/kafka-sink.kamelet.yaml
@@ -51,7 +51,7 @@ spec:
         description: Comma separated list of Kafka topic names
         type: string
       bootstrapServers:
-        title: Brokers
+        title: Bootstrap Servers
         description: Comma separated list of Kafka Broker URLs
         type: string
       securityProtocol:

--- a/library/camel-kamelets/src/main/resources/kamelets/kafka-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/kafka-source.kamelet.yaml
@@ -43,7 +43,7 @@ spec:
         description: Comma separated list of Kafka topic names
         type: string
       bootstrapServers:
-        title: Brokers
+        title: Bootstrap Servers
         description: Comma separated list of Kafka Broker URLs
         type: string
       securityProtocol:

--- a/templates/bindings/camel-k/kafka-not-secured-sink-binding.yaml
+++ b/templates/bindings/camel-k/kafka-not-secured-sink-binding.yaml
@@ -14,6 +14,6 @@ spec:
       apiVersion: camel.apache.org/v1alpha1
       name: kafka-not-secured-sink
     properties:
-      brokers: "The Brokers"
+      bootstrapServers: "The Bootstrap Servers"
       topic: "The Topic Names"
   

--- a/templates/bindings/camel-k/kafka-not-secured-source-binding.yaml
+++ b/templates/bindings/camel-k/kafka-not-secured-source-binding.yaml
@@ -9,7 +9,7 @@ spec:
       apiVersion: camel.apache.org/v1alpha1
       name: kafka-not-secured-source
     properties:
-      brokers: "The Brokers"
+      bootstrapServers: "The Bootstrap Servers"
       topic: "The Topic Names"
   sink:
     ref:

--- a/templates/bindings/camel-k/kafka-sink-binding.yaml
+++ b/templates/bindings/camel-k/kafka-sink-binding.yaml
@@ -14,7 +14,7 @@ spec:
       apiVersion: camel.apache.org/v1alpha1
       name: kafka-sink
     properties:
-      bootstrapServers: "The Brokers"
+      bootstrapServers: "The Bootstrap Servers"
       password: "The Password"
       topic: "The Topic Names"
       user: "The Username"

--- a/templates/bindings/camel-k/kafka-source-binding.yaml
+++ b/templates/bindings/camel-k/kafka-source-binding.yaml
@@ -9,7 +9,7 @@ spec:
       apiVersion: camel.apache.org/v1alpha1
       name: kafka-source
     properties:
-      bootstrapServers: "The Brokers"
+      bootstrapServers: "The Bootstrap Servers"
       password: "The Password"
       topic: "The Topic Names"
       user: "The Username"

--- a/templates/bindings/core/kafka-not-secured-sink-binding.yaml
+++ b/templates/bindings/core/kafka-not-secured-sink-binding.yaml
@@ -8,6 +8,6 @@
       - to:
           uri: "kamelet:kafka-not-secured-sink"
           parameters:
-            brokers: "The Brokers"
+            bootstrapServers: "The Bootstrap Servers"
             topic: "The Topic Names"
     

--- a/templates/bindings/core/kafka-not-secured-source-binding.yaml
+++ b/templates/bindings/core/kafka-not-secured-source-binding.yaml
@@ -2,7 +2,7 @@
     from:
       uri: "kamelet:kafka-not-secured-source"
       parameters:
-        brokers: "The Brokers"
+        bootstrapServers: "The Bootstrap Servers"
         topic: "The Topic Names"
     steps:
       - to:

--- a/templates/bindings/core/kafka-sink-binding.yaml
+++ b/templates/bindings/core/kafka-sink-binding.yaml
@@ -8,7 +8,7 @@
       - to:
           uri: "kamelet:kafka-sink"
           parameters:
-            bootstrapServers: "The Brokers"
+            bootstrapServers: "The Bootstrap Servers"
             password: "The Password"
             topic: "The Topic Names"
             user: "The Username"

--- a/templates/bindings/core/kafka-source-binding.yaml
+++ b/templates/bindings/core/kafka-source-binding.yaml
@@ -2,7 +2,7 @@
     from:
       uri: "kamelet:kafka-source"
       parameters:
-        bootstrapServers: "The Brokers"
+        bootstrapServers: "The Bootstrap Servers"
         password: "The Password"
         topic: "The Topic Names"
         user: "The Username"


### PR DESCRIPTION
This aligns the not-secured Kafka Kamelets to the standard ones and fixes some documentation.