### PR TITLE
chore: move deprecated flow to template

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ spec:
   types:
     out:
       mediaType: text/plain
-  flow:
+  template:
     from:
       uri: timer:tick
       parameters:
@@ -128,7 +128,7 @@ spec:
   - camel:telegram
   - mvn:org.apache.commons:commons-vfs2:2.7.0
   - github:apache/camel-kamelets
-  flow:
+  template:
     # ...
 ```
 

--- a/kamelets/avro-deserialize-action.kamelet.yaml
+++ b/kamelets/avro-deserialize-action.kamelet.yaml
@@ -52,7 +52,7 @@ spec:
   - "camel:kamelet"
   - "camel:core"
   - "camel:jackson-avro"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/kamelets/avro-serialize-action.kamelet.yaml
+++ b/kamelets/avro-serialize-action.kamelet.yaml
@@ -52,7 +52,7 @@ spec:
   - "camel:kamelet"
   - "camel:core"
   - "camel:jackson-avro"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/kamelets/aws-cloudwatch-sink.kamelet.yaml
+++ b/kamelets/aws-cloudwatch-sink.kamelet.yaml
@@ -88,7 +88,7 @@ spec:
   dependencies:
     - "camel:aws2-cw"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/kamelets/aws-ddb-streams-source.kamelet.yaml
+++ b/kamelets/aws-ddb-streams-source.kamelet.yaml
@@ -82,7 +82,7 @@ spec:
   - "camel:gson"
   - "camel:aws2-ddb"
   - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "aws2-ddbstream:{{table}}"
       parameters:

--- a/kamelets/aws-ec2-sink.kamelet.yaml
+++ b/kamelets/aws-ec2-sink.kamelet.yaml
@@ -66,7 +66,7 @@ spec:
   dependencies:
     - "camel:aws2-ec2"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/kamelets/aws-kinesis-firehose-sink.kamelet.yaml
+++ b/kamelets/aws-kinesis-firehose-sink.kamelet.yaml
@@ -67,7 +67,7 @@ spec:
   dependencies:
     - "camel:aws2-kinesis"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/kamelets/aws-kinesis-sink.kamelet.yaml
+++ b/kamelets/aws-kinesis-sink.kamelet.yaml
@@ -79,7 +79,7 @@ spec:
   dependencies:
     - "camel:aws2-kinesis"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/kamelets/aws-kinesis-source.kamelet.yaml
+++ b/kamelets/aws-kinesis-source.kamelet.yaml
@@ -71,7 +71,7 @@ spec:
     - "camel:aws2-kinesis"
     - "camel:kamelet"
     - "camel:gson"
-  flow:
+  template:
     from:
       uri: aws2-kinesis:{{stream}}
       parameters:

--- a/kamelets/aws-lambda-sink.kamelet.yaml
+++ b/kamelets/aws-lambda-sink.kamelet.yaml
@@ -67,7 +67,7 @@ spec:
   dependencies:
     - "camel:aws2-lambda"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/kamelets/aws-redshift-sink.kamelet.yaml
+++ b/kamelets/aws-redshift-sink.kamelet.yaml
@@ -89,7 +89,7 @@ spec:
   - "camel:sql"
   - "mvn:com.amazon.redshift:redshift-jdbc42:2.1.0.3"
   - "mvn:org.apache.commons:commons-dbcp2:2.9.0"
-  flow:
+  template:
     beans:
       - name: dsBean
         type: "#class:org.apache.commons.dbcp2.BasicDataSource"

--- a/kamelets/aws-redshift-source.kamelet.yaml
+++ b/kamelets/aws-redshift-source.kamelet.yaml
@@ -86,7 +86,7 @@ spec:
   - "camel:sql"
   - "mvn:com.amazon.redshift:redshift-jdbc42:2.1.0.3"
   - "mvn:org.apache.commons:commons-dbcp2:2.9.0"
-  flow:
+  template:
     beans:
       - name: dsBean
         type: "#class:org.apache.commons.dbcp2.BasicDataSource"

--- a/kamelets/aws-s3-sink.kamelet.yaml
+++ b/kamelets/aws-s3-sink.kamelet.yaml
@@ -89,7 +89,7 @@ spec:
   dependencies:
     - "camel:aws2-s3"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "kamelet:source"
       steps:

--- a/kamelets/aws-s3-source.kamelet.yaml
+++ b/kamelets/aws-s3-source.kamelet.yaml
@@ -92,7 +92,7 @@ spec:
   dependencies:
     - "camel:aws2-s3"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "aws2-s3:{{bucketNameOrArn}}"
       parameters:

--- a/kamelets/aws-s3-streaming-upload-sink.kamelet.yaml
+++ b/kamelets/aws-s3-streaming-upload-sink.kamelet.yaml
@@ -110,7 +110,7 @@ spec:
   dependencies:
     - "camel:aws2-s3"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "kamelet:source"
       steps:

--- a/kamelets/aws-secrets-manager-sink.kamelet.yaml
+++ b/kamelets/aws-secrets-manager-sink.kamelet.yaml
@@ -68,7 +68,7 @@ spec:
   dependencies:
     - "camel:aws-secrets-manager"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "kamelet:source"
       steps:

--- a/kamelets/aws-ses-sink.kamelet.yaml
+++ b/kamelets/aws-ses-sink.kamelet.yaml
@@ -79,7 +79,7 @@ spec:
   dependencies:
     - "camel:aws2-ses"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "kamelet:source"
       steps:

--- a/kamelets/aws-sns-fifo-sink.kamelet.yaml
+++ b/kamelets/aws-sns-fifo-sink.kamelet.yaml
@@ -86,7 +86,7 @@ spec:
   - "camel:aws2-sns"
   - "camel:core"
   - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/kamelets/aws-sns-sink.kamelet.yaml
+++ b/kamelets/aws-sns-sink.kamelet.yaml
@@ -78,7 +78,7 @@ spec:
   dependencies:
     - "camel:aws2-sns"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/kamelets/aws-sqs-batch-sink.kamelet.yaml
+++ b/kamelets/aws-sqs-batch-sink.kamelet.yaml
@@ -90,7 +90,7 @@ spec:
   dependencies:
     - "camel:aws2-sqs"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/kamelets/aws-sqs-fifo-sink.kamelet.yaml
+++ b/kamelets/aws-sqs-fifo-sink.kamelet.yaml
@@ -91,7 +91,7 @@ spec:
   - "camel:aws2-sqs"
   - "camel:core"
   - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/kamelets/aws-sqs-sink.kamelet.yaml
+++ b/kamelets/aws-sqs-sink.kamelet.yaml
@@ -84,7 +84,7 @@ spec:
   dependencies:
     - "camel:aws2-sqs"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/kamelets/aws-sqs-source.kamelet.yaml
+++ b/kamelets/aws-sqs-source.kamelet.yaml
@@ -106,7 +106,7 @@ spec:
   dependencies:
     - "camel:aws2-sqs"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "aws2-sqs:{{queueNameOrArn}}"
       parameters:

--- a/kamelets/aws-translate-action.kamelet.yaml
+++ b/kamelets/aws-translate-action.kamelet.yaml
@@ -75,7 +75,7 @@ spec:
     - "camel:dns"
     - "camel:kamelet"
     - "camel:aws2-translate"
-  flow:
+  template:
     from:
       uri: "kamelet:source"
       steps:

--- a/kamelets/azure-cosmosdb-source.kamelet.yaml
+++ b/kamelets/azure-cosmosdb-source.kamelet.yaml
@@ -88,7 +88,7 @@ spec:
     - "camel:azure-cosmosdb"
     - "camel:kamelet"
     - "camel:jackson"
-  flow:
+  template:
     from:
       uri: "azure-cosmosdb:{{databaseName}}/{{containerName}}"
       parameters:

--- a/kamelets/azure-eventhubs-sink.kamelet.yaml
+++ b/kamelets/azure-eventhubs-sink.kamelet.yaml
@@ -75,7 +75,7 @@ spec:
   - "mvn:com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.11.3"
   - "camel:azure-eventhubs"
   - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "kamelet:source"
       steps:

--- a/kamelets/azure-eventhubs-source.kamelet.yaml
+++ b/kamelets/azure-eventhubs-source.kamelet.yaml
@@ -92,7 +92,7 @@ spec:
   - "camel:azure-eventhubs"
   - "camel:kamelet"
   - "camel:jackson"
-  flow:
+  template:
     from:
       uri: 'azure-eventhubs://{{namespaceName}}/{{eventhubName}}'
       parameters:

--- a/kamelets/azure-storage-blob-sink.kamelet.yaml
+++ b/kamelets/azure-storage-blob-sink.kamelet.yaml
@@ -70,7 +70,7 @@ spec:
   dependencies:
   - "camel:azure-storage-blob"
   - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "kamelet:source"
       steps:

--- a/kamelets/azure-storage-blob-source.kamelet.yaml
+++ b/kamelets/azure-storage-blob-source.kamelet.yaml
@@ -68,7 +68,7 @@ spec:
     - "camel:core"
     - "camel:jsonpath"
     - "camel:timer"
-  flow:
+  template:
     from:
       uri: "timer:azure-storage-blob-stream"
       parameters:

--- a/kamelets/azure-storage-queue-sink.kamelet.yaml
+++ b/kamelets/azure-storage-queue-sink.kamelet.yaml
@@ -67,7 +67,7 @@ spec:
   dependencies:
     - "camel:azure-storage-queue"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "kamelet:source"
       steps:

--- a/kamelets/azure-storage-queue-source.kamelet.yaml
+++ b/kamelets/azure-storage-queue-source.kamelet.yaml
@@ -64,7 +64,7 @@ spec:
   dependencies:
     - "camel:azure-storage-queue"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "azure-storage-queue://{{accountName}}/{{queueName}}"
       parameters:

--- a/kamelets/bitcoin-source.kamelet.yaml
+++ b/kamelets/bitcoin-source.kamelet.yaml
@@ -73,7 +73,7 @@ spec:
     - "camel:kamelet"
     - "camel:jackson"
     - "camel:timer"
-  flow:
+  template:
     from:
       uri: "timer:update"
       parameters:

--- a/kamelets/caffeine-action.kamelet.yaml
+++ b/kamelets/caffeine-action.kamelet.yaml
@@ -53,7 +53,7 @@ spec:
   dependencies:
     - "camel:caffeine"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "kamelet:source"
       steps:

--- a/kamelets/cassandra-sink.kamelet.yaml
+++ b/kamelets/cassandra-sink.kamelet.yaml
@@ -92,7 +92,7 @@ spec:
   - "camel:jackson"
   - "camel:kamelet"
   - "camel:cassandraql"
-  flow:
+  template:
     from:
       uri: "kamelet:source"
       steps:

--- a/kamelets/cassandra-source.kamelet.yaml
+++ b/kamelets/cassandra-source.kamelet.yaml
@@ -88,7 +88,7 @@ spec:
   - "camel:jackson"
   - "camel:kamelet"
   - "camel:cassandraql"
-  flow:
+  template:
     from:
       uri: "cql://{{connectionHost}}:{{connectionPort}}/{{keyspace}}"
       parameters:

--- a/kamelets/chuck-norris-source.kamelet.yaml
+++ b/kamelets/chuck-norris-source.kamelet.yaml
@@ -46,7 +46,7 @@ spec:
     - "camel:timer"
     - "camel:http"
     - "camel:jsonpath"
-  flow:
+  template:
     from:
       uri: "timer:chuck"
       parameters:

--- a/kamelets/chunk-template-action.kamelet.yaml
+++ b/kamelets/chunk-template-action.kamelet.yaml
@@ -44,7 +44,7 @@ spec:
   dependencies:
   - "camel:chunk"
   - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "kamelet:source"
       steps:

--- a/kamelets/couchbase-sink.kamelet.yaml
+++ b/kamelets/couchbase-sink.kamelet.yaml
@@ -83,7 +83,7 @@ spec:
   dependencies:
     - "camel:couchbase"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "kamelet:source"
       steps:

--- a/kamelets/cron-source.kamelet.yaml
+++ b/kamelets/cron-source.kamelet.yaml
@@ -54,7 +54,7 @@ spec:
   - "camel:core"
   - "camel:cron"
   - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "cron:tick"
       parameters:

--- a/kamelets/delay-action.kamelet.yaml
+++ b/kamelets/delay-action.kamelet.yaml
@@ -43,7 +43,7 @@ spec:
   dependencies:
   - "camel:core"
   - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "kamelet:source"
       steps:

--- a/kamelets/dns-dig-action.kamelet.yaml
+++ b/kamelets/dns-dig-action.kamelet.yaml
@@ -45,7 +45,7 @@ spec:
   dependencies:
     - "camel:dns"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "kamelet:source"
       steps:

--- a/kamelets/dns-ip-action.kamelet.yaml
+++ b/kamelets/dns-ip-action.kamelet.yaml
@@ -41,7 +41,7 @@ spec:
   dependencies:
     - "camel:dns"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "kamelet:source"
       steps:

--- a/kamelets/dns-lookup-action.kamelet.yaml
+++ b/kamelets/dns-lookup-action.kamelet.yaml
@@ -45,7 +45,7 @@ spec:
     - "camel:jackson"
     - "camel:dns"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "kamelet:source"
       steps:

--- a/kamelets/drop-header-action.kamelet.yaml
+++ b/kamelets/drop-header-action.kamelet.yaml
@@ -42,7 +42,7 @@ spec:
   dependencies:
     - "camel:core"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/kamelets/drop-headers-action.kamelet.yaml
+++ b/kamelets/drop-headers-action.kamelet.yaml
@@ -47,7 +47,7 @@ spec:
   dependencies:
     - "camel:core"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/kamelets/dropbox-sink.kamelet.yaml
+++ b/kamelets/dropbox-sink.kamelet.yaml
@@ -70,7 +70,7 @@ spec:
   dependencies:
     - "camel:dropbox"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "kamelet:source"
       steps:

--- a/kamelets/dropbox-source.kamelet.yaml
+++ b/kamelets/dropbox-source.kamelet.yaml
@@ -72,7 +72,7 @@ spec:
     - "camel:core"
     - "camel:jsonpath"
     - "camel:timer"
-  flow:
+  template:
     from:
       uri: "timer:dropbox-stream"
       parameters:

--- a/kamelets/earthquake-source.kamelet.yaml
+++ b/kamelets/earthquake-source.kamelet.yaml
@@ -55,7 +55,7 @@ spec:
     - "camel:jackson"
     - "camel:jsonpath"
     - "camel:timer"
-  flow:
+  template:
     from:
       uri: "timer:earthquake"
       parameters:

--- a/kamelets/elasticsearch-index-sink.kamelet.yaml
+++ b/kamelets/elasticsearch-index-sink.kamelet.yaml
@@ -93,7 +93,7 @@ spec:
     - "camel:elasticsearch-rest"
     - "camel:gson"
     - "camel:bean"
-  flow:
+  template:
     beans:
       - name: local-es
         type: "#class:org.apache.camel.component.elasticsearch.ElasticsearchComponent"

--- a/kamelets/elasticsearch-search-source.kamelet.yaml
+++ b/kamelets/elasticsearch-search-source.kamelet.yaml
@@ -89,7 +89,7 @@ spec:
       - "camel:timer"
       - "camel:elasticsearch-rest"
       - "camel:gson"
-  flow:
+  template:
     beans:
       - name: local-es
         type: "#class:org.apache.camel.component.elasticsearch.ElasticsearchComponent"

--- a/kamelets/exec-sink.kamelet.yaml
+++ b/kamelets/exec-sink.kamelet.yaml
@@ -49,7 +49,7 @@ spec:
     - "camel:core"
     - "camel:exec"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/kamelets/extract-field-action.kamelet.yaml
+++ b/kamelets/extract-field-action.kamelet.yaml
@@ -76,7 +76,7 @@ spec:
   - "camel:kamelet"
   - "camel:core"
   - "camel:jackson"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/kamelets/fhir-source.kamelet.yaml
+++ b/kamelets/fhir-source.kamelet.yaml
@@ -83,7 +83,7 @@ spec:
   dependencies:
     - "camel:fhir"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "fhir://search/searchByUrl"
       parameters:

--- a/kamelets/file-watch-source.kamelet.yaml
+++ b/kamelets/file-watch-source.kamelet.yaml
@@ -48,7 +48,7 @@ spec:
   dependencies:
     - "camel:file-watch"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "file-watch:{{filePath}}"
       parameters:

--- a/kamelets/freemarker-template-action.kamelet.yaml
+++ b/kamelets/freemarker-template-action.kamelet.yaml
@@ -44,7 +44,7 @@ spec:
   dependencies:
   - "camel:freemarker"
   - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "kamelet:source"
       steps:

--- a/kamelets/ftp-sink.kamelet.yaml
+++ b/kamelets/ftp-sink.kamelet.yaml
@@ -88,7 +88,7 @@ spec:
     - "camel:ftp"
     - "camel:core"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "kamelet:source"
       steps:

--- a/kamelets/ftp-source.kamelet.yaml
+++ b/kamelets/ftp-source.kamelet.yaml
@@ -91,7 +91,7 @@ spec:
     - "camel:ftp"
     - "camel:core"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "ftp:{{username}}@{{connectionHost}}:{{connectionPort}}/{{directoryName}}"
       parameters:

--- a/kamelets/ftps-sink.kamelet.yaml
+++ b/kamelets/ftps-sink.kamelet.yaml
@@ -88,7 +88,7 @@ spec:
     - "camel:ftp"
     - "camel:core"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "kamelet:source"
       steps:

--- a/kamelets/ftps-source.kamelet.yaml
+++ b/kamelets/ftps-source.kamelet.yaml
@@ -91,7 +91,7 @@ spec:
     - "camel:ftp"
     - "camel:core"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "ftps:{{username}}@{{connectionHost}}:{{connectionPort}}/{{directoryName}}"
       parameters:

--- a/kamelets/github-commit-source.kamelet.yaml
+++ b/kamelets/github-commit-source.kamelet.yaml
@@ -71,7 +71,7 @@ spec:
   - "camel:jackson"
   - "camel:github"
   - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "github://commit/{{branch}}"
       parameters:

--- a/kamelets/github-event-source.kamelet.yaml
+++ b/kamelets/github-event-source.kamelet.yaml
@@ -60,7 +60,7 @@ spec:
   - "camel:jackson"
   - "camel:github"
   - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "github://event"
       parameters:

--- a/kamelets/github-pullrequest-comment-source.kamelet.yaml
+++ b/kamelets/github-pullrequest-comment-source.kamelet.yaml
@@ -60,7 +60,7 @@ spec:
   - "camel:jackson"
   - "camel:github"
   - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "github://pullRequestComment"
       parameters:

--- a/kamelets/github-pullrequest-source.kamelet.yaml
+++ b/kamelets/github-pullrequest-source.kamelet.yaml
@@ -60,7 +60,7 @@ spec:
   - "camel:jackson"
   - "camel:github"
   - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "github://pullRequest"
       parameters:

--- a/kamelets/github-tag-source.kamelet.yaml
+++ b/kamelets/github-tag-source.kamelet.yaml
@@ -60,7 +60,7 @@ spec:
   - "camel:jackson"
   - "camel:github"
   - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "github://tag"
       parameters:

--- a/kamelets/google-calendar-source.kamelet.yaml
+++ b/kamelets/google-calendar-source.kamelet.yaml
@@ -90,7 +90,7 @@ spec:
         title: Application name
         description: Google Calendar application name
         type: string
-      syncFlow:
+      synctemplate:
         title: Sync Flow
         description: Sync events for incremental synchronization
         type: boolean
@@ -111,7 +111,7 @@ spec:
   - "camel:jackson"
   - "camel:google-calendar"
   - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "google-calendar-stream://{{index}}"
       parameters:
@@ -122,7 +122,7 @@ spec:
         clientSecret: "{{clientSecret}}"
         delay: "{{delay}}"
         applicationName: "{{applicationName}}"
-        syncFlow: "{{syncFlow}}"
+        synctemplate: "{{syncFlow}}"
         consumeFromNow: "{{consumeFromNow}}"
       steps:
       - marshal:

--- a/kamelets/google-functions-sink.kamelet.yaml
+++ b/kamelets/google-functions-sink.kamelet.yaml
@@ -62,7 +62,7 @@ spec:
     - "camel:kamelet"
     - "camel:google-functions"
     - "camel:jackson"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/kamelets/google-mail-source.kamelet.yaml
+++ b/kamelets/google-mail-source.kamelet.yaml
@@ -110,7 +110,7 @@ spec:
   - "camel:jackson"
   - "camel:kamelet"
   - "camel:google-mail"
-  flow:
+  template:
     from:
       uri: "google-mail-stream://{{index}}"
       parameters:

--- a/kamelets/google-pubsub-sink.kamelet.yaml
+++ b/kamelets/google-pubsub-sink.kamelet.yaml
@@ -57,7 +57,7 @@ spec:
     - "camel:kamelet"
     - "camel:google-pubsub"
     - "camel:jackson"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/kamelets/google-pubsub-source.kamelet.yaml
+++ b/kamelets/google-pubsub-source.kamelet.yaml
@@ -74,7 +74,7 @@ spec:
     - "camel:kamelet"
     - "camel:google-pubsub"
     - "camel:jackson"
-  flow:
+  template:
     from:
       uri: "google-pubsub://{{projectId}}:{{subscriptionName}}"
       parameters:

--- a/kamelets/google-sheets-source.kamelet.yaml
+++ b/kamelets/google-sheets-source.kamelet.yaml
@@ -115,7 +115,7 @@ spec:
   - "camel:jackson"
   - "camel:kamelet"
   - "camel:google-sheets"
-  flow:
+  template:
     from:
       uri: "google-sheets-stream://{{index}}"
       parameters:

--- a/kamelets/google-storage-sink.kamelet.yaml
+++ b/kamelets/google-storage-sink.kamelet.yaml
@@ -63,7 +63,7 @@ spec:
     - "camel:kamelet"
     - "camel:google-storage"
     - "camel:jackson"
-  flow:
+  template:
     from:
       uri: "kamelet:source"
       steps:

--- a/kamelets/google-storage-source.kamelet.yaml
+++ b/kamelets/google-storage-source.kamelet.yaml
@@ -66,7 +66,7 @@ spec:
     - "camel:kamelet"
     - "camel:google-storage"
     - "camel:jackson"
-  flow:
+  template:
     from:
       uri: "google-storage://{{bucketNameOrArn}}"
       parameters:

--- a/kamelets/has-header-filter-action.kamelet.yaml
+++ b/kamelets/has-header-filter-action.kamelet.yaml
@@ -47,7 +47,7 @@ spec:
   dependencies:
   - "camel:core"
   - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/kamelets/header-matches-filter-action.kamelet.yaml
+++ b/kamelets/header-matches-filter-action.kamelet.yaml
@@ -46,7 +46,7 @@ spec:
   dependencies:
   - "camel:core"
   - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/kamelets/hoist-field-action.kamelet.yaml
+++ b/kamelets/hoist-field-action.kamelet.yaml
@@ -43,7 +43,7 @@ spec:
   - "camel:core"
   - "camel:jackson"
   - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/kamelets/http-secured-sink.kamelet.yaml
+++ b/kamelets/http-secured-sink.kamelet.yaml
@@ -75,7 +75,7 @@ spec:
   - "camel:http"
   - "camel:kamelet"
   - "camel:core"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/kamelets/http-secured-source.kamelet.yaml
+++ b/kamelets/http-secured-source.kamelet.yaml
@@ -82,7 +82,7 @@ spec:
     - "camel:kamelet"
     - "camel:core"
     - "camel:timer"
-  flow:
+  template:
     from:
       uri: "timer:fetch"
       parameters:

--- a/kamelets/http-sink.kamelet.yaml
+++ b/kamelets/http-sink.kamelet.yaml
@@ -49,7 +49,7 @@ spec:
   - "camel:http"
   - "camel:kamelet"
   - "camel:core"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/kamelets/http-source.kamelet.yaml
+++ b/kamelets/http-source.kamelet.yaml
@@ -56,7 +56,7 @@ spec:
     - "camel:kamelet"
     - "camel:core"
     - "camel:timer"
-  flow:
+  template:
     from:
       uri: "timer:fetch"
       parameters:

--- a/kamelets/infinispan-sink.kamelet.yaml
+++ b/kamelets/infinispan-sink.kamelet.yaml
@@ -92,7 +92,7 @@ spec:
     - "camel:kamelet"
     - "camel:core"
     - "camel:infinispan"
-  flow:
+  template:
     beans:
       - name: local-infinispan
         type: "#class:org.apache.camel.component.infinispan.remote.InfinispanRemoteComponent"

--- a/kamelets/infinispan-source.kamelet.yaml
+++ b/kamelets/infinispan-source.kamelet.yaml
@@ -92,7 +92,7 @@ spec:
     - "camel:kamelet"
     - "camel:core"
     - "camel:infinispan"
-  flow:
+  template:
     beans:
       - name: local-infinispan
         type: "#class:org.apache.camel.component.infinispan.remote.InfinispanRemoteComponent"

--- a/kamelets/insert-field-action.kamelet.yaml
+++ b/kamelets/insert-field-action.kamelet.yaml
@@ -53,7 +53,7 @@ spec:
   - "camel:core"
   - "camel:jackson"
   - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/kamelets/insert-header-action.kamelet.yaml
+++ b/kamelets/insert-header-action.kamelet.yaml
@@ -47,7 +47,7 @@ spec:
   dependencies:
     - "camel:core"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/kamelets/is-tombstone-filter-action.kamelet.yaml
+++ b/kamelets/is-tombstone-filter-action.kamelet.yaml
@@ -34,7 +34,7 @@ spec:
   dependencies:
   - "camel:core"
   - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/kamelets/jira-source.kamelet.yaml
+++ b/kamelets/jira-source.kamelet.yaml
@@ -70,7 +70,7 @@ spec:
   - "camel:jira"
   - "camel:kamelet"
   - "mvn:com.fasterxml.jackson.datatype:jackson-datatype-joda:2.12.5"
-  flow:
+  template:
     from:
       uri: "jira:newIssues"
       parameters:

--- a/kamelets/jms-amqp-10-sink.kamelet.yaml
+++ b/kamelets/jms-amqp-10-sink.kamelet.yaml
@@ -54,7 +54,7 @@ spec:
   - "camel:jms"
   - "camel:kamelet"
   - "mvn:org.apache.qpid:qpid-jms-client:1.0.0"
-  flow:
+  template:
     beans:
       - name: connectionFactoryBean
         type: "#class:org.apache.qpid.jms.JmsConnectionFactory"

--- a/kamelets/jms-amqp-10-source.kamelet.yaml
+++ b/kamelets/jms-amqp-10-source.kamelet.yaml
@@ -54,7 +54,7 @@ spec:
   - "camel:jms"
   - "camel:kamelet"
   - "mvn:org.apache.qpid:qpid-jms-client:1.0.0"
-  flow:
+  template:
     beans:
       - name: connectionFactoryBean
         type: "#class:org.apache.qpid.jms.JmsConnectionFactory"

--- a/kamelets/jms-apache-artemis-sink.kamelet.yaml
+++ b/kamelets/jms-apache-artemis-sink.kamelet.yaml
@@ -55,7 +55,7 @@ spec:
   - "camel:jms"
   - "camel:kamelet"
   - "mvn:org.apache.activemq:artemis-jms-client-all:2.17.0"
-  flow:
+  template:
     beans:
       - name: connectionFactoryBean
         type: "#class:org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory"

--- a/kamelets/jms-apache-artemis-source.kamelet.yaml
+++ b/kamelets/jms-apache-artemis-source.kamelet.yaml
@@ -54,7 +54,7 @@ spec:
   - "camel:jms"
   - "camel:kamelet"
   - "mvn:org.apache.activemq:artemis-jms-client-all:2.17.0"
-  flow:
+  template:
     beans:
       - name: connectionFactoryBean
         type: "#class:org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory"

--- a/kamelets/jolt-transformation-action.kamelet.yaml
+++ b/kamelets/jolt-transformation-action.kamelet.yaml
@@ -44,7 +44,7 @@ spec:
   dependencies:
   - "camel:jolt"
   - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "kamelet:source"
       steps:

--- a/kamelets/json-deserialize-action.kamelet.yaml
+++ b/kamelets/json-deserialize-action.kamelet.yaml
@@ -36,7 +36,7 @@ spec:
   - "camel:kamelet"
   - "camel:core"
   - "camel:jackson"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/kamelets/json-patch-action.kamelet.yaml
+++ b/kamelets/json-patch-action.kamelet.yaml
@@ -44,7 +44,7 @@ spec:
   dependencies:
   - "camel:json-patch"
   - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "kamelet:source"
       steps:

--- a/kamelets/json-schema-validator-action.kamelet.yaml
+++ b/kamelets/json-schema-validator-action.kamelet.yaml
@@ -44,7 +44,7 @@ spec:
   dependencies:
   - "camel:json-validator"
   - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "kamelet:source"
       steps:

--- a/kamelets/json-serialize-action.kamelet.yaml
+++ b/kamelets/json-serialize-action.kamelet.yaml
@@ -36,7 +36,7 @@ spec:
   - "camel:kamelet"
   - "camel:core"
   - "camel:jackson"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/kamelets/jsonata-action.kamelet.yaml
+++ b/kamelets/jsonata-action.kamelet.yaml
@@ -44,7 +44,7 @@ spec:
   dependencies:
   - "camel:jsonata"
   - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "kamelet:source"
       steps:

--- a/kamelets/kafka-manual-commit-action.kamelet.yaml
+++ b/kamelets/kafka-manual-commit-action.kamelet.yaml
@@ -34,7 +34,7 @@ spec:
   dependencies:
   - github:apache.camel-kamelets:camel-kamelets-utils:main-SNAPSHOT
   - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/kamelets/kafka-not-secured-sink.kamelet.yaml
+++ b/kamelets/kafka-not-secured-sink.kamelet.yaml
@@ -55,7 +55,7 @@ spec:
   dependencies:
     - "camel:kafka"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "kamelet:source"
       steps:

--- a/kamelets/kafka-not-secured-source.kamelet.yaml
+++ b/kamelets/kafka-not-secured-source.kamelet.yaml
@@ -88,7 +88,7 @@ spec:
   dependencies:
     - "camel:kafka"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "kafka:{{topic}}"
       parameters:

--- a/kamelets/kafka-sink.kamelet.yaml
+++ b/kamelets/kafka-sink.kamelet.yaml
@@ -81,7 +81,7 @@ spec:
   dependencies:
     - "camel:kafka"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "kamelet:source"
       steps:

--- a/kamelets/kafka-source.kamelet.yaml
+++ b/kamelets/kafka-source.kamelet.yaml
@@ -120,7 +120,7 @@ spec:
   dependencies:
     - "camel:kafka"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "kafka:{{topic}}"
       parameters:

--- a/kamelets/kubernetes-namespaces-source.kamelet.yaml
+++ b/kamelets/kubernetes-namespaces-source.kamelet.yaml
@@ -55,7 +55,7 @@ spec:
     - "camel:kubernetes"
     - "camel:kamelet"
     - "camel:jackson"
-  flow:
+  template:
     from:
       uri: "kubernetes-namespaces://{{masterUrl}}"
       parameters:

--- a/kamelets/kubernetes-nodes-source.kamelet.yaml
+++ b/kamelets/kubernetes-nodes-source.kamelet.yaml
@@ -59,7 +59,7 @@ spec:
     - "camel:kubernetes"
     - "camel:kamelet"
     - "camel:jackson"
-  flow:
+  template:
     from:
       uri: "kubernetes-nodes://{{masterUrl}}"
       parameters:

--- a/kamelets/kubernetes-pods-source.kamelet.yaml
+++ b/kamelets/kubernetes-pods-source.kamelet.yaml
@@ -59,7 +59,7 @@ spec:
     - "camel:kubernetes"
     - "camel:kamelet"
     - "camel:jackson"
-  flow:
+  template:
     from:
       uri: "kubernetes-pods://{{masterUrl}}"
       parameters:

--- a/kamelets/log-sink.kamelet.yaml
+++ b/kamelets/log-sink.kamelet.yaml
@@ -50,7 +50,7 @@ spec:
   dependencies:
   - "camel:kamelet"
   - "camel:log"
-  flow:
+  template:
     from:
       uri: "kamelet:source"
       steps:

--- a/kamelets/mail-imap-source.kamelet.yaml
+++ b/kamelets/mail-imap-source.kamelet.yaml
@@ -87,7 +87,7 @@ spec:
     - "camel:core"
     - "camel:mail"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "imaps:{{connectionHost}}:{{connectionPort}}"
       parameters:

--- a/kamelets/mail-sink.kamelet.yaml
+++ b/kamelets/mail-sink.kamelet.yaml
@@ -81,7 +81,7 @@ spec:
     - "camel:core"
     - "camel:mail"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "kamelet:source"
       steps:

--- a/kamelets/mariadb-sink.kamelet.yaml
+++ b/kamelets/mariadb-sink.kamelet.yaml
@@ -92,7 +92,7 @@ spec:
   - "camel:kamelet"
   - "camel:sql"
   - "mvn:org.apache.commons:commons-dbcp2:2.9.0"
-  flow:
+  template:
     beans:
       - name: dsBean
         type: "#class:org.apache.commons.dbcp2.BasicDataSource"

--- a/kamelets/mariadb-source.kamelet.yaml
+++ b/kamelets/mariadb-source.kamelet.yaml
@@ -89,7 +89,7 @@ spec:
   - "camel:kamelet"
   - "camel:sql"
   - "mvn:org.apache.commons:commons-dbcp2:2.9.0"
-  flow:
+  template:
     beans:
       - name: dsBean
         type: "#class:org.apache.commons.dbcp2.BasicDataSource"

--- a/kamelets/mask-field-action.kamelet.yaml
+++ b/kamelets/mask-field-action.kamelet.yaml
@@ -48,7 +48,7 @@ spec:
   - "camel:jackson"
   - "camel:kamelet"
   - "camel:core"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/kamelets/message-timestamp-router-action.kamelet.yaml
+++ b/kamelets/message-timestamp-router-action.kamelet.yaml
@@ -58,7 +58,7 @@ spec:
   - "camel:jackson"
   - "camel:kamelet"
   - "camel:core"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/kamelets/minio-sink.kamelet.yaml
+++ b/kamelets/minio-sink.kamelet.yaml
@@ -79,7 +79,7 @@ spec:
   dependencies:
     - "camel:minio"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "kamelet:source"
       steps:

--- a/kamelets/minio-source.kamelet.yaml
+++ b/kamelets/minio-source.kamelet.yaml
@@ -84,7 +84,7 @@ spec:
   - "camel:jackson"
   - "camel:minio"
   - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "minio:{{bucketName}}"
       parameters:

--- a/kamelets/mongodb-sink.kamelet.yaml
+++ b/kamelets/mongodb-sink.kamelet.yaml
@@ -87,7 +87,7 @@ spec:
     - "camel:kamelet"
     - "camel:mongodb"
     - "camel:jackson"
-  flow:
+  template:
     beans:
       - name: local-mongodb
         type: "#class:org.apache.camel.component.mongodb.MongoDbComponent"

--- a/kamelets/mongodb-source.kamelet.yaml
+++ b/kamelets/mongodb-source.kamelet.yaml
@@ -82,7 +82,7 @@ spec:
     - "camel:kamelet"
     - "camel:mongodb"
     - "camel:jackson"
-  flow:
+  template:
     beans:
       - name: local-mongodb
         type: "#class:org.apache.camel.component.mongodb.MongoDbComponent"

--- a/kamelets/mqtt-sink.kamelet.yaml
+++ b/kamelets/mqtt-sink.kamelet.yaml
@@ -63,7 +63,7 @@ spec:
   dependencies:
     - "camel:paho"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/kamelets/mqtt-source.kamelet.yaml
+++ b/kamelets/mqtt-source.kamelet.yaml
@@ -68,7 +68,7 @@ spec:
   dependencies:
     - "camel:paho"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: paho:{{topic}}
       parameters:

--- a/kamelets/mustache-template-action.kamelet.yaml
+++ b/kamelets/mustache-template-action.kamelet.yaml
@@ -44,7 +44,7 @@ spec:
   dependencies:
   - "camel:mustache"
   - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "kamelet:source"
       steps:

--- a/kamelets/mvel-template-action.kamelet.yaml
+++ b/kamelets/mvel-template-action.kamelet.yaml
@@ -44,7 +44,7 @@ spec:
   dependencies:
   - "camel:mvel"
   - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "kamelet:source"
       steps:

--- a/kamelets/mysql-sink.kamelet.yaml
+++ b/kamelets/mysql-sink.kamelet.yaml
@@ -92,7 +92,7 @@ spec:
   - "camel:kamelet"
   - "camel:sql"
   - "mvn:org.apache.commons:commons-dbcp2:2.9.0"
-  flow:
+  template:
     beans:
       - name: dsBean
         type: "#class:org.apache.commons.dbcp2.BasicDataSource"

--- a/kamelets/mysql-source.kamelet.yaml
+++ b/kamelets/mysql-source.kamelet.yaml
@@ -89,7 +89,7 @@ spec:
   - "camel:kamelet"
   - "camel:sql"
   - "mvn:org.apache.commons:commons-dbcp2:2.9.0"
-  flow:
+  template:
     beans:
       - name: dsBean
         type: "#class:org.apache.commons.dbcp2.BasicDataSource"

--- a/kamelets/nats-sink.kamelet.yaml
+++ b/kamelets/nats-sink.kamelet.yaml
@@ -47,7 +47,7 @@ spec:
   dependencies:
   - "camel:nats"
   - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "kamelet:source"
       steps:

--- a/kamelets/nats-source.kamelet.yaml
+++ b/kamelets/nats-source.kamelet.yaml
@@ -51,7 +51,7 @@ spec:
   - "camel:jackson"
   - "camel:nats"
   - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "nats:{{topic}}"
       parameters:

--- a/kamelets/openai-classification-action.kamelet.yaml
+++ b/kamelets/openai-classification-action.kamelet.yaml
@@ -80,7 +80,7 @@ spec:
   - "camel:core"
   - "camel:kamelet"
   - "camel:http"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/kamelets/openai-completion-action.kamelet.yaml
+++ b/kamelets/openai-completion-action.kamelet.yaml
@@ -72,7 +72,7 @@ spec:
   - "camel:core"
   - "camel:kamelet"
   - "camel:http"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/kamelets/pdf-action.kamelet.yaml
+++ b/kamelets/pdf-action.kamelet.yaml
@@ -55,7 +55,7 @@ spec:
   dependencies:
   - "camel:pdf"
   - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "kamelet:source"
       steps:

--- a/kamelets/postgresql-sink.kamelet.yaml
+++ b/kamelets/postgresql-sink.kamelet.yaml
@@ -89,7 +89,7 @@ spec:
   - "camel:sql"
   - "mvn:org.postgresql:postgresql:42.2.14"
   - "mvn:org.apache.commons:commons-dbcp2:2.9.0"
-  flow:
+  template:
     beans:
       - name: dsBean
         type: "#class:org.apache.commons.dbcp2.BasicDataSource"

--- a/kamelets/postgresql-source.kamelet.yaml
+++ b/kamelets/postgresql-source.kamelet.yaml
@@ -86,7 +86,7 @@ spec:
   - "camel:sql"
   - "mvn:org.postgresql:postgresql:42.2.14"
   - "mvn:org.apache.commons:commons-dbcp2:2.9.0"
-  flow:
+  template:
     beans:
       - name: dsBean
         type: "#class:org.apache.commons.dbcp2.BasicDataSource"

--- a/kamelets/predicate-filter-action.kamelet.yaml
+++ b/kamelets/predicate-filter-action.kamelet.yaml
@@ -43,7 +43,7 @@ spec:
   - "camel:core"
   - "camel:kamelet"
   - "camel:jsonpath"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/kamelets/protobuf-deserialize-action.kamelet.yaml
+++ b/kamelets/protobuf-deserialize-action.kamelet.yaml
@@ -44,7 +44,7 @@ spec:
   - "camel:kamelet"
   - "camel:core"
   - "camel:jackson-protobuf"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/kamelets/protobuf-serialize-action.kamelet.yaml
+++ b/kamelets/protobuf-serialize-action.kamelet.yaml
@@ -44,7 +44,7 @@ spec:
   - "camel:kamelet"
   - "camel:core"
   - "camel:jackson-protobuf"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/kamelets/pulsar-sink.kamelet.yaml
+++ b/kamelets/pulsar-sink.kamelet.yaml
@@ -147,7 +147,7 @@ spec:
         type: int
         default: 30000
     type: object
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/kamelets/pulsar-source.kamelet.yaml
+++ b/kamelets/pulsar-source.kamelet.yaml
@@ -144,7 +144,7 @@ spec:
         x-descriptors:
           - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
     type: object
-  flow:
+  template:
     from:
       uri: pulsar:{{topicType}}/{{tenant}}/{{namespaceName}}/{{topic}}
       parameters:

--- a/kamelets/rabbitmq-source.kamelet.yaml
+++ b/kamelets/rabbitmq-source.kamelet.yaml
@@ -70,7 +70,7 @@ spec:
   dependencies:
     - "camel:rabbitmq"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "rabbitmq://{{exchangeName}}"
       parameters:

--- a/kamelets/redis-sink.kamelet.yaml
+++ b/kamelets/redis-sink.kamelet.yaml
@@ -63,7 +63,7 @@ spec:
     - "camel:kamelet"
     - "camel:core"
     - "camel:spring-redis"
-  flow:
+  template:
     from:
       uri: "kamelet:source"
       steps:

--- a/kamelets/redis-source.kamelet.yaml
+++ b/kamelets/redis-source.kamelet.yaml
@@ -63,7 +63,7 @@ spec:
     - "camel:kamelet"
     - "camel:core"
     - "camel:spring-redis"
-  flow:
+  template:
     from:
       uri: "spring-redis:{{redisHost}}:{{redisPort}}"
       parameters:

--- a/kamelets/regex-router-action.kamelet.yaml
+++ b/kamelets/regex-router-action.kamelet.yaml
@@ -47,7 +47,7 @@ spec:
   - github:apache.camel-kamelets:camel-kamelets-utils:main-SNAPSHOT
   - "camel:kamelet"
   - "camel:core"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/kamelets/replace-field-action.kamelet.yaml
+++ b/kamelets/replace-field-action.kamelet.yaml
@@ -68,7 +68,7 @@ spec:
   - "camel:core"
   - "camel:jackson"
   - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/kamelets/salesforce-source.kamelet.yaml
+++ b/kamelets/salesforce-source.kamelet.yaml
@@ -95,7 +95,7 @@ spec:
   - "camel:jackson"
   - "camel:salesforce"
   - "camel:kamelet"
-  flow:
+  template:
     beans:
       - name: local-salesforce
         type: "#class:org.apache.camel.component.salesforce.SalesforceComponent"

--- a/kamelets/sftp-sink.kamelet.yaml
+++ b/kamelets/sftp-sink.kamelet.yaml
@@ -88,7 +88,7 @@ spec:
     - "camel:ftp"
     - "camel:core"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "kamelet:source"
       steps:

--- a/kamelets/sftp-source.kamelet.yaml
+++ b/kamelets/sftp-source.kamelet.yaml
@@ -91,7 +91,7 @@ spec:
     - "camel:ftp"
     - "camel:core"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "sftp:{{username}}@{{connectionHost}}:{{connectionPort}}/{{directoryName}}"
       parameters:

--- a/kamelets/slack-sink.kamelet.yaml
+++ b/kamelets/slack-sink.kamelet.yaml
@@ -68,7 +68,7 @@ spec:
   - "camel:jackson"
   - "camel:slack"
   - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "kamelet:source"
       steps:

--- a/kamelets/slack-source.kamelet.yaml
+++ b/kamelets/slack-source.kamelet.yaml
@@ -61,7 +61,7 @@ spec:
   - "camel:gson"
   - "camel:slack"
   - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "slack:{{channel}}"
       parameters:

--- a/kamelets/solr-sink.kamelet.yaml
+++ b/kamelets/solr-sink.kamelet.yaml
@@ -73,7 +73,7 @@ spec:
   - "camel:core"
   - "camel:jackson"
   - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "kamelet:source"
       steps:

--- a/kamelets/solr-source.kamelet.yaml
+++ b/kamelets/solr-source.kamelet.yaml
@@ -78,7 +78,7 @@ spec:
   - "camel:timer"
   - "camel:jackson"
   - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "timer:solr-stream"
       parameters:

--- a/kamelets/sqlserver-sink.kamelet.yaml
+++ b/kamelets/sqlserver-sink.kamelet.yaml
@@ -92,7 +92,7 @@ spec:
   - "camel:kamelet"
   - "camel:sql"
   - "mvn:org.apache.commons:commons-dbcp2:2.9.0"
-  flow:
+  template:
     beans:
       - name: dsBean
         type: "#class:org.apache.commons.dbcp2.BasicDataSource"

--- a/kamelets/sqlserver-source.kamelet.yaml
+++ b/kamelets/sqlserver-source.kamelet.yaml
@@ -89,7 +89,7 @@ spec:
   - "camel:kamelet"
   - "camel:sql"
   - "mvn:org.apache.commons:commons-dbcp2:2.9.0"
-  flow:
+  template:
     beans:
       - name: dsBean
         type: "#class:org.apache.commons.dbcp2.BasicDataSource"

--- a/kamelets/ssh-sink.kamelet.yaml
+++ b/kamelets/ssh-sink.kamelet.yaml
@@ -70,7 +70,7 @@ spec:
     - "camel:ssh"
     - "camel:gson"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "kamelet:source"
       steps:

--- a/kamelets/ssh-source.kamelet.yaml
+++ b/kamelets/ssh-source.kamelet.yaml
@@ -75,7 +75,7 @@ spec:
   dependencies:
     - "camel:ssh"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "ssh://{{connectionHost}}:{{connectionPort}}"
       parameters:

--- a/kamelets/string-template-action.kamelet.yaml
+++ b/kamelets/string-template-action.kamelet.yaml
@@ -44,7 +44,7 @@ spec:
   dependencies:
   - "camel:stringtemplate"
   - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "kamelet:source"
       steps:

--- a/kamelets/telegram-sink.kamelet.yaml
+++ b/kamelets/telegram-sink.kamelet.yaml
@@ -67,7 +67,7 @@ spec:
     - "camel:jackson"
     - "camel:kamelet"
     - "camel:telegram"
-  flow:
+  template:
     from:
       uri: "kamelet:source"
       steps:

--- a/kamelets/telegram-source.kamelet.yaml
+++ b/kamelets/telegram-source.kamelet.yaml
@@ -58,7 +58,7 @@ spec:
     - "camel:kamelet"
     - "camel:telegram"
     - "camel:core"
-  flow:
+  template:
     from:
       uri: telegram:bots
       parameters:

--- a/kamelets/throttle-action.kamelet.yaml
+++ b/kamelets/throttle-action.kamelet.yaml
@@ -47,7 +47,7 @@ spec:
   dependencies:
     - "camel:core"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/kamelets/timer-source.kamelet.yaml
+++ b/kamelets/timer-source.kamelet.yaml
@@ -55,7 +55,7 @@ spec:
     - "camel:core"
     - "camel:timer"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: timer:tick
       parameters:

--- a/kamelets/timestamp-router-action.kamelet.yaml
+++ b/kamelets/timestamp-router-action.kamelet.yaml
@@ -51,7 +51,7 @@ spec:
   - github:apache.camel-kamelets:camel-kamelets-utils:main-SNAPSHOT
   - "camel:kamelet"
   - "camel:core"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/kamelets/topic-name-matches-filter-action.kamelet.yaml
+++ b/kamelets/topic-name-matches-filter-action.kamelet.yaml
@@ -41,7 +41,7 @@ spec:
   dependencies:
   - "camel:core"
   - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/kamelets/twitter-directmessage-source.kamelet.yaml
+++ b/kamelets/twitter-directmessage-source.kamelet.yaml
@@ -86,7 +86,7 @@ spec:
     - "camel:jackson"
     - "camel:twitter"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "twitter-directmessage:{{user}}"
       parameters:

--- a/kamelets/twitter-search-source.kamelet.yaml
+++ b/kamelets/twitter-search-source.kamelet.yaml
@@ -86,7 +86,7 @@ spec:
     - "camel:jackson"
     - "camel:twitter"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "twitter-search:{{keywords}}"
       parameters:

--- a/kamelets/twitter-timeline-source.kamelet.yaml
+++ b/kamelets/twitter-timeline-source.kamelet.yaml
@@ -86,7 +86,7 @@ spec:
     - "camel:jackson"
     - "camel:twitter"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "twitter-timeline:user"
       parameters:

--- a/kamelets/value-to-key-action.kamelet.yaml
+++ b/kamelets/value-to-key-action.kamelet.yaml
@@ -43,7 +43,7 @@ spec:
   - "camel:core"
   - "camel:jackson"
   - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/kamelets/velocity-template-action.kamelet.yaml
+++ b/kamelets/velocity-template-action.kamelet.yaml
@@ -44,7 +44,7 @@ spec:
   dependencies:
   - "camel:velocity"
   - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "kamelet:source"
       steps:

--- a/kamelets/webhook-source.kamelet.yaml
+++ b/kamelets/webhook-source.kamelet.yaml
@@ -47,7 +47,7 @@ spec:
   dependencies:
     - "camel:platform-http"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "platform-http:///{{subpath}}"
       steps:

--- a/kamelets/websocket-source.kamelet.yaml
+++ b/kamelets/websocket-source.kamelet.yaml
@@ -96,7 +96,7 @@ spec:
     - "camel:kamelet"
     - "camel:core"
     - "camel:websocket"
-  flow:
+  template:
     from:
       uri: "websocket://{{websocketHost}}:{{websocketPort}}/{{resourceUri}}"
       parameters:

--- a/kamelets/wttrin-source.kamelet.yaml
+++ b/kamelets/wttrin-source.kamelet.yaml
@@ -63,7 +63,7 @@ spec:
     - "camel:jsonpath"
     - "camel:kamelet"
     - "camel:timer"
-  flow:
+  template:
     from:
       uri: timer:wttr.in
       parameters:

--- a/kamelets/xj-identity-action.kamelet.yaml
+++ b/kamelets/xj-identity-action.kamelet.yaml
@@ -42,7 +42,7 @@ spec:
   dependencies:
   - "camel:xj"
   - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "kamelet:source"
       steps:

--- a/kamelets/xj-template-action.kamelet.yaml
+++ b/kamelets/xj-template-action.kamelet.yaml
@@ -49,7 +49,7 @@ spec:
   dependencies:
   - "camel:xj"
   - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "kamelet:source"
       steps:

--- a/library/camel-kamelets/src/main/resources/kamelets/avro-deserialize-action.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/avro-deserialize-action.kamelet.yaml
@@ -52,7 +52,7 @@ spec:
   - "camel:kamelet"
   - "camel:core"
   - "camel:jackson-avro"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/library/camel-kamelets/src/main/resources/kamelets/avro-serialize-action.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/avro-serialize-action.kamelet.yaml
@@ -52,7 +52,7 @@ spec:
   - "camel:kamelet"
   - "camel:core"
   - "camel:jackson-avro"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/library/camel-kamelets/src/main/resources/kamelets/aws-cloudwatch-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/aws-cloudwatch-sink.kamelet.yaml
@@ -88,7 +88,7 @@ spec:
   dependencies:
     - "camel:aws2-cw"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/library/camel-kamelets/src/main/resources/kamelets/aws-ddb-streams-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/aws-ddb-streams-source.kamelet.yaml
@@ -82,7 +82,7 @@ spec:
   - "camel:gson"
   - "camel:aws2-ddb"
   - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "aws2-ddbstream:{{table}}"
       parameters:

--- a/library/camel-kamelets/src/main/resources/kamelets/aws-ec2-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/aws-ec2-sink.kamelet.yaml
@@ -66,7 +66,7 @@ spec:
   dependencies:
     - "camel:aws2-ec2"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/library/camel-kamelets/src/main/resources/kamelets/aws-kinesis-firehose-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/aws-kinesis-firehose-sink.kamelet.yaml
@@ -67,7 +67,7 @@ spec:
   dependencies:
     - "camel:aws2-kinesis"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/library/camel-kamelets/src/main/resources/kamelets/aws-kinesis-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/aws-kinesis-sink.kamelet.yaml
@@ -79,7 +79,7 @@ spec:
   dependencies:
     - "camel:aws2-kinesis"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/library/camel-kamelets/src/main/resources/kamelets/aws-kinesis-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/aws-kinesis-source.kamelet.yaml
@@ -71,7 +71,7 @@ spec:
     - "camel:aws2-kinesis"
     - "camel:kamelet"
     - "camel:gson"
-  flow:
+  template:
     from:
       uri: aws2-kinesis:{{stream}}
       parameters:

--- a/library/camel-kamelets/src/main/resources/kamelets/aws-lambda-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/aws-lambda-sink.kamelet.yaml
@@ -67,7 +67,7 @@ spec:
   dependencies:
     - "camel:aws2-lambda"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/library/camel-kamelets/src/main/resources/kamelets/aws-redshift-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/aws-redshift-sink.kamelet.yaml
@@ -89,7 +89,7 @@ spec:
   - "camel:sql"
   - "mvn:com.amazon.redshift:redshift-jdbc42:2.1.0.3"
   - "mvn:org.apache.commons:commons-dbcp2:2.9.0"
-  flow:
+  template:
     beans:
       - name: dsBean
         type: "#class:org.apache.commons.dbcp2.BasicDataSource"

--- a/library/camel-kamelets/src/main/resources/kamelets/aws-redshift-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/aws-redshift-source.kamelet.yaml
@@ -86,7 +86,7 @@ spec:
   - "camel:sql"
   - "mvn:com.amazon.redshift:redshift-jdbc42:2.1.0.3"
   - "mvn:org.apache.commons:commons-dbcp2:2.9.0"
-  flow:
+  template:
     beans:
       - name: dsBean
         type: "#class:org.apache.commons.dbcp2.BasicDataSource"

--- a/library/camel-kamelets/src/main/resources/kamelets/aws-s3-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/aws-s3-sink.kamelet.yaml
@@ -89,7 +89,7 @@ spec:
   dependencies:
     - "camel:aws2-s3"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "kamelet:source"
       steps:

--- a/library/camel-kamelets/src/main/resources/kamelets/aws-s3-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/aws-s3-source.kamelet.yaml
@@ -92,7 +92,7 @@ spec:
   dependencies:
     - "camel:aws2-s3"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "aws2-s3:{{bucketNameOrArn}}"
       parameters:

--- a/library/camel-kamelets/src/main/resources/kamelets/aws-s3-streaming-upload-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/aws-s3-streaming-upload-sink.kamelet.yaml
@@ -110,7 +110,7 @@ spec:
   dependencies:
     - "camel:aws2-s3"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "kamelet:source"
       steps:

--- a/library/camel-kamelets/src/main/resources/kamelets/aws-secrets-manager-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/aws-secrets-manager-sink.kamelet.yaml
@@ -68,7 +68,7 @@ spec:
   dependencies:
     - "camel:aws-secrets-manager"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "kamelet:source"
       steps:

--- a/library/camel-kamelets/src/main/resources/kamelets/aws-ses-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/aws-ses-sink.kamelet.yaml
@@ -79,7 +79,7 @@ spec:
   dependencies:
     - "camel:aws2-ses"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "kamelet:source"
       steps:

--- a/library/camel-kamelets/src/main/resources/kamelets/aws-sns-fifo-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/aws-sns-fifo-sink.kamelet.yaml
@@ -86,7 +86,7 @@ spec:
   - "camel:aws2-sns"
   - "camel:core"
   - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/library/camel-kamelets/src/main/resources/kamelets/aws-sns-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/aws-sns-sink.kamelet.yaml
@@ -78,7 +78,7 @@ spec:
   dependencies:
     - "camel:aws2-sns"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/library/camel-kamelets/src/main/resources/kamelets/aws-sqs-batch-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/aws-sqs-batch-sink.kamelet.yaml
@@ -90,7 +90,7 @@ spec:
   dependencies:
     - "camel:aws2-sqs"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/library/camel-kamelets/src/main/resources/kamelets/aws-sqs-fifo-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/aws-sqs-fifo-sink.kamelet.yaml
@@ -91,7 +91,7 @@ spec:
   - "camel:aws2-sqs"
   - "camel:core"
   - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/library/camel-kamelets/src/main/resources/kamelets/aws-sqs-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/aws-sqs-sink.kamelet.yaml
@@ -84,7 +84,7 @@ spec:
   dependencies:
     - "camel:aws2-sqs"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/library/camel-kamelets/src/main/resources/kamelets/aws-sqs-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/aws-sqs-source.kamelet.yaml
@@ -106,7 +106,7 @@ spec:
   dependencies:
     - "camel:aws2-sqs"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "aws2-sqs:{{queueNameOrArn}}"
       parameters:

--- a/library/camel-kamelets/src/main/resources/kamelets/aws-translate-action.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/aws-translate-action.kamelet.yaml
@@ -75,7 +75,7 @@ spec:
     - "camel:dns"
     - "camel:kamelet"
     - "camel:aws2-translate"
-  flow:
+  template:
     from:
       uri: "kamelet:source"
       steps:

--- a/library/camel-kamelets/src/main/resources/kamelets/azure-cosmosdb-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/azure-cosmosdb-source.kamelet.yaml
@@ -88,7 +88,7 @@ spec:
     - "camel:azure-cosmosdb"
     - "camel:kamelet"
     - "camel:jackson"
-  flow:
+  template:
     from:
       uri: "azure-cosmosdb:{{databaseName}}/{{containerName}}"
       parameters:

--- a/library/camel-kamelets/src/main/resources/kamelets/azure-eventhubs-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/azure-eventhubs-sink.kamelet.yaml
@@ -75,7 +75,7 @@ spec:
   - "mvn:com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.11.3"
   - "camel:azure-eventhubs"
   - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "kamelet:source"
       steps:

--- a/library/camel-kamelets/src/main/resources/kamelets/azure-eventhubs-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/azure-eventhubs-source.kamelet.yaml
@@ -92,7 +92,7 @@ spec:
   - "camel:azure-eventhubs"
   - "camel:kamelet"
   - "camel:jackson"
-  flow:
+  template:
     from:
       uri: 'azure-eventhubs://{{namespaceName}}/{{eventhubName}}'
       parameters:

--- a/library/camel-kamelets/src/main/resources/kamelets/azure-storage-blob-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/azure-storage-blob-sink.kamelet.yaml
@@ -70,7 +70,7 @@ spec:
   dependencies:
   - "camel:azure-storage-blob"
   - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "kamelet:source"
       steps:

--- a/library/camel-kamelets/src/main/resources/kamelets/azure-storage-blob-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/azure-storage-blob-source.kamelet.yaml
@@ -68,7 +68,7 @@ spec:
     - "camel:core"
     - "camel:jsonpath"
     - "camel:timer"
-  flow:
+  template:
     from:
       uri: "timer:azure-storage-blob-stream"
       parameters:

--- a/library/camel-kamelets/src/main/resources/kamelets/azure-storage-queue-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/azure-storage-queue-sink.kamelet.yaml
@@ -67,7 +67,7 @@ spec:
   dependencies:
     - "camel:azure-storage-queue"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "kamelet:source"
       steps:

--- a/library/camel-kamelets/src/main/resources/kamelets/azure-storage-queue-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/azure-storage-queue-source.kamelet.yaml
@@ -64,7 +64,7 @@ spec:
   dependencies:
     - "camel:azure-storage-queue"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "azure-storage-queue://{{accountName}}/{{queueName}}"
       parameters:

--- a/library/camel-kamelets/src/main/resources/kamelets/bitcoin-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/bitcoin-source.kamelet.yaml
@@ -73,7 +73,7 @@ spec:
     - "camel:kamelet"
     - "camel:jackson"
     - "camel:timer"
-  flow:
+  template:
     from:
       uri: "timer:update"
       parameters:

--- a/library/camel-kamelets/src/main/resources/kamelets/caffeine-action.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/caffeine-action.kamelet.yaml
@@ -53,7 +53,7 @@ spec:
   dependencies:
     - "camel:caffeine"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "kamelet:source"
       steps:

--- a/library/camel-kamelets/src/main/resources/kamelets/cassandra-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/cassandra-sink.kamelet.yaml
@@ -92,7 +92,7 @@ spec:
   - "camel:jackson"
   - "camel:kamelet"
   - "camel:cassandraql"
-  flow:
+  template:
     from:
       uri: "kamelet:source"
       steps:

--- a/library/camel-kamelets/src/main/resources/kamelets/cassandra-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/cassandra-source.kamelet.yaml
@@ -88,7 +88,7 @@ spec:
   - "camel:jackson"
   - "camel:kamelet"
   - "camel:cassandraql"
-  flow:
+  template:
     from:
       uri: "cql://{{connectionHost}}:{{connectionPort}}/{{keyspace}}"
       parameters:

--- a/library/camel-kamelets/src/main/resources/kamelets/chuck-norris-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/chuck-norris-source.kamelet.yaml
@@ -46,7 +46,7 @@ spec:
     - "camel:timer"
     - "camel:http"
     - "camel:jsonpath"
-  flow:
+  template:
     from:
       uri: "timer:chuck"
       parameters:

--- a/library/camel-kamelets/src/main/resources/kamelets/chunk-template-action.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/chunk-template-action.kamelet.yaml
@@ -44,7 +44,7 @@ spec:
   dependencies:
   - "camel:chunk"
   - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "kamelet:source"
       steps:

--- a/library/camel-kamelets/src/main/resources/kamelets/couchbase-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/couchbase-sink.kamelet.yaml
@@ -83,7 +83,7 @@ spec:
   dependencies:
     - "camel:couchbase"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "kamelet:source"
       steps:

--- a/library/camel-kamelets/src/main/resources/kamelets/cron-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/cron-source.kamelet.yaml
@@ -54,7 +54,7 @@ spec:
   - "camel:core"
   - "camel:cron"
   - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "cron:tick"
       parameters:

--- a/library/camel-kamelets/src/main/resources/kamelets/delay-action.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/delay-action.kamelet.yaml
@@ -43,7 +43,7 @@ spec:
   dependencies:
   - "camel:core"
   - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "kamelet:source"
       steps:

--- a/library/camel-kamelets/src/main/resources/kamelets/dns-dig-action.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/dns-dig-action.kamelet.yaml
@@ -45,7 +45,7 @@ spec:
   dependencies:
     - "camel:dns"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "kamelet:source"
       steps:

--- a/library/camel-kamelets/src/main/resources/kamelets/dns-ip-action.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/dns-ip-action.kamelet.yaml
@@ -41,7 +41,7 @@ spec:
   dependencies:
     - "camel:dns"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "kamelet:source"
       steps:

--- a/library/camel-kamelets/src/main/resources/kamelets/dns-lookup-action.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/dns-lookup-action.kamelet.yaml
@@ -45,7 +45,7 @@ spec:
     - "camel:jackson"
     - "camel:dns"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "kamelet:source"
       steps:

--- a/library/camel-kamelets/src/main/resources/kamelets/drop-header-action.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/drop-header-action.kamelet.yaml
@@ -42,7 +42,7 @@ spec:
   dependencies:
     - "camel:core"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/library/camel-kamelets/src/main/resources/kamelets/drop-headers-action.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/drop-headers-action.kamelet.yaml
@@ -47,7 +47,7 @@ spec:
   dependencies:
     - "camel:core"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/library/camel-kamelets/src/main/resources/kamelets/dropbox-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/dropbox-sink.kamelet.yaml
@@ -70,7 +70,7 @@ spec:
   dependencies:
     - "camel:dropbox"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "kamelet:source"
       steps:

--- a/library/camel-kamelets/src/main/resources/kamelets/dropbox-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/dropbox-source.kamelet.yaml
@@ -72,7 +72,7 @@ spec:
     - "camel:core"
     - "camel:jsonpath"
     - "camel:timer"
-  flow:
+  template:
     from:
       uri: "timer:dropbox-stream"
       parameters:

--- a/library/camel-kamelets/src/main/resources/kamelets/earthquake-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/earthquake-source.kamelet.yaml
@@ -55,7 +55,7 @@ spec:
     - "camel:jackson"
     - "camel:jsonpath"
     - "camel:timer"
-  flow:
+  template:
     from:
       uri: "timer:earthquake"
       parameters:

--- a/library/camel-kamelets/src/main/resources/kamelets/elasticsearch-index-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/elasticsearch-index-sink.kamelet.yaml
@@ -93,7 +93,7 @@ spec:
     - "camel:elasticsearch-rest"
     - "camel:gson"
     - "camel:bean"
-  flow:
+  template:
     beans:
       - name: local-es
         type: "#class:org.apache.camel.component.elasticsearch.ElasticsearchComponent"

--- a/library/camel-kamelets/src/main/resources/kamelets/elasticsearch-search-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/elasticsearch-search-source.kamelet.yaml
@@ -89,7 +89,7 @@ spec:
       - "camel:timer"
       - "camel:elasticsearch-rest"
       - "camel:gson"
-  flow:
+  template:
     beans:
       - name: local-es
         type: "#class:org.apache.camel.component.elasticsearch.ElasticsearchComponent"

--- a/library/camel-kamelets/src/main/resources/kamelets/exec-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/exec-sink.kamelet.yaml
@@ -49,7 +49,7 @@ spec:
     - "camel:core"
     - "camel:exec"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/library/camel-kamelets/src/main/resources/kamelets/extract-field-action.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/extract-field-action.kamelet.yaml
@@ -76,7 +76,7 @@ spec:
   - "camel:kamelet"
   - "camel:core"
   - "camel:jackson"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/library/camel-kamelets/src/main/resources/kamelets/fhir-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/fhir-source.kamelet.yaml
@@ -83,7 +83,7 @@ spec:
   dependencies:
     - "camel:fhir"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "fhir://search/searchByUrl"
       parameters:

--- a/library/camel-kamelets/src/main/resources/kamelets/file-watch-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/file-watch-source.kamelet.yaml
@@ -48,7 +48,7 @@ spec:
   dependencies:
     - "camel:file-watch"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "file-watch:{{filePath}}"
       parameters:

--- a/library/camel-kamelets/src/main/resources/kamelets/freemarker-template-action.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/freemarker-template-action.kamelet.yaml
@@ -44,7 +44,7 @@ spec:
   dependencies:
   - "camel:freemarker"
   - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "kamelet:source"
       steps:

--- a/library/camel-kamelets/src/main/resources/kamelets/ftp-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/ftp-sink.kamelet.yaml
@@ -88,7 +88,7 @@ spec:
     - "camel:ftp"
     - "camel:core"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "kamelet:source"
       steps:

--- a/library/camel-kamelets/src/main/resources/kamelets/ftp-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/ftp-source.kamelet.yaml
@@ -91,7 +91,7 @@ spec:
     - "camel:ftp"
     - "camel:core"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "ftp:{{username}}@{{connectionHost}}:{{connectionPort}}/{{directoryName}}"
       parameters:

--- a/library/camel-kamelets/src/main/resources/kamelets/ftps-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/ftps-sink.kamelet.yaml
@@ -88,7 +88,7 @@ spec:
     - "camel:ftp"
     - "camel:core"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "kamelet:source"
       steps:

--- a/library/camel-kamelets/src/main/resources/kamelets/ftps-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/ftps-source.kamelet.yaml
@@ -91,7 +91,7 @@ spec:
     - "camel:ftp"
     - "camel:core"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "ftps:{{username}}@{{connectionHost}}:{{connectionPort}}/{{directoryName}}"
       parameters:

--- a/library/camel-kamelets/src/main/resources/kamelets/github-commit-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/github-commit-source.kamelet.yaml
@@ -71,7 +71,7 @@ spec:
   - "camel:jackson"
   - "camel:github"
   - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "github://commit/{{branch}}"
       parameters:

--- a/library/camel-kamelets/src/main/resources/kamelets/github-event-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/github-event-source.kamelet.yaml
@@ -60,7 +60,7 @@ spec:
   - "camel:jackson"
   - "camel:github"
   - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "github://event"
       parameters:

--- a/library/camel-kamelets/src/main/resources/kamelets/github-pullrequest-comment-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/github-pullrequest-comment-source.kamelet.yaml
@@ -60,7 +60,7 @@ spec:
   - "camel:jackson"
   - "camel:github"
   - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "github://pullRequestComment"
       parameters:

--- a/library/camel-kamelets/src/main/resources/kamelets/github-pullrequest-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/github-pullrequest-source.kamelet.yaml
@@ -60,7 +60,7 @@ spec:
   - "camel:jackson"
   - "camel:github"
   - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "github://pullRequest"
       parameters:

--- a/library/camel-kamelets/src/main/resources/kamelets/github-tag-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/github-tag-source.kamelet.yaml
@@ -60,7 +60,7 @@ spec:
   - "camel:jackson"
   - "camel:github"
   - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "github://tag"
       parameters:

--- a/library/camel-kamelets/src/main/resources/kamelets/google-calendar-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/google-calendar-source.kamelet.yaml
@@ -90,7 +90,7 @@ spec:
         title: Application name
         description: Google Calendar application name
         type: string
-      syncFlow:
+      synctemplate:
         title: Sync Flow
         description: Sync events for incremental synchronization
         type: boolean
@@ -111,7 +111,7 @@ spec:
   - "camel:jackson"
   - "camel:google-calendar"
   - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "google-calendar-stream://{{index}}"
       parameters:
@@ -122,7 +122,7 @@ spec:
         clientSecret: "{{clientSecret}}"
         delay: "{{delay}}"
         applicationName: "{{applicationName}}"
-        syncFlow: "{{syncFlow}}"
+        synctemplate: "{{syncFlow}}"
         consumeFromNow: "{{consumeFromNow}}"
       steps:
       - marshal:

--- a/library/camel-kamelets/src/main/resources/kamelets/google-functions-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/google-functions-sink.kamelet.yaml
@@ -62,7 +62,7 @@ spec:
     - "camel:kamelet"
     - "camel:google-functions"
     - "camel:jackson"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/library/camel-kamelets/src/main/resources/kamelets/google-mail-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/google-mail-source.kamelet.yaml
@@ -110,7 +110,7 @@ spec:
   - "camel:jackson"
   - "camel:kamelet"
   - "camel:google-mail"
-  flow:
+  template:
     from:
       uri: "google-mail-stream://{{index}}"
       parameters:

--- a/library/camel-kamelets/src/main/resources/kamelets/google-pubsub-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/google-pubsub-sink.kamelet.yaml
@@ -57,7 +57,7 @@ spec:
     - "camel:kamelet"
     - "camel:google-pubsub"
     - "camel:jackson"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/library/camel-kamelets/src/main/resources/kamelets/google-pubsub-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/google-pubsub-source.kamelet.yaml
@@ -74,7 +74,7 @@ spec:
     - "camel:kamelet"
     - "camel:google-pubsub"
     - "camel:jackson"
-  flow:
+  template:
     from:
       uri: "google-pubsub://{{projectId}}:{{subscriptionName}}"
       parameters:

--- a/library/camel-kamelets/src/main/resources/kamelets/google-sheets-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/google-sheets-source.kamelet.yaml
@@ -115,7 +115,7 @@ spec:
   - "camel:jackson"
   - "camel:kamelet"
   - "camel:google-sheets"
-  flow:
+  template:
     from:
       uri: "google-sheets-stream://{{index}}"
       parameters:

--- a/library/camel-kamelets/src/main/resources/kamelets/google-storage-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/google-storage-sink.kamelet.yaml
@@ -63,7 +63,7 @@ spec:
     - "camel:kamelet"
     - "camel:google-storage"
     - "camel:jackson"
-  flow:
+  template:
     from:
       uri: "kamelet:source"
       steps:

--- a/library/camel-kamelets/src/main/resources/kamelets/google-storage-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/google-storage-source.kamelet.yaml
@@ -66,7 +66,7 @@ spec:
     - "camel:kamelet"
     - "camel:google-storage"
     - "camel:jackson"
-  flow:
+  template:
     from:
       uri: "google-storage://{{bucketNameOrArn}}"
       parameters:

--- a/library/camel-kamelets/src/main/resources/kamelets/has-header-filter-action.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/has-header-filter-action.kamelet.yaml
@@ -47,7 +47,7 @@ spec:
   dependencies:
   - "camel:core"
   - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/library/camel-kamelets/src/main/resources/kamelets/header-matches-filter-action.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/header-matches-filter-action.kamelet.yaml
@@ -46,7 +46,7 @@ spec:
   dependencies:
   - "camel:core"
   - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/library/camel-kamelets/src/main/resources/kamelets/hoist-field-action.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/hoist-field-action.kamelet.yaml
@@ -43,7 +43,7 @@ spec:
   - "camel:core"
   - "camel:jackson"
   - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/library/camel-kamelets/src/main/resources/kamelets/http-secured-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/http-secured-sink.kamelet.yaml
@@ -75,7 +75,7 @@ spec:
   - "camel:http"
   - "camel:kamelet"
   - "camel:core"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/library/camel-kamelets/src/main/resources/kamelets/http-secured-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/http-secured-source.kamelet.yaml
@@ -82,7 +82,7 @@ spec:
     - "camel:kamelet"
     - "camel:core"
     - "camel:timer"
-  flow:
+  template:
     from:
       uri: "timer:fetch"
       parameters:

--- a/library/camel-kamelets/src/main/resources/kamelets/http-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/http-sink.kamelet.yaml
@@ -49,7 +49,7 @@ spec:
   - "camel:http"
   - "camel:kamelet"
   - "camel:core"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/library/camel-kamelets/src/main/resources/kamelets/http-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/http-source.kamelet.yaml
@@ -56,7 +56,7 @@ spec:
     - "camel:kamelet"
     - "camel:core"
     - "camel:timer"
-  flow:
+  template:
     from:
       uri: "timer:fetch"
       parameters:

--- a/library/camel-kamelets/src/main/resources/kamelets/infinispan-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/infinispan-sink.kamelet.yaml
@@ -92,7 +92,7 @@ spec:
     - "camel:kamelet"
     - "camel:core"
     - "camel:infinispan"
-  flow:
+  template:
     beans:
       - name: local-infinispan
         type: "#class:org.apache.camel.component.infinispan.remote.InfinispanRemoteComponent"

--- a/library/camel-kamelets/src/main/resources/kamelets/infinispan-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/infinispan-source.kamelet.yaml
@@ -92,7 +92,7 @@ spec:
     - "camel:kamelet"
     - "camel:core"
     - "camel:infinispan"
-  flow:
+  template:
     beans:
       - name: local-infinispan
         type: "#class:org.apache.camel.component.infinispan.remote.InfinispanRemoteComponent"

--- a/library/camel-kamelets/src/main/resources/kamelets/insert-field-action.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/insert-field-action.kamelet.yaml
@@ -53,7 +53,7 @@ spec:
   - "camel:core"
   - "camel:jackson"
   - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/library/camel-kamelets/src/main/resources/kamelets/insert-header-action.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/insert-header-action.kamelet.yaml
@@ -47,7 +47,7 @@ spec:
   dependencies:
     - "camel:core"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/library/camel-kamelets/src/main/resources/kamelets/is-tombstone-filter-action.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/is-tombstone-filter-action.kamelet.yaml
@@ -34,7 +34,7 @@ spec:
   dependencies:
   - "camel:core"
   - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/library/camel-kamelets/src/main/resources/kamelets/jira-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/jira-source.kamelet.yaml
@@ -70,7 +70,7 @@ spec:
   - "camel:jira"
   - "camel:kamelet"
   - "mvn:com.fasterxml.jackson.datatype:jackson-datatype-joda:2.12.5"
-  flow:
+  template:
     from:
       uri: "jira:newIssues"
       parameters:

--- a/library/camel-kamelets/src/main/resources/kamelets/jms-amqp-10-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/jms-amqp-10-sink.kamelet.yaml
@@ -54,7 +54,7 @@ spec:
   - "camel:jms"
   - "camel:kamelet"
   - "mvn:org.apache.qpid:qpid-jms-client:1.0.0"
-  flow:
+  template:
     beans:
       - name: connectionFactoryBean
         type: "#class:org.apache.qpid.jms.JmsConnectionFactory"

--- a/library/camel-kamelets/src/main/resources/kamelets/jms-amqp-10-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/jms-amqp-10-source.kamelet.yaml
@@ -54,7 +54,7 @@ spec:
   - "camel:jms"
   - "camel:kamelet"
   - "mvn:org.apache.qpid:qpid-jms-client:1.0.0"
-  flow:
+  template:
     beans:
       - name: connectionFactoryBean
         type: "#class:org.apache.qpid.jms.JmsConnectionFactory"

--- a/library/camel-kamelets/src/main/resources/kamelets/jms-apache-artemis-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/jms-apache-artemis-sink.kamelet.yaml
@@ -55,7 +55,7 @@ spec:
   - "camel:jms"
   - "camel:kamelet"
   - "mvn:org.apache.activemq:artemis-jms-client-all:2.17.0"
-  flow:
+  template:
     beans:
       - name: connectionFactoryBean
         type: "#class:org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory"

--- a/library/camel-kamelets/src/main/resources/kamelets/jms-apache-artemis-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/jms-apache-artemis-source.kamelet.yaml
@@ -54,7 +54,7 @@ spec:
   - "camel:jms"
   - "camel:kamelet"
   - "mvn:org.apache.activemq:artemis-jms-client-all:2.17.0"
-  flow:
+  template:
     beans:
       - name: connectionFactoryBean
         type: "#class:org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory"

--- a/library/camel-kamelets/src/main/resources/kamelets/jolt-transformation-action.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/jolt-transformation-action.kamelet.yaml
@@ -44,7 +44,7 @@ spec:
   dependencies:
   - "camel:jolt"
   - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "kamelet:source"
       steps:

--- a/library/camel-kamelets/src/main/resources/kamelets/json-deserialize-action.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/json-deserialize-action.kamelet.yaml
@@ -36,7 +36,7 @@ spec:
   - "camel:kamelet"
   - "camel:core"
   - "camel:jackson"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/library/camel-kamelets/src/main/resources/kamelets/json-patch-action.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/json-patch-action.kamelet.yaml
@@ -44,7 +44,7 @@ spec:
   dependencies:
   - "camel:json-patch"
   - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "kamelet:source"
       steps:

--- a/library/camel-kamelets/src/main/resources/kamelets/json-schema-validator-action.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/json-schema-validator-action.kamelet.yaml
@@ -44,7 +44,7 @@ spec:
   dependencies:
   - "camel:json-validator"
   - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "kamelet:source"
       steps:

--- a/library/camel-kamelets/src/main/resources/kamelets/json-serialize-action.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/json-serialize-action.kamelet.yaml
@@ -36,7 +36,7 @@ spec:
   - "camel:kamelet"
   - "camel:core"
   - "camel:jackson"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/library/camel-kamelets/src/main/resources/kamelets/jsonata-action.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/jsonata-action.kamelet.yaml
@@ -44,7 +44,7 @@ spec:
   dependencies:
   - "camel:jsonata"
   - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "kamelet:source"
       steps:

--- a/library/camel-kamelets/src/main/resources/kamelets/kafka-manual-commit-action.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/kafka-manual-commit-action.kamelet.yaml
@@ -34,7 +34,7 @@ spec:
   dependencies:
   - github:apache.camel-kamelets:camel-kamelets-utils:main-SNAPSHOT
   - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/library/camel-kamelets/src/main/resources/kamelets/kafka-not-secured-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/kafka-not-secured-sink.kamelet.yaml
@@ -55,7 +55,7 @@ spec:
   dependencies:
     - "camel:kafka"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "kamelet:source"
       steps:

--- a/library/camel-kamelets/src/main/resources/kamelets/kafka-not-secured-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/kafka-not-secured-source.kamelet.yaml
@@ -88,7 +88,7 @@ spec:
   dependencies:
     - "camel:kafka"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "kafka:{{topic}}"
       parameters:

--- a/library/camel-kamelets/src/main/resources/kamelets/kafka-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/kafka-sink.kamelet.yaml
@@ -81,7 +81,7 @@ spec:
   dependencies:
     - "camel:kafka"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "kamelet:source"
       steps:

--- a/library/camel-kamelets/src/main/resources/kamelets/kafka-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/kafka-source.kamelet.yaml
@@ -120,7 +120,7 @@ spec:
   dependencies:
     - "camel:kafka"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "kafka:{{topic}}"
       parameters:

--- a/library/camel-kamelets/src/main/resources/kamelets/kubernetes-namespaces-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/kubernetes-namespaces-source.kamelet.yaml
@@ -55,7 +55,7 @@ spec:
     - "camel:kubernetes"
     - "camel:kamelet"
     - "camel:jackson"
-  flow:
+  template:
     from:
       uri: "kubernetes-namespaces://{{masterUrl}}"
       parameters:

--- a/library/camel-kamelets/src/main/resources/kamelets/kubernetes-nodes-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/kubernetes-nodes-source.kamelet.yaml
@@ -59,7 +59,7 @@ spec:
     - "camel:kubernetes"
     - "camel:kamelet"
     - "camel:jackson"
-  flow:
+  template:
     from:
       uri: "kubernetes-nodes://{{masterUrl}}"
       parameters:

--- a/library/camel-kamelets/src/main/resources/kamelets/kubernetes-pods-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/kubernetes-pods-source.kamelet.yaml
@@ -59,7 +59,7 @@ spec:
     - "camel:kubernetes"
     - "camel:kamelet"
     - "camel:jackson"
-  flow:
+  template:
     from:
       uri: "kubernetes-pods://{{masterUrl}}"
       parameters:

--- a/library/camel-kamelets/src/main/resources/kamelets/log-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/log-sink.kamelet.yaml
@@ -50,7 +50,7 @@ spec:
   dependencies:
   - "camel:kamelet"
   - "camel:log"
-  flow:
+  template:
     from:
       uri: "kamelet:source"
       steps:

--- a/library/camel-kamelets/src/main/resources/kamelets/mail-imap-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/mail-imap-source.kamelet.yaml
@@ -87,7 +87,7 @@ spec:
     - "camel:core"
     - "camel:mail"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "imaps:{{connectionHost}}:{{connectionPort}}"
       parameters:

--- a/library/camel-kamelets/src/main/resources/kamelets/mail-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/mail-sink.kamelet.yaml
@@ -81,7 +81,7 @@ spec:
     - "camel:core"
     - "camel:mail"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "kamelet:source"
       steps:

--- a/library/camel-kamelets/src/main/resources/kamelets/mariadb-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/mariadb-sink.kamelet.yaml
@@ -92,7 +92,7 @@ spec:
   - "camel:kamelet"
   - "camel:sql"
   - "mvn:org.apache.commons:commons-dbcp2:2.9.0"
-  flow:
+  template:
     beans:
       - name: dsBean
         type: "#class:org.apache.commons.dbcp2.BasicDataSource"

--- a/library/camel-kamelets/src/main/resources/kamelets/mariadb-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/mariadb-source.kamelet.yaml
@@ -89,7 +89,7 @@ spec:
   - "camel:kamelet"
   - "camel:sql"
   - "mvn:org.apache.commons:commons-dbcp2:2.9.0"
-  flow:
+  template:
     beans:
       - name: dsBean
         type: "#class:org.apache.commons.dbcp2.BasicDataSource"

--- a/library/camel-kamelets/src/main/resources/kamelets/mask-field-action.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/mask-field-action.kamelet.yaml
@@ -48,7 +48,7 @@ spec:
   - "camel:jackson"
   - "camel:kamelet"
   - "camel:core"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/library/camel-kamelets/src/main/resources/kamelets/message-timestamp-router-action.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/message-timestamp-router-action.kamelet.yaml
@@ -58,7 +58,7 @@ spec:
   - "camel:jackson"
   - "camel:kamelet"
   - "camel:core"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/library/camel-kamelets/src/main/resources/kamelets/minio-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/minio-sink.kamelet.yaml
@@ -79,7 +79,7 @@ spec:
   dependencies:
     - "camel:minio"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "kamelet:source"
       steps:

--- a/library/camel-kamelets/src/main/resources/kamelets/minio-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/minio-source.kamelet.yaml
@@ -84,7 +84,7 @@ spec:
   - "camel:jackson"
   - "camel:minio"
   - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "minio:{{bucketName}}"
       parameters:

--- a/library/camel-kamelets/src/main/resources/kamelets/mongodb-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/mongodb-sink.kamelet.yaml
@@ -87,7 +87,7 @@ spec:
     - "camel:kamelet"
     - "camel:mongodb"
     - "camel:jackson"
-  flow:
+  template:
     beans:
       - name: local-mongodb
         type: "#class:org.apache.camel.component.mongodb.MongoDbComponent"

--- a/library/camel-kamelets/src/main/resources/kamelets/mongodb-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/mongodb-source.kamelet.yaml
@@ -82,7 +82,7 @@ spec:
     - "camel:kamelet"
     - "camel:mongodb"
     - "camel:jackson"
-  flow:
+  template:
     beans:
       - name: local-mongodb
         type: "#class:org.apache.camel.component.mongodb.MongoDbComponent"

--- a/library/camel-kamelets/src/main/resources/kamelets/mqtt-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/mqtt-sink.kamelet.yaml
@@ -63,7 +63,7 @@ spec:
   dependencies:
     - "camel:paho"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/library/camel-kamelets/src/main/resources/kamelets/mqtt-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/mqtt-source.kamelet.yaml
@@ -68,7 +68,7 @@ spec:
   dependencies:
     - "camel:paho"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: paho:{{topic}}
       parameters:

--- a/library/camel-kamelets/src/main/resources/kamelets/mustache-template-action.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/mustache-template-action.kamelet.yaml
@@ -44,7 +44,7 @@ spec:
   dependencies:
   - "camel:mustache"
   - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "kamelet:source"
       steps:

--- a/library/camel-kamelets/src/main/resources/kamelets/mvel-template-action.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/mvel-template-action.kamelet.yaml
@@ -44,7 +44,7 @@ spec:
   dependencies:
   - "camel:mvel"
   - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "kamelet:source"
       steps:

--- a/library/camel-kamelets/src/main/resources/kamelets/mysql-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/mysql-sink.kamelet.yaml
@@ -92,7 +92,7 @@ spec:
   - "camel:kamelet"
   - "camel:sql"
   - "mvn:org.apache.commons:commons-dbcp2:2.9.0"
-  flow:
+  template:
     beans:
       - name: dsBean
         type: "#class:org.apache.commons.dbcp2.BasicDataSource"

--- a/library/camel-kamelets/src/main/resources/kamelets/mysql-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/mysql-source.kamelet.yaml
@@ -89,7 +89,7 @@ spec:
   - "camel:kamelet"
   - "camel:sql"
   - "mvn:org.apache.commons:commons-dbcp2:2.9.0"
-  flow:
+  template:
     beans:
       - name: dsBean
         type: "#class:org.apache.commons.dbcp2.BasicDataSource"

--- a/library/camel-kamelets/src/main/resources/kamelets/nats-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/nats-sink.kamelet.yaml
@@ -47,7 +47,7 @@ spec:
   dependencies:
   - "camel:nats"
   - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "kamelet:source"
       steps:

--- a/library/camel-kamelets/src/main/resources/kamelets/nats-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/nats-source.kamelet.yaml
@@ -51,7 +51,7 @@ spec:
   - "camel:jackson"
   - "camel:nats"
   - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "nats:{{topic}}"
       parameters:

--- a/library/camel-kamelets/src/main/resources/kamelets/openai-classification-action.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/openai-classification-action.kamelet.yaml
@@ -80,7 +80,7 @@ spec:
   - "camel:core"
   - "camel:kamelet"
   - "camel:http"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/library/camel-kamelets/src/main/resources/kamelets/openai-completion-action.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/openai-completion-action.kamelet.yaml
@@ -72,7 +72,7 @@ spec:
   - "camel:core"
   - "camel:kamelet"
   - "camel:http"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/library/camel-kamelets/src/main/resources/kamelets/pdf-action.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/pdf-action.kamelet.yaml
@@ -55,7 +55,7 @@ spec:
   dependencies:
   - "camel:pdf"
   - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "kamelet:source"
       steps:

--- a/library/camel-kamelets/src/main/resources/kamelets/postgresql-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/postgresql-sink.kamelet.yaml
@@ -89,7 +89,7 @@ spec:
   - "camel:sql"
   - "mvn:org.postgresql:postgresql:42.2.14"
   - "mvn:org.apache.commons:commons-dbcp2:2.9.0"
-  flow:
+  template:
     beans:
       - name: dsBean
         type: "#class:org.apache.commons.dbcp2.BasicDataSource"

--- a/library/camel-kamelets/src/main/resources/kamelets/postgresql-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/postgresql-source.kamelet.yaml
@@ -86,7 +86,7 @@ spec:
   - "camel:sql"
   - "mvn:org.postgresql:postgresql:42.2.14"
   - "mvn:org.apache.commons:commons-dbcp2:2.9.0"
-  flow:
+  template:
     beans:
       - name: dsBean
         type: "#class:org.apache.commons.dbcp2.BasicDataSource"

--- a/library/camel-kamelets/src/main/resources/kamelets/predicate-filter-action.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/predicate-filter-action.kamelet.yaml
@@ -43,7 +43,7 @@ spec:
   - "camel:core"
   - "camel:kamelet"
   - "camel:jsonpath"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/library/camel-kamelets/src/main/resources/kamelets/protobuf-deserialize-action.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/protobuf-deserialize-action.kamelet.yaml
@@ -44,7 +44,7 @@ spec:
   - "camel:kamelet"
   - "camel:core"
   - "camel:jackson-protobuf"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/library/camel-kamelets/src/main/resources/kamelets/protobuf-serialize-action.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/protobuf-serialize-action.kamelet.yaml
@@ -44,7 +44,7 @@ spec:
   - "camel:kamelet"
   - "camel:core"
   - "camel:jackson-protobuf"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/library/camel-kamelets/src/main/resources/kamelets/pulsar-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/pulsar-sink.kamelet.yaml
@@ -147,7 +147,7 @@ spec:
         type: int
         default: 30000
     type: object
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/library/camel-kamelets/src/main/resources/kamelets/pulsar-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/pulsar-source.kamelet.yaml
@@ -144,7 +144,7 @@ spec:
         x-descriptors:
           - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
     type: object
-  flow:
+  template:
     from:
       uri: pulsar:{{topicType}}/{{tenant}}/{{namespaceName}}/{{topic}}
       parameters:

--- a/library/camel-kamelets/src/main/resources/kamelets/rabbitmq-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/rabbitmq-source.kamelet.yaml
@@ -70,7 +70,7 @@ spec:
   dependencies:
     - "camel:rabbitmq"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "rabbitmq://{{exchangeName}}"
       parameters:

--- a/library/camel-kamelets/src/main/resources/kamelets/redis-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/redis-sink.kamelet.yaml
@@ -63,7 +63,7 @@ spec:
     - "camel:kamelet"
     - "camel:core"
     - "camel:spring-redis"
-  flow:
+  template:
     from:
       uri: "kamelet:source"
       steps:

--- a/library/camel-kamelets/src/main/resources/kamelets/redis-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/redis-source.kamelet.yaml
@@ -63,7 +63,7 @@ spec:
     - "camel:kamelet"
     - "camel:core"
     - "camel:spring-redis"
-  flow:
+  template:
     from:
       uri: "spring-redis:{{redisHost}}:{{redisPort}}"
       parameters:

--- a/library/camel-kamelets/src/main/resources/kamelets/regex-router-action.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/regex-router-action.kamelet.yaml
@@ -47,7 +47,7 @@ spec:
   - github:apache.camel-kamelets:camel-kamelets-utils:main-SNAPSHOT
   - "camel:kamelet"
   - "camel:core"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/library/camel-kamelets/src/main/resources/kamelets/replace-field-action.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/replace-field-action.kamelet.yaml
@@ -68,7 +68,7 @@ spec:
   - "camel:core"
   - "camel:jackson"
   - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/library/camel-kamelets/src/main/resources/kamelets/salesforce-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/salesforce-source.kamelet.yaml
@@ -95,7 +95,7 @@ spec:
   - "camel:jackson"
   - "camel:salesforce"
   - "camel:kamelet"
-  flow:
+  template:
     beans:
       - name: local-salesforce
         type: "#class:org.apache.camel.component.salesforce.SalesforceComponent"

--- a/library/camel-kamelets/src/main/resources/kamelets/sftp-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/sftp-sink.kamelet.yaml
@@ -88,7 +88,7 @@ spec:
     - "camel:ftp"
     - "camel:core"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "kamelet:source"
       steps:

--- a/library/camel-kamelets/src/main/resources/kamelets/sftp-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/sftp-source.kamelet.yaml
@@ -91,7 +91,7 @@ spec:
     - "camel:ftp"
     - "camel:core"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "sftp:{{username}}@{{connectionHost}}:{{connectionPort}}/{{directoryName}}"
       parameters:

--- a/library/camel-kamelets/src/main/resources/kamelets/slack-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/slack-sink.kamelet.yaml
@@ -68,7 +68,7 @@ spec:
   - "camel:jackson"
   - "camel:slack"
   - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "kamelet:source"
       steps:

--- a/library/camel-kamelets/src/main/resources/kamelets/slack-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/slack-source.kamelet.yaml
@@ -61,7 +61,7 @@ spec:
   - "camel:gson"
   - "camel:slack"
   - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "slack:{{channel}}"
       parameters:

--- a/library/camel-kamelets/src/main/resources/kamelets/solr-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/solr-sink.kamelet.yaml
@@ -73,7 +73,7 @@ spec:
   - "camel:core"
   - "camel:jackson"
   - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "kamelet:source"
       steps:

--- a/library/camel-kamelets/src/main/resources/kamelets/solr-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/solr-source.kamelet.yaml
@@ -78,7 +78,7 @@ spec:
   - "camel:timer"
   - "camel:jackson"
   - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "timer:solr-stream"
       parameters:

--- a/library/camel-kamelets/src/main/resources/kamelets/sqlserver-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/sqlserver-sink.kamelet.yaml
@@ -92,7 +92,7 @@ spec:
   - "camel:kamelet"
   - "camel:sql"
   - "mvn:org.apache.commons:commons-dbcp2:2.9.0"
-  flow:
+  template:
     beans:
       - name: dsBean
         type: "#class:org.apache.commons.dbcp2.BasicDataSource"

--- a/library/camel-kamelets/src/main/resources/kamelets/sqlserver-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/sqlserver-source.kamelet.yaml
@@ -89,7 +89,7 @@ spec:
   - "camel:kamelet"
   - "camel:sql"
   - "mvn:org.apache.commons:commons-dbcp2:2.9.0"
-  flow:
+  template:
     beans:
       - name: dsBean
         type: "#class:org.apache.commons.dbcp2.BasicDataSource"

--- a/library/camel-kamelets/src/main/resources/kamelets/ssh-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/ssh-sink.kamelet.yaml
@@ -70,7 +70,7 @@ spec:
     - "camel:ssh"
     - "camel:gson"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "kamelet:source"
       steps:

--- a/library/camel-kamelets/src/main/resources/kamelets/ssh-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/ssh-source.kamelet.yaml
@@ -75,7 +75,7 @@ spec:
   dependencies:
     - "camel:ssh"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "ssh://{{connectionHost}}:{{connectionPort}}"
       parameters:

--- a/library/camel-kamelets/src/main/resources/kamelets/string-template-action.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/string-template-action.kamelet.yaml
@@ -44,7 +44,7 @@ spec:
   dependencies:
   - "camel:stringtemplate"
   - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "kamelet:source"
       steps:

--- a/library/camel-kamelets/src/main/resources/kamelets/telegram-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/telegram-sink.kamelet.yaml
@@ -67,7 +67,7 @@ spec:
     - "camel:jackson"
     - "camel:kamelet"
     - "camel:telegram"
-  flow:
+  template:
     from:
       uri: "kamelet:source"
       steps:

--- a/library/camel-kamelets/src/main/resources/kamelets/telegram-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/telegram-source.kamelet.yaml
@@ -58,7 +58,7 @@ spec:
     - "camel:kamelet"
     - "camel:telegram"
     - "camel:core"
-  flow:
+  template:
     from:
       uri: telegram:bots
       parameters:

--- a/library/camel-kamelets/src/main/resources/kamelets/throttle-action.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/throttle-action.kamelet.yaml
@@ -47,7 +47,7 @@ spec:
   dependencies:
     - "camel:core"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/library/camel-kamelets/src/main/resources/kamelets/timer-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/timer-source.kamelet.yaml
@@ -55,7 +55,7 @@ spec:
     - "camel:core"
     - "camel:timer"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: timer:tick
       parameters:

--- a/library/camel-kamelets/src/main/resources/kamelets/timestamp-router-action.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/timestamp-router-action.kamelet.yaml
@@ -51,7 +51,7 @@ spec:
   - github:apache.camel-kamelets:camel-kamelets-utils:main-SNAPSHOT
   - "camel:kamelet"
   - "camel:core"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/library/camel-kamelets/src/main/resources/kamelets/topic-name-matches-filter-action.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/topic-name-matches-filter-action.kamelet.yaml
@@ -41,7 +41,7 @@ spec:
   dependencies:
   - "camel:core"
   - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/library/camel-kamelets/src/main/resources/kamelets/twitter-directmessage-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/twitter-directmessage-source.kamelet.yaml
@@ -86,7 +86,7 @@ spec:
     - "camel:jackson"
     - "camel:twitter"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "twitter-directmessage:{{user}}"
       parameters:

--- a/library/camel-kamelets/src/main/resources/kamelets/twitter-search-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/twitter-search-source.kamelet.yaml
@@ -86,7 +86,7 @@ spec:
     - "camel:jackson"
     - "camel:twitter"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "twitter-search:{{keywords}}"
       parameters:

--- a/library/camel-kamelets/src/main/resources/kamelets/twitter-timeline-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/twitter-timeline-source.kamelet.yaml
@@ -86,7 +86,7 @@ spec:
     - "camel:jackson"
     - "camel:twitter"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "twitter-timeline:user"
       parameters:

--- a/library/camel-kamelets/src/main/resources/kamelets/value-to-key-action.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/value-to-key-action.kamelet.yaml
@@ -43,7 +43,7 @@ spec:
   - "camel:core"
   - "camel:jackson"
   - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/library/camel-kamelets/src/main/resources/kamelets/velocity-template-action.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/velocity-template-action.kamelet.yaml
@@ -44,7 +44,7 @@ spec:
   dependencies:
   - "camel:velocity"
   - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "kamelet:source"
       steps:

--- a/library/camel-kamelets/src/main/resources/kamelets/webhook-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/webhook-source.kamelet.yaml
@@ -47,7 +47,7 @@ spec:
   dependencies:
     - "camel:platform-http"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "platform-http:///{{subpath}}"
       steps:

--- a/library/camel-kamelets/src/main/resources/kamelets/websocket-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/websocket-source.kamelet.yaml
@@ -96,7 +96,7 @@ spec:
     - "camel:kamelet"
     - "camel:core"
     - "camel:websocket"
-  flow:
+  template:
     from:
       uri: "websocket://{{websocketHost}}:{{websocketPort}}/{{resourceUri}}"
       parameters:

--- a/library/camel-kamelets/src/main/resources/kamelets/wttrin-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/wttrin-source.kamelet.yaml
@@ -63,7 +63,7 @@ spec:
     - "camel:jsonpath"
     - "camel:kamelet"
     - "camel:timer"
-  flow:
+  template:
     from:
       uri: timer:wttr.in
       parameters:

--- a/library/camel-kamelets/src/main/resources/kamelets/xj-identity-action.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/xj-identity-action.kamelet.yaml
@@ -42,7 +42,7 @@ spec:
   dependencies:
   - "camel:xj"
   - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "kamelet:source"
       steps:

--- a/library/camel-kamelets/src/main/resources/kamelets/xj-template-action.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/xj-template-action.kamelet.yaml
@@ -49,7 +49,7 @@ spec:
   dependencies:
   - "camel:xj"
   - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "kamelet:source"
       steps:

--- a/templates/init-template.kamelet.yaml.vm
+++ b/templates/init-template.kamelet.yaml.vm
@@ -34,7 +34,7 @@ spec:
 #end
   dependencies:
   - "${kamelet.dependency}"
-  flow:
+  template:
 #if ($kameletBeans.size() > 0)
     beans:
 #end


### PR DESCRIPTION
This PR span over all the list of Kamelets as we've deprecated since a while `.spec.flow` parameter in favour of `.spec.template`. https://github.com/apache/camel-k/pull/2932 will remove it from next `camel-k` spec (1.9), so we must apply this change before that PR is merged as well.