### PR TITLE
Slack source improvements

### DIFF
--- a/kamelets/slack-source.kamelet.yaml
+++ b/kamelets/slack-source.kamelet.yaml
@@ -49,6 +49,12 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
+      delay:
+        title: Delay
+        description: The delay between polls
+        type: string
+        example: "1s"
+        delay: "{{?delay}}"
   types:
     out:
       mediaType: application/json
@@ -61,6 +67,7 @@ spec:
       uri: "slack:{{channel}}"
       parameters:
         token: "{{token}}"
+        delay: "{{?delay}}"
       steps:
       - marshal:
           json: {}

--- a/kamelets/slack-source.kamelet.yaml
+++ b/kamelets/slack-source.kamelet.yaml
@@ -59,7 +59,7 @@ spec:
     out:
       mediaType: application/json
   dependencies:
-  - "camel:jackson"
+  - "camel:gson"
   - "camel:slack"
   - "camel:kamelet"
   flow:
@@ -70,5 +70,6 @@ spec:
         delay: "{{?delay}}"
       steps:
       - marshal:
-          json: {}
+          json:
+            library: "Gson"
       - to: "kamelet:sink"


### PR DESCRIPTION
- slack source: add an additional property to control the delay between polls (useful to prevent API throttling)
- slack source: use Gson as json serialization library instead of Jackson as Slack's model rely on Gson annotations
