### PR TITLE
Support Default Credentials Provider for AWS Kamelets in 0.7.x

### DIFF
--- a/kamelets/aws-kinesis-sink.kamelet.yaml
+++ b/kamelets/aws-kinesis-sink.kamelet.yaml
@@ -80,7 +80,7 @@ spec:
         example: eu-west-1
       useDefaultCredentialsProvider:
         title: Default Credentials Provider
-        description: Set whether the Kinesis Firehose client should expect to load credentials through a default credentials provider or to expect static credentials to be passed in.
+        description: Set whether the Kinesis client should expect to load credentials through a default credentials provider or to expect static credentials to be passed in.
         type: boolean
         x-descriptors:
         - 'urn:alm:descriptor:com.tectonic.ui:checkbox'

--- a/kamelets/aws-kinesis-source.kamelet.yaml
+++ b/kamelets/aws-kinesis-source.kamelet.yaml
@@ -68,7 +68,7 @@ spec:
         example: eu-west-1
       useDefaultCredentialsProvider:
         title: Default Credentials Provider
-        description: Set whether the Kinesis Firehose client should expect to load credentials through a default credentials provider or to expect static credentials to be passed in.
+        description: Set whether the Kinesis client should expect to load credentials through a default credentials provider or to expect static credentials to be passed in.
         type: boolean
         x-descriptors:
         - 'urn:alm:descriptor:com.tectonic.ui:checkbox'

--- a/kamelets/aws-lambda-sink.kamelet.yaml
+++ b/kamelets/aws-lambda-sink.kamelet.yaml
@@ -68,7 +68,7 @@ spec:
         example: eu-west-1
       useDefaultCredentialsProvider:
         title: Default Credentials Provider
-        description: Set whether the Kinesis Firehose client should expect to load credentials through a default credentials provider or to expect static credentials to be passed in.
+        description: Set whether the Lambda client should expect to load credentials through a default credentials provider or to expect static credentials to be passed in.
         type: boolean
         x-descriptors:
         - 'urn:alm:descriptor:com.tectonic.ui:checkbox'

--- a/kamelets/aws-s3-streaming-upload-sink.kamelet.yaml
+++ b/kamelets/aws-s3-streaming-upload-sink.kamelet.yaml
@@ -111,7 +111,7 @@ spec:
         type: string
       useDefaultCredentialsProvider:
         title: Default Credentials Provider
-        description: Set whether the Kinesis Firehose client should expect to load credentials through a default credentials provider or to expect static credentials to be passed in.
+        description: Set whether the S3 client should expect to load credentials through a default credentials provider or to expect static credentials to be passed in.
         type: boolean
         x-descriptors:
         - 'urn:alm:descriptor:com.tectonic.ui:checkbox'

--- a/kamelets/aws-s3-streaming-upload-sink.kamelet.yaml
+++ b/kamelets/aws-s3-streaming-upload-sink.kamelet.yaml
@@ -32,10 +32,12 @@ spec:
     title: "AWS S3 Streaming upload Sink"
     description: |-
       Upload data to AWS S3 in streaming upload mode.
+
+      Access Key/Secret Key are the basic method for authenticating to the AWS S3 Service. These parameters are optional, because the Kamelet provide also the 'useDefaultCredentialsProvider'.
+      
+      When using a default Credentials Provider the S3 client will load the credentials through this provider and won't use the static credential. This is reason for not having the access key and secret key as mandatory parameter for this Kamelet.
     required:
       - bucketNameOrArn
-      - accessKey
-      - secretKey
       - region
       - keyName
     type: object
@@ -107,6 +109,13 @@ spec:
         title: Key Name
         description: Setting the key name for an element in the bucket through endpoint parameter. In Streaming Upload, with the default configuration, this will be the base for the progressive creation of files.
         type: string
+      useDefaultCredentialsProvider:
+        title: Default Credentials Provider
+        description: Set whether the Kinesis Firehose client should expect to load credentials through a default credentials provider or to expect static credentials to be passed in.
+        type: boolean
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+        default: false
   dependencies:
     - "camel:aws2-s3"
     - "camel:kamelet"
@@ -117,8 +126,8 @@ spec:
       - to:
           uri: "aws2-s3:{{bucketNameOrArn}}"
           parameters:
-            secretKey: "{{secretKey}}"
-            accessKey: "{{accessKey}}"
+            secretKey: "{{?secretKey}}"
+            accessKey: "{{?accessKey}}"
             region: "{{region}}"
             autoCreateBucket: "{{autoCreateBucket}}"
             streamingUploadMode: "{{streamingUploadMode}}"
@@ -128,4 +137,5 @@ spec:
             namingStrategy: "{{namingStrategy}}"
             keyName: "{{keyName}}"
             streamingUploadTimeout: "{{?streamingUploadTimeout}}"
+            useDefaultCredentialsProvider: "{{useDefaultCredentialsProvider}}"
 

--- a/kamelets/aws-secrets-manager-sink.kamelet.yaml
+++ b/kamelets/aws-secrets-manager-sink.kamelet.yaml
@@ -69,7 +69,7 @@ spec:
         example: eu-west-1
       useDefaultCredentialsProvider:
         title: Default Credentials Provider
-        description: Set whether the Kinesis Firehose client should expect to load credentials through a default credentials provider or to expect static credentials to be passed in.
+        description: Set whether the Secrets Manager client should expect to load credentials through a default credentials provider or to expect static credentials to be passed in.
         type: boolean
         x-descriptors:
         - 'urn:alm:descriptor:com.tectonic.ui:checkbox'

--- a/kamelets/aws-secrets-manager-sink.kamelet.yaml
+++ b/kamelets/aws-secrets-manager-sink.kamelet.yaml
@@ -31,7 +31,11 @@ spec:
   definition:
     title: "AWS Secrets Manager Sink"
     description: |-
-      Create a secret in AWS Secrets Manager
+      Create a secret in AWS Secrets Manager.
+
+      Access Key/Secret Key are the basic method for authenticating to the AWS Secrets Manager Service. These parameters are optional, because the Kamelet provide also the 'useDefaultCredentialsProvider'.
+      
+      When using a default Credentials Provider the Secrets Manager client will load the credentials through this provider and won't use the static credential. This is reason for not having the access key and secret key as mandatory parameter for this Kamelet.
 
       The Kamelet expects the following headers to be set:
 
@@ -39,8 +43,6 @@ spec:
 
       If the header won't be set the exchange ID will be used as secret name.
     required:
-      - accessKey
-      - secretKey
       - region
     type: object
     properties:
@@ -65,6 +67,13 @@ spec:
         description: The AWS region to connect to.
         type: string
         example: eu-west-1
+      useDefaultCredentialsProvider:
+        title: Default Credentials Provider
+        description: Set whether the Kinesis Firehose client should expect to load credentials through a default credentials provider or to expect static credentials to be passed in.
+        type: boolean
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+        default: false
   dependencies:
     - "camel:core"
     - "camel:aws-secrets-manager"
@@ -93,7 +102,8 @@ spec:
       - to:
           uri: "aws-secrets-manager:kamelet"
           parameters:
-            secretKey: "{{secretKey}}"
-            accessKey: "{{accessKey}}"
+            secretKey: "{{?secretKey}}"
+            accessKey: "{{?accessKey}}"
             region: "{{region}}"
+            useDefaultCredentialsProvider: "{{useDefaultCredentialsProvider}}"
             operation: "createSecret"

--- a/kamelets/aws-ses-sink.kamelet.yaml
+++ b/kamelets/aws-ses-sink.kamelet.yaml
@@ -33,6 +33,10 @@ spec:
     description: |-
       Send Email through AWS SES Service.
 
+      Access Key/Secret Key are the basic method for authenticating to the AWS SES Service. These parameters are optional, because the Kamelet provide also the 'useDefaultCredentialsProvider'.
+      
+      When using a default Credentials Provider the SES client will load the credentials through this provider and won't use the static credential. This is reason for not having the access key and secret key as mandatory parameter for this Kamelet.
+
       The Kamelet expects the following headers to be set:
 
       - `subject` / `ce-subject`: The email subject
@@ -45,8 +49,6 @@ spec:
 
     required:
       - from
-      - accessKey
-      - secretKey
       - region
     type: object
     properties:
@@ -76,6 +78,13 @@ spec:
         description: The AWS region to connect to.
         type: string
         example: eu-west-1
+      useDefaultCredentialsProvider:
+        title: Default Credentials Provider
+        description: Set whether the SES client should expect to load credentials through a default credentials provider or to expect static credentials to be passed in.
+        type: boolean
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+        default: false
   dependencies:
     - "camel:core"
     - "camel:aws2-ses"
@@ -128,6 +137,7 @@ spec:
       - to:
           uri: "aws2-ses://{{from}}"
           parameters:
-            secretKey: "{{secretKey}}"
-            accessKey: "{{accessKey}}"
+            secretKey: "{{?secretKey}}"
+            accessKey: "{{?accessKey}}"
             region: "{{region}}"
+            useDefaultCredentialsProvider: "{{useDefaultCredentialsProvider}}"

--- a/kamelets/aws-sns-fifo-sink.kamelet.yaml
+++ b/kamelets/aws-sns-fifo-sink.kamelet.yaml
@@ -31,15 +31,17 @@ spec:
   definition:
     title: AWS SNS FIFO Sink
     description: |- 
-      Send message to an AWS SNS FIFO Topic
+      Send message to an AWS SNS FIFO Topic.
+
+      Access Key/Secret Key are the basic method for authenticating to the AWS SNS Service. These parameters are optional, because the Kamelet provide also the 'useDefaultCredentialsProvider'.
+      
+      When using a default Credentials Provider the SNS client will load the credentials through this provider and won't use the static credential. This is reason for not having the access key and secret key as mandatory parameter for this Kamelet.
 
       The Kamelet expects the following headers to be set:
 
       - `subject` / `ce-subject`: the subject of the message
     required:
       - topicNameOrArn
-      - accessKey
-      - secretKey
       - region
     type: object
     properties:
@@ -78,6 +80,13 @@ spec:
       autoCreateTopic:
         title: Autocreate Topic
         description: Setting the autocreation of the SNS topic. 
+        type: boolean
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+        default: false
+      useDefaultCredentialsProvider:
+        title: Default Credentials Provider
+        description: Set whether the SNS client should expect to load credentials through a default credentials provider or to expect static credentials to be passed in.
         type: boolean
         x-descriptors:
         - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
@@ -130,9 +139,10 @@ spec:
                 uri: "aws2-sns:{{topicNameOrArn}}"
                 parameters:
                   autoCreateTopic: "{{autoCreateTopic}}"
-                  accessKey: "{{accessKey}}"
-                  secretKey: "{{secretKey}}"
+                  accessKey: "{{?accessKey}}"
+                  secretKey: "{{?secretKey}}"
                   region: "{{region}}"
+                  useDefaultCredentialsProvider: "{{useDefaultCredentialsProvider}}"
                   messageGroupIdStrategy: "usePropertyValue"
                   messageDeduplicationIdStrategy: "useContentBasedDeduplication"
           otherwise:
@@ -141,8 +151,9 @@ spec:
                 uri: "aws2-sns:{{topicNameOrArn}}"
                 parameters:
                   autoCreateTopic: "{{autoCreateTopic}}"
-                  accessKey: "{{accessKey}}"
-                  secretKey: "{{secretKey}}"
+                  accessKey: "{{?accessKey}}"
+                  secretKey: "{{?secretKey}}"
                   region: "{{region}}"
+                  useDefaultCredentialsProvider: "{{useDefaultCredentialsProvider}}"
                   messageGroupIdStrategy: "usePropertyValue"
                   messageDeduplicationIdStrategy: "useExchangeId"

--- a/kamelets/aws-sns-sink.kamelet.yaml
+++ b/kamelets/aws-sns-sink.kamelet.yaml
@@ -31,15 +31,17 @@ spec:
   definition:
     title: AWS SNS Sink
     description: |-
-      Send message to an AWS SNS Topic
+      Send message to an AWS SNS Topic.
+
+      Access Key/Secret Key are the basic method for authenticating to the AWS SNS Service. These parameters are optional, because the Kamelet provide also the 'useDefaultCredentialsProvider'.
+      
+      When using a default Credentials Provider the SNS client will load the credentials through this provider and won't use the static credential. This is reason for not having the access key and secret key as mandatory parameter for this Kamelet.
 
       The Kamelet expects the following headers to be set:
 
       - `subject` / `ce-subject`: the subject of the message
     required:
       - topicNameOrArn
-      - accessKey
-      - secretKey
       - region
     type: object
     properties:
@@ -75,6 +77,13 @@ spec:
         x-descriptors:
         - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
+      useDefaultCredentialsProvider:
+        title: Default Credentials Provider
+        description: Set whether the SNS client should expect to load credentials through a default credentials provider or to expect static credentials to be passed in.
+        type: boolean
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+        default: false
   dependencies:
     - "camel:core"
     - "camel:aws2-sns"
@@ -99,6 +108,7 @@ spec:
           uri: "aws2-sns:{{topicNameOrArn}}"
           parameters:
             autoCreateTopic: "{{autoCreateTopic}}"
-            accessKey: "{{accessKey}}"
-            secretKey: "{{secretKey}}"
+            accessKey: "{{?accessKey}}"
+            secretKey: "{{?secretKey}}"
             region: "{{region}}"
+            useDefaultCredentialsProvider: "{{useDefaultCredentialsProvider}}"

--- a/library/camel-kamelets/src/main/resources/kamelets/aws-kinesis-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/aws-kinesis-sink.kamelet.yaml
@@ -80,7 +80,7 @@ spec:
         example: eu-west-1
       useDefaultCredentialsProvider:
         title: Default Credentials Provider
-        description: Set whether the Kinesis Firehose client should expect to load credentials through a default credentials provider or to expect static credentials to be passed in.
+        description: Set whether the Kinesis client should expect to load credentials through a default credentials provider or to expect static credentials to be passed in.
         type: boolean
         x-descriptors:
         - 'urn:alm:descriptor:com.tectonic.ui:checkbox'

--- a/library/camel-kamelets/src/main/resources/kamelets/aws-kinesis-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/aws-kinesis-source.kamelet.yaml
@@ -68,7 +68,7 @@ spec:
         example: eu-west-1
       useDefaultCredentialsProvider:
         title: Default Credentials Provider
-        description: Set whether the Kinesis Firehose client should expect to load credentials through a default credentials provider or to expect static credentials to be passed in.
+        description: Set whether the Kinesis client should expect to load credentials through a default credentials provider or to expect static credentials to be passed in.
         type: boolean
         x-descriptors:
         - 'urn:alm:descriptor:com.tectonic.ui:checkbox'

--- a/library/camel-kamelets/src/main/resources/kamelets/aws-lambda-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/aws-lambda-sink.kamelet.yaml
@@ -68,7 +68,7 @@ spec:
         example: eu-west-1
       useDefaultCredentialsProvider:
         title: Default Credentials Provider
-        description: Set whether the Kinesis Firehose client should expect to load credentials through a default credentials provider or to expect static credentials to be passed in.
+        description: Set whether the Lambda client should expect to load credentials through a default credentials provider or to expect static credentials to be passed in.
         type: boolean
         x-descriptors:
         - 'urn:alm:descriptor:com.tectonic.ui:checkbox'

--- a/library/camel-kamelets/src/main/resources/kamelets/aws-s3-streaming-upload-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/aws-s3-streaming-upload-sink.kamelet.yaml
@@ -111,7 +111,7 @@ spec:
         type: string
       useDefaultCredentialsProvider:
         title: Default Credentials Provider
-        description: Set whether the Kinesis Firehose client should expect to load credentials through a default credentials provider or to expect static credentials to be passed in.
+        description: Set whether the S3 client should expect to load credentials through a default credentials provider or to expect static credentials to be passed in.
         type: boolean
         x-descriptors:
         - 'urn:alm:descriptor:com.tectonic.ui:checkbox'

--- a/library/camel-kamelets/src/main/resources/kamelets/aws-s3-streaming-upload-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/aws-s3-streaming-upload-sink.kamelet.yaml
@@ -32,10 +32,12 @@ spec:
     title: "AWS S3 Streaming upload Sink"
     description: |-
       Upload data to AWS S3 in streaming upload mode.
+
+      Access Key/Secret Key are the basic method for authenticating to the AWS S3 Service. These parameters are optional, because the Kamelet provide also the 'useDefaultCredentialsProvider'.
+      
+      When using a default Credentials Provider the S3 client will load the credentials through this provider and won't use the static credential. This is reason for not having the access key and secret key as mandatory parameter for this Kamelet.
     required:
       - bucketNameOrArn
-      - accessKey
-      - secretKey
       - region
       - keyName
     type: object
@@ -107,6 +109,13 @@ spec:
         title: Key Name
         description: Setting the key name for an element in the bucket through endpoint parameter. In Streaming Upload, with the default configuration, this will be the base for the progressive creation of files.
         type: string
+      useDefaultCredentialsProvider:
+        title: Default Credentials Provider
+        description: Set whether the Kinesis Firehose client should expect to load credentials through a default credentials provider or to expect static credentials to be passed in.
+        type: boolean
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+        default: false
   dependencies:
     - "camel:aws2-s3"
     - "camel:kamelet"
@@ -117,8 +126,8 @@ spec:
       - to:
           uri: "aws2-s3:{{bucketNameOrArn}}"
           parameters:
-            secretKey: "{{secretKey}}"
-            accessKey: "{{accessKey}}"
+            secretKey: "{{?secretKey}}"
+            accessKey: "{{?accessKey}}"
             region: "{{region}}"
             autoCreateBucket: "{{autoCreateBucket}}"
             streamingUploadMode: "{{streamingUploadMode}}"
@@ -128,4 +137,5 @@ spec:
             namingStrategy: "{{namingStrategy}}"
             keyName: "{{keyName}}"
             streamingUploadTimeout: "{{?streamingUploadTimeout}}"
+            useDefaultCredentialsProvider: "{{useDefaultCredentialsProvider}}"
 

--- a/library/camel-kamelets/src/main/resources/kamelets/aws-secrets-manager-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/aws-secrets-manager-sink.kamelet.yaml
@@ -69,7 +69,7 @@ spec:
         example: eu-west-1
       useDefaultCredentialsProvider:
         title: Default Credentials Provider
-        description: Set whether the Kinesis Firehose client should expect to load credentials through a default credentials provider or to expect static credentials to be passed in.
+        description: Set whether the Secrets Manager client should expect to load credentials through a default credentials provider or to expect static credentials to be passed in.
         type: boolean
         x-descriptors:
         - 'urn:alm:descriptor:com.tectonic.ui:checkbox'

--- a/library/camel-kamelets/src/main/resources/kamelets/aws-secrets-manager-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/aws-secrets-manager-sink.kamelet.yaml
@@ -31,7 +31,11 @@ spec:
   definition:
     title: "AWS Secrets Manager Sink"
     description: |-
-      Create a secret in AWS Secrets Manager
+      Create a secret in AWS Secrets Manager.
+
+      Access Key/Secret Key are the basic method for authenticating to the AWS Secrets Manager Service. These parameters are optional, because the Kamelet provide also the 'useDefaultCredentialsProvider'.
+      
+      When using a default Credentials Provider the Secrets Manager client will load the credentials through this provider and won't use the static credential. This is reason for not having the access key and secret key as mandatory parameter for this Kamelet.
 
       The Kamelet expects the following headers to be set:
 
@@ -39,8 +43,6 @@ spec:
 
       If the header won't be set the exchange ID will be used as secret name.
     required:
-      - accessKey
-      - secretKey
       - region
     type: object
     properties:
@@ -65,6 +67,13 @@ spec:
         description: The AWS region to connect to.
         type: string
         example: eu-west-1
+      useDefaultCredentialsProvider:
+        title: Default Credentials Provider
+        description: Set whether the Kinesis Firehose client should expect to load credentials through a default credentials provider or to expect static credentials to be passed in.
+        type: boolean
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+        default: false
   dependencies:
     - "camel:core"
     - "camel:aws-secrets-manager"
@@ -93,7 +102,8 @@ spec:
       - to:
           uri: "aws-secrets-manager:kamelet"
           parameters:
-            secretKey: "{{secretKey}}"
-            accessKey: "{{accessKey}}"
+            secretKey: "{{?secretKey}}"
+            accessKey: "{{?accessKey}}"
             region: "{{region}}"
+            useDefaultCredentialsProvider: "{{useDefaultCredentialsProvider}}"
             operation: "createSecret"

--- a/library/camel-kamelets/src/main/resources/kamelets/aws-ses-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/aws-ses-sink.kamelet.yaml
@@ -33,6 +33,10 @@ spec:
     description: |-
       Send Email through AWS SES Service.
 
+      Access Key/Secret Key are the basic method for authenticating to the AWS SES Service. These parameters are optional, because the Kamelet provide also the 'useDefaultCredentialsProvider'.
+      
+      When using a default Credentials Provider the SES client will load the credentials through this provider and won't use the static credential. This is reason for not having the access key and secret key as mandatory parameter for this Kamelet.
+
       The Kamelet expects the following headers to be set:
 
       - `subject` / `ce-subject`: The email subject
@@ -45,8 +49,6 @@ spec:
 
     required:
       - from
-      - accessKey
-      - secretKey
       - region
     type: object
     properties:
@@ -76,6 +78,13 @@ spec:
         description: The AWS region to connect to.
         type: string
         example: eu-west-1
+      useDefaultCredentialsProvider:
+        title: Default Credentials Provider
+        description: Set whether the SES client should expect to load credentials through a default credentials provider or to expect static credentials to be passed in.
+        type: boolean
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+        default: false
   dependencies:
     - "camel:core"
     - "camel:aws2-ses"
@@ -128,6 +137,7 @@ spec:
       - to:
           uri: "aws2-ses://{{from}}"
           parameters:
-            secretKey: "{{secretKey}}"
-            accessKey: "{{accessKey}}"
+            secretKey: "{{?secretKey}}"
+            accessKey: "{{?accessKey}}"
             region: "{{region}}"
+            useDefaultCredentialsProvider: "{{useDefaultCredentialsProvider}}"

--- a/library/camel-kamelets/src/main/resources/kamelets/aws-sns-fifo-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/aws-sns-fifo-sink.kamelet.yaml
@@ -31,15 +31,17 @@ spec:
   definition:
     title: AWS SNS FIFO Sink
     description: |- 
-      Send message to an AWS SNS FIFO Topic
+      Send message to an AWS SNS FIFO Topic.
+
+      Access Key/Secret Key are the basic method for authenticating to the AWS SNS Service. These parameters are optional, because the Kamelet provide also the 'useDefaultCredentialsProvider'.
+      
+      When using a default Credentials Provider the SNS client will load the credentials through this provider and won't use the static credential. This is reason for not having the access key and secret key as mandatory parameter for this Kamelet.
 
       The Kamelet expects the following headers to be set:
 
       - `subject` / `ce-subject`: the subject of the message
     required:
       - topicNameOrArn
-      - accessKey
-      - secretKey
       - region
     type: object
     properties:
@@ -78,6 +80,13 @@ spec:
       autoCreateTopic:
         title: Autocreate Topic
         description: Setting the autocreation of the SNS topic. 
+        type: boolean
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+        default: false
+      useDefaultCredentialsProvider:
+        title: Default Credentials Provider
+        description: Set whether the SNS client should expect to load credentials through a default credentials provider or to expect static credentials to be passed in.
         type: boolean
         x-descriptors:
         - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
@@ -130,9 +139,10 @@ spec:
                 uri: "aws2-sns:{{topicNameOrArn}}"
                 parameters:
                   autoCreateTopic: "{{autoCreateTopic}}"
-                  accessKey: "{{accessKey}}"
-                  secretKey: "{{secretKey}}"
+                  accessKey: "{{?accessKey}}"
+                  secretKey: "{{?secretKey}}"
                   region: "{{region}}"
+                  useDefaultCredentialsProvider: "{{useDefaultCredentialsProvider}}"
                   messageGroupIdStrategy: "usePropertyValue"
                   messageDeduplicationIdStrategy: "useContentBasedDeduplication"
           otherwise:
@@ -141,8 +151,9 @@ spec:
                 uri: "aws2-sns:{{topicNameOrArn}}"
                 parameters:
                   autoCreateTopic: "{{autoCreateTopic}}"
-                  accessKey: "{{accessKey}}"
-                  secretKey: "{{secretKey}}"
+                  accessKey: "{{?accessKey}}"
+                  secretKey: "{{?secretKey}}"
                   region: "{{region}}"
+                  useDefaultCredentialsProvider: "{{useDefaultCredentialsProvider}}"
                   messageGroupIdStrategy: "usePropertyValue"
                   messageDeduplicationIdStrategy: "useExchangeId"

--- a/library/camel-kamelets/src/main/resources/kamelets/aws-sns-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/aws-sns-sink.kamelet.yaml
@@ -31,15 +31,17 @@ spec:
   definition:
     title: AWS SNS Sink
     description: |-
-      Send message to an AWS SNS Topic
+      Send message to an AWS SNS Topic.
+
+      Access Key/Secret Key are the basic method for authenticating to the AWS SNS Service. These parameters are optional, because the Kamelet provide also the 'useDefaultCredentialsProvider'.
+      
+      When using a default Credentials Provider the SNS client will load the credentials through this provider and won't use the static credential. This is reason for not having the access key and secret key as mandatory parameter for this Kamelet.
 
       The Kamelet expects the following headers to be set:
 
       - `subject` / `ce-subject`: the subject of the message
     required:
       - topicNameOrArn
-      - accessKey
-      - secretKey
       - region
     type: object
     properties:
@@ -75,6 +77,13 @@ spec:
         x-descriptors:
         - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
+      useDefaultCredentialsProvider:
+        title: Default Credentials Provider
+        description: Set whether the SNS client should expect to load credentials through a default credentials provider or to expect static credentials to be passed in.
+        type: boolean
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+        default: false
   dependencies:
     - "camel:core"
     - "camel:aws2-sns"
@@ -99,6 +108,7 @@ spec:
           uri: "aws2-sns:{{topicNameOrArn}}"
           parameters:
             autoCreateTopic: "{{autoCreateTopic}}"
-            accessKey: "{{accessKey}}"
-            secretKey: "{{secretKey}}"
+            accessKey: "{{?accessKey}}"
+            secretKey: "{{?secretKey}}"
             region: "{{region}}"
+            useDefaultCredentialsProvider: "{{useDefaultCredentialsProvider}}"


### PR DESCRIPTION
Related to #735 