### PR TITLE
fix #635: cassandra sink and source kamelets problems

### DIFF
--- a/docs/modules/ROOT/pages/cassandra-sink.adoc
+++ b/docs/modules/ROOT/pages/cassandra-sink.adoc
@@ -19,10 +19,11 @@ The following table summarizes the configuration options available for the `cass
 | *connectionHost {empty}* *| Connection Host| Hostname(s) cassandra server(s). Multiple hosts can be separated by comma.| string| | `"localhost"`
 | *connectionPort {empty}* *| Connection Port| Port number of cassandra server(s)| string| | `9042`
 | *keyspace {empty}* *| Keyspace| Keyspace to use| string| | `"customers"`
-| *password {empty}* *| Password| The password to use for accessing a secured Cassandra Cluster| string| | 
-| *preparedStatement {empty}* *| Prepared Statement| The Prepared statement to execute against the Cassandra cluster table| string| | 
-| *username {empty}* *| Username| The username to use for accessing a secured Cassandra Cluster| string| | 
+| *query {empty}* *| Query| The query to execute against the Cassandra cluster table| string| | 
 | consistencyLevel| Consistency Level| Consistency level to use. The value can be one of ANY, ONE, TWO, THREE, QUORUM, ALL, LOCAL_QUORUM, EACH_QUORUM, SERIAL, LOCAL_SERIAL, LOCAL_ONE| string| `"ANY"`| 
+| password| Password| The password to use for accessing a secured Cassandra Cluster| string| | 
+| preparedStatement| Prepared Statement| Whether to use PreparedStatements or regular Statements as the query.| boolean| `true`| 
+| username| Username| The username to use for accessing a secured Cassandra Cluster| string| | 
 |===
 
 NOTE: Fields marked with an asterisk ({empty}*) are mandatory.
@@ -66,9 +67,7 @@ spec:
       connectionHost: "localhost"
       connectionPort: 9042
       keyspace: "customers"
-      password: "The Password"
-      preparedStatement: "The Prepared Statement"
-      username: "The Username"
+      query: "The Query"
   
 ----
 
@@ -93,7 +92,7 @@ Configure and run the sink by using the following command:
 
 [source,shell]
 ----
-kamel bind channel:mychannel cassandra-sink -p "sink.connectionHost=localhost" -p sink.connectionPort=9042 -p "sink.keyspace=customers" -p "sink.password=The Password" -p "sink.preparedStatement=The Prepared Statement" -p "sink.username=The Username"
+kamel bind channel:mychannel cassandra-sink -p "sink.connectionHost=localhost" -p sink.connectionPort=9042 -p "sink.keyspace=customers" -p "sink.query=The Query"
 ----
 
 This command creates the KameletBinding in the current namespace on the cluster.
@@ -124,9 +123,7 @@ spec:
       connectionHost: "localhost"
       connectionPort: 9042
       keyspace: "customers"
-      password: "The Password"
-      preparedStatement: "The Prepared Statement"
-      username: "The Username"
+      query: "The Query"
   
 ----
 
@@ -153,7 +150,7 @@ Configure and run the sink by using the following command:
 
 [source,shell]
 ----
-kamel bind kafka.strimzi.io/v1beta1:KafkaTopic:my-topic cassandra-sink -p "sink.connectionHost=localhost" -p sink.connectionPort=9042 -p "sink.keyspace=customers" -p "sink.password=The Password" -p "sink.preparedStatement=The Prepared Statement" -p "sink.username=The Username"
+kamel bind kafka.strimzi.io/v1beta1:KafkaTopic:my-topic cassandra-sink -p "sink.connectionHost=localhost" -p sink.connectionPort=9042 -p "sink.keyspace=customers" -p "sink.query=The Query"
 ----
 
 This command creates the KameletBinding in the current namespace on the cluster.

--- a/docs/modules/ROOT/pages/cassandra-source.adoc
+++ b/docs/modules/ROOT/pages/cassandra-source.adoc
@@ -17,11 +17,11 @@ The following table summarizes the configuration options available for the `cass
 | *connectionHost {empty}* *| Connection Host| Hostname(s) cassandra server(s). Multiple hosts can be separated by comma.| string| | `"localhost"`
 | *connectionPort {empty}* *| Connection Port| Port number of cassandra server(s)| string| | `9042`
 | *keyspace {empty}* *| Keyspace| Keyspace to use| string| | `"customers"`
-| *password {empty}* *| Password| The password to use for accessing a secured Cassandra Cluster| string| | 
 | *query {empty}* *| Query| The query to execute against the Cassandra cluster table| string| | 
-| *username {empty}* *| Username| The username to use for accessing a secured Cassandra Cluster| string| | 
 | consistencyLevel| Consistency Level| Consistency level to use. The value can be one of ANY, ONE, TWO, THREE, QUORUM, ALL, LOCAL_QUORUM, EACH_QUORUM, SERIAL, LOCAL_SERIAL, LOCAL_ONE| string| `"ANY"`| 
+| password| Password| The password to use for accessing a secured Cassandra Cluster| string| | 
 | resultStrategy| Result Strategy| The strategy to convert the result set of the query. Possible values are ALL, ONE, LIMIT_10, LIMIT_100...| string| `"ALL"`| 
+| username| Username| The username to use for accessing a secured Cassandra Cluster| string| | 
 |===
 
 NOTE: Fields marked with an asterisk ({empty}*) are mandatory.
@@ -60,9 +60,7 @@ spec:
       connectionHost: "localhost"
       connectionPort: 9042
       keyspace: "customers"
-      password: "The Password"
       query: "The Query"
-      username: "The Username"
   sink:
     ref:
       kind: Channel
@@ -92,7 +90,7 @@ Configure and run the source by using the following command:
 
 [source,shell]
 ----
-kamel bind cassandra-source -p "source.connectionHost=localhost" -p source.connectionPort=9042 -p "source.keyspace=customers" -p "source.password=The Password" -p "source.query=The Query" -p "source.username=The Username" channel:mychannel
+kamel bind cassandra-source -p "source.connectionHost=localhost" -p source.connectionPort=9042 -p "source.keyspace=customers" -p "source.query=The Query" channel:mychannel
 ----
 
 This command creates the KameletBinding in the current namespace on the cluster.
@@ -118,9 +116,7 @@ spec:
       connectionHost: "localhost"
       connectionPort: 9042
       keyspace: "customers"
-      password: "The Password"
       query: "The Query"
-      username: "The Username"
   sink:
     ref:
       kind: KafkaTopic
@@ -152,7 +148,7 @@ Configure and run the source by using the following command:
 
 [source,shell]
 ----
-kamel bind cassandra-source -p "source.connectionHost=localhost" -p source.connectionPort=9042 -p "source.keyspace=customers" -p "source.password=The Password" -p "source.query=The Query" -p "source.username=The Username" kafka.strimzi.io/v1beta1:KafkaTopic:my-topic
+kamel bind cassandra-source -p "source.connectionHost=localhost" -p source.connectionPort=9042 -p "source.keyspace=customers" -p "source.query=The Query" kafka.strimzi.io/v1beta1:KafkaTopic:my-topic
 ----
 
 This command creates the KameletBinding in the current namespace on the cluster.

--- a/kamelets/cassandra-sink.kamelet.yaml
+++ b/kamelets/cassandra-sink.kamelet.yaml
@@ -37,9 +37,7 @@ spec:
       - connectionHost
       - connectionPort
       - keyspace
-      - username
-      - password
-      - preparedStatement
+      - query
     type: object
     properties:
       connectionHost:
@@ -78,7 +76,14 @@ spec:
         default: ANY
       preparedStatement:
         title: Prepared Statement
-        description: The Prepared statement to execute against the Cassandra cluster table
+        description: Whether to use PreparedStatements or regular Statements as the query.
+        type: boolean
+        default: true
+        x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:checkbox
+      query:
+        title: Query
+        description: The query to execute against the Cassandra cluster table
         type: string
   types:
     in:
@@ -98,7 +103,8 @@ spec:
       - to: 
           uri: "cql://{{connectionHost}}:{{connectionPort}}/{{keyspace}}"
           parameters:
-            username: "{{username}}"
-            password: "{{password}}"
+            username: "{{?username}}"
+            password: "{{?password}}"
             preparedStatement: "{{preparedStatement}}"
             consistencyLevel: "{{consistencyLevel}}"
+            cql: "{{query}}"

--- a/kamelets/cassandra-source.kamelet.yaml
+++ b/kamelets/cassandra-source.kamelet.yaml
@@ -35,8 +35,6 @@ spec:
       - connectionHost
       - connectionPort
       - keyspace
-      - username
-      - password
       - query
     type: object
     properties:
@@ -94,8 +92,8 @@ spec:
     from:
       uri: "cql://{{connectionHost}}:{{connectionPort}}/{{keyspace}}"
       parameters:
-        username: "{{username}}"
-        password: "{{password}}"
+        username: "{{?username}}"
+        password: "{{?password}}"
         cql: "{{query}}"
         consistencyLevel: "{{consistencyLevel}}"
         resultSetConversionStrategy: "{{resultStrategy}}"

--- a/library/camel-kamelets/src/main/resources/kamelets/cassandra-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/cassandra-sink.kamelet.yaml
@@ -37,9 +37,7 @@ spec:
       - connectionHost
       - connectionPort
       - keyspace
-      - username
-      - password
-      - preparedStatement
+      - query
     type: object
     properties:
       connectionHost:
@@ -78,7 +76,12 @@ spec:
         default: ANY
       preparedStatement:
         title: Prepared Statement
-        description: The Prepared statement to execute against the Cassandra cluster table
+        description: Whether to use PreparedStatements or regular Statements as the query.
+        type: boolean
+        default: true
+      query:
+        title: Query
+        description: The query to execute against the Cassandra cluster table
         type: string
   types:
     in:
@@ -98,7 +101,8 @@ spec:
       - to: 
           uri: "cql://{{connectionHost}}:{{connectionPort}}/{{keyspace}}"
           parameters:
-            username: "{{username}}"
-            password: "{{password}}"
+            username: "{{?username}}"
+            password: "{{?password}}"
             preparedStatement: "{{preparedStatement}}"
             consistencyLevel: "{{consistencyLevel}}"
+            cql: "{{query}}"

--- a/library/camel-kamelets/src/main/resources/kamelets/cassandra-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/cassandra-source.kamelet.yaml
@@ -35,8 +35,6 @@ spec:
       - connectionHost
       - connectionPort
       - keyspace
-      - username
-      - password
       - query
     type: object
     properties:
@@ -94,8 +92,8 @@ spec:
     from:
       uri: "cql://{{connectionHost}}:{{connectionPort}}/{{keyspace}}"
       parameters:
-        username: "{{username}}"
-        password: "{{password}}"
+        username: "{{?username}}"
+        password: "{{?password}}"
         cql: "{{query}}"
         consistencyLevel: "{{consistencyLevel}}"
         resultSetConversionStrategy: "{{resultStrategy}}"

--- a/templates/bindings/camel-k/cassandra-sink-binding.yaml
+++ b/templates/bindings/camel-k/cassandra-sink-binding.yaml
@@ -17,7 +17,5 @@ spec:
       connectionHost: "localhost"
       connectionPort: 9042
       keyspace: "customers"
-      password: "The Password"
-      preparedStatement: "The Prepared Statement"
-      username: "The Username"
+      query: "The Query"
   

--- a/templates/bindings/camel-k/cassandra-source-binding.yaml
+++ b/templates/bindings/camel-k/cassandra-source-binding.yaml
@@ -12,9 +12,7 @@ spec:
       connectionHost: "localhost"
       connectionPort: 9042
       keyspace: "customers"
-      password: "The Password"
       query: "The Query"
-      username: "The Username"
   sink:
     ref:
       kind: KafkaTopic

--- a/templates/bindings/core/cassandra-sink-binding.yaml
+++ b/templates/bindings/core/cassandra-sink-binding.yaml
@@ -11,7 +11,5 @@
             connectionHost: "localhost"
             connectionPort: 9042
             keyspace: "customers"
-            password: "The Password"
-            preparedStatement: "The Prepared Statement"
-            username: "The Username"
+            query: "The Query"
     

--- a/templates/bindings/core/cassandra-source-binding.yaml
+++ b/templates/bindings/core/cassandra-source-binding.yaml
@@ -5,9 +5,7 @@
         connectionHost: "localhost"
         connectionPort: 9042
         keyspace: "customers"
-        password: "The Password"
         query: "The Query"
-        username: "The Username"
     steps:
       - to:
           uri: "log:info"


### PR DESCRIPTION
    cassandra-sink:
        there is no cql parameter defined
        username and password must be optional
        preparedStatement was of a wrong type (string but it is actually boolean)

    cassandra-source:
        username and password must be optional