### PR TITLE
Update Log4j to 2.17.1 to address CVE-2021-44832

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
 
         <camel.version>3.14.0</camel.version>
         <slf4j.version>1.7.30</slf4j.version>
-        <log4j.version>2.17.0</log4j.version>
+        <log4j.version>2.17.1</log4j.version>
         <jackson.version>2.12.5</jackson.version>
         <camel.k.extension.version>5.11.0</camel.k.extension.version>
         <commons.io.version>2.11.0</commons.io.version>


### PR DESCRIPTION
Updating Log4j version to 2.17.1 because of CVE-2021-44832 vulnerability.
https://nvd.nist.gov/vuln/detail/CVE-2021-44832