### PR TITLE
Support Default Credentials Provider for AWS Kamelets in 0.7.x

### DIFF
--- a/kamelets/aws-sqs-batch-sink.kamelet.yaml
+++ b/kamelets/aws-sqs-batch-sink.kamelet.yaml
@@ -91,7 +91,7 @@ spec:
         default: https
       useDefaultCredentialsProvider:
         title: Default Credentials Provider
-        description: Set whether the SNS client should expect to load credentials through a default credentials provider or to expect static credentials to be passed in.
+        description: Set whether the SQS client should expect to load credentials through a default credentials provider or to expect static credentials to be passed in.
         type: boolean
         x-descriptors:
         - 'urn:alm:descriptor:com.tectonic.ui:checkbox'

--- a/kamelets/aws-sqs-batch-sink.kamelet.yaml
+++ b/kamelets/aws-sqs-batch-sink.kamelet.yaml
@@ -31,11 +31,13 @@ spec:
   definition:
     title: AWS SQS Batch Sink
     description: |-
-      Send Batch message to an AWS SQS Queue
+      Send Batch message to an AWS SQS Queue.
+
+      Access Key/Secret Key are the basic method for authenticating to the AWS SQS Service. These parameters are optional, because the Kamelet provide also the 'useDefaultCredentialsProvider'.
+      
+      When using a default Credentials Provider the SQS client will load the credentials through this provider and won't use the static credential. This is reason for not having the access key and secret key as mandatory parameter for this Kamelet.
     required:
       - queueNameOrArn
-      - accessKey
-      - secretKey
       - region
       - batchSeparator
     type: object
@@ -86,7 +88,14 @@ spec:
         description: The underlying protocol used to communicate with SQS
         type: string
         example: http or https
-        default: https        
+        default: https
+      useDefaultCredentialsProvider:
+        title: Default Credentials Provider
+        description: Set whether the SNS client should expect to load credentials through a default credentials provider or to expect static credentials to be passed in.
+        type: boolean
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+        default: false        
   dependencies:
     - "camel:aws2-sqs"
     - "camel:kamelet"
@@ -98,10 +107,11 @@ spec:
           uri: "aws2-sqs:{{queueNameOrArn}}"
           parameters:
             autoCreateQueue: "{{autoCreateQueue}}"
-            accessKey: "{{accessKey}}"
-            secretKey: "{{secretKey}}"
+            accessKey: "{{?accessKey}}"
+            secretKey: "{{?secretKey}}"
             region: "{{region}}"
             batchSeparator: "{{batchSeparator}}"
             operation: "sendBatchMessage"
             amazonAWSHost: "{{?amazonAWSHost}}"
-            protocol: "{{?protocol}}"            
+            protocol: "{{?protocol}}"
+            useDefaultCredentialsProvider: "{{useDefaultCredentialsProvider}}"            

--- a/kamelets/aws-sqs-fifo-sink.kamelet.yaml
+++ b/kamelets/aws-sqs-fifo-sink.kamelet.yaml
@@ -30,11 +30,15 @@ metadata:
 spec:
   definition:
     title: AWS SQS FIFO Sink
-    description: Send message to an AWS SQS FIFO Queue
+    description: |-
+
+      Send message to an AWS SQS FIFO Queue.
+
+      Access Key/Secret Key are the basic method for authenticating to the AWS SQS Service. These parameters are optional, because the Kamelet provide also the 'useDefaultCredentialsProvider'.
+      
+      When using a default Credentials Provider the SQS client will load the credentials through this provider and won't use the static credential. This is reason for not having the access key and secret key as mandatory parameter for this Kamelet.
     required:
       - queueNameOrArn
-      - accessKey
-      - secretKey
       - region
     type: object
     properties:
@@ -86,7 +90,14 @@ spec:
         description: The underlying protocol used to communicate with SQS
         type: string
         example: http or https
-        default: https  
+        default: https
+      useDefaultCredentialsProvider:
+        title: Default Credentials Provider
+        description: Set whether the SQS client should expect to load credentials through a default credentials provider or to expect static credentials to be passed in.
+        type: boolean
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+        default: false  
   dependencies:
   - "camel:aws2-sqs"
   - "camel:core"
@@ -123,9 +134,10 @@ spec:
                 uri: "aws2-sqs:{{queueNameOrArn}}"
                 parameters:
                   autoCreateQueue: "{{autoCreateQueue}}"
-                  accessKey: "{{accessKey}}"
-                  secretKey: "{{secretKey}}"
+                  accessKey: "{{?accessKey}}"
+                  secretKey: "{{?secretKey}}"
                   region: "{{region}}"
+                  useDefaultCredentialsProvider: "{{useDefaultCredentialsProvider}}" 
                   messageGroupIdStrategy: "usePropertyValue"
                   messageDeduplicationIdStrategy: "useContentBasedDeduplication"
           otherwise:
@@ -134,9 +146,10 @@ spec:
                 uri: "aws2-sqs:{{queueNameOrArn}}"
                 parameters:
                   autoCreateQueue: "{{autoCreateQueue}}"
-                  accessKey: "{{accessKey}}"
-                  secretKey: "{{secretKey}}"
+                  accessKey: "{{?accessKey}}"
+                  secretKey: "{{?secretKey}}"
                   region: "{{region}}"
+                  useDefaultCredentialsProvider: "{{useDefaultCredentialsProvider}}" 
                   messageGroupIdStrategy: "usePropertyValue"
                   messageDeduplicationIdStrategy: "useExchangeId"
                   amazonAWSHost: "{{?amazonAWSHost}}"

--- a/kamelets/aws-sqs-sink.kamelet.yaml
+++ b/kamelets/aws-sqs-sink.kamelet.yaml
@@ -31,11 +31,13 @@ spec:
   definition:
     title: AWS SQS Sink
     description: |-
-      Send message to an AWS SQS Queue
+      Send message to an AWS SQS Queue.
+
+      Access Key/Secret Key are the basic method for authenticating to the AWS SQS Service. These parameters are optional, because the Kamelet provide also the 'useDefaultCredentialsProvider'.
+      
+      When using a default Credentials Provider the SQS client will load the credentials through this provider and won't use the static credential. This is reason for not having the access key and secret key as mandatory parameter for this Kamelet.
     required:
       - queueNameOrArn
-      - accessKey
-      - secretKey
       - region
     type: object
     properties:
@@ -80,7 +82,14 @@ spec:
         description: The underlying protocol used to communicate with SQS
         type: string
         example: http or https
-        default: https  
+        default: https
+      useDefaultCredentialsProvider:
+        title: Default Credentials Provider
+        description: Set whether the SQS client should expect to load credentials through a default credentials provider or to expect static credentials to be passed in.
+        type: boolean
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+        default: false    
   dependencies:
     - "camel:aws2-sqs"
     - "camel:kamelet"
@@ -92,8 +101,9 @@ spec:
           uri: "aws2-sqs:{{queueNameOrArn}}"
           parameters:
             autoCreateQueue: "{{autoCreateQueue}}"
-            accessKey: "{{accessKey}}"
-            secretKey: "{{secretKey}}"
+            accessKey: "{{?accessKey}}"
+            secretKey: "{{?secretKey}}"
             region: "{{region}}"
             amazonAWSHost: "{{?amazonAWSHost}}"
-            protocol: "{{?protocol}}"            
+            protocol: "{{?protocol}}"
+            useDefaultCredentialsProvider: "{{useDefaultCredentialsProvider}}"            

--- a/kamelets/aws-sqs-source.kamelet.yaml
+++ b/kamelets/aws-sqs-source.kamelet.yaml
@@ -33,10 +33,12 @@ spec:
     title: "AWS SQS Source"
     description: |-
       Receive data from AWS SQS.
+
+      Access Key/Secret Key are the basic method for authenticating to the AWS SQS Service. These parameters are optional, because the Kamelet provide also the 'useDefaultCredentialsProvider'.
+      
+      When using a default Credentials Provider the SQS client will load the credentials through this provider and won't use the static credential. This is reason for not having the access key and secret key as mandatory parameter for this Kamelet.
     required:
       - queueNameOrArn
-      - accessKey
-      - secretKey
       - region
     type: object
     properties:
@@ -103,6 +105,13 @@ spec:
         x-descriptors:
         - urn:keda:metadata:queueURL
         - urn:keda:required
+      useDefaultCredentialsProvider:
+        title: Default Credentials Provider
+        description: Set whether the SQS client should expect to load credentials through a default credentials provider or to expect static credentials to be passed in.
+        type: boolean
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+        default: false
   dependencies:
     - "camel:aws2-sqs"
     - "camel:kamelet"
@@ -111,11 +120,12 @@ spec:
       uri: "aws2-sqs:{{queueNameOrArn}}"
       parameters:
         autoCreateQueue: "{{autoCreateQueue}}"
-        secretKey: "{{secretKey}}"
-        accessKey: "{{accessKey}}"
+        secretKey: "{{?secretKey}}"
+        accessKey: "{{?accessKey}}"
         region: "{{region}}"
         deleteAfterRead: "{{deleteAfterRead}}"
         amazonAWSHost: "{{?amazonAWSHost}}"
         protocol: "{{?protocol}}"
+        useDefaultCredentialsProvider: "{{useDefaultCredentialsProvider}}"
       steps:
       - to: "kamelet:sink"

--- a/kamelets/aws-translate-action.kamelet.yaml
+++ b/kamelets/aws-translate-action.kamelet.yaml
@@ -31,10 +31,12 @@ spec:
   definition:
     title: "AWS Translate Action"
     description: |-
-      Translate a text in a specific language
+      Translate a text in a specific language.
+
+      Access Key/Secret Key are the basic method for authenticating to the AWS Translate Service. These parameters are optional, because the Kamelet provide also the 'useDefaultCredentialsProvider'.
+      
+      When using a default Credentials Provider the Translate client will load the credentials through this provider and won't use the static credential. This is reason for not having the access key and secret key as mandatory parameter for this Kamelet.
     required:
-      - accessKey
-      - secretKey
       - region
       - sourceLanguage
       - targetLanguage
@@ -71,6 +73,13 @@ spec:
         description: The target language of the translating text. Possible values are ARABIC("ar"), CHINESE_SIMPLIFIED("zh"), CHINESE_TRADITIONAL("zh-TW"), CZECH("cs"), DANISH("da"), DUTCH("nl"), ENGLISH("en"), FINNISH("fi"), FRENCH("fr"), GERMAN("de"), HEBREW("he"), HINDI("hi"), INDONESIAN("id"), ITALIAN("it"), JAPANESE("ja"), KOREAN("ko"), MALAY("ms"), NORWEGIAN("no"), PERSIAN("fa"), POLISH("pl"), PORTUGUESE("pt"), RUSSIAN("ru"), SPANISH("es"), SWEDISH("sv") and TURKISH("tr").
         type: string
         example: en
+      useDefaultCredentialsProvider:
+        title: Default Credentials Provider
+        description: Set whether the Translate client should expect to load credentials through a default credentials provider or to expect static credentials to be passed in.
+        type: boolean
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+        default: false
   dependencies:
     - "camel:dns"
     - "camel:kamelet"
@@ -82,8 +91,9 @@ spec:
       - to:
           uri: "aws2-translate://translate"
           parameters:
-            secretKey: "{{secretKey}}"
-            accessKey: "{{accessKey}}"
+            secretKey: "{{?secretKey}}"
+            accessKey: "{{?accessKey}}"
             region: "{{region}}"
             sourceLanguage: "{{sourceLanguage}}"
             targetLanguage: "{{targetLanguage}}"
+            useDefaultCredentialsProvider: "{{useDefaultCredentialsProvider}}"

--- a/library/camel-kamelets-catalog/src/test/java/org/apache/camel/kamelets/catalog/KameletsCatalogTest.java
+++ b/library/camel-kamelets-catalog/src/test/java/org/apache/camel/kamelets/catalog/KameletsCatalogTest.java
@@ -56,14 +56,14 @@ public class KameletsCatalogTest {
     @Test
     void testGetKameletsDefinition() throws Exception {
         JSONSchemaProps props = catalog.getKameletDefinition("aws-sqs-source");
-        assertEquals(9, props.getProperties().keySet().size());
+        assertEquals(10, props.getProperties().keySet().size());
         assertTrue(props.getProperties().keySet().contains("queueNameOrArn"));
     }
 
     @Test
     void testGetKameletsRequiredProperties() throws Exception {
         List<String> props = catalog.getKameletRequiredProperties("aws-sqs-source");
-        assertEquals(4, props.size());
+        assertEquals(2, props.size());
         assertTrue(props.contains("queueNameOrArn"));
     }
 

--- a/library/camel-kamelets/src/main/resources/kamelets/aws-sqs-batch-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/aws-sqs-batch-sink.kamelet.yaml
@@ -91,7 +91,7 @@ spec:
         default: https
       useDefaultCredentialsProvider:
         title: Default Credentials Provider
-        description: Set whether the SNS client should expect to load credentials through a default credentials provider or to expect static credentials to be passed in.
+        description: Set whether the SQS client should expect to load credentials through a default credentials provider or to expect static credentials to be passed in.
         type: boolean
         x-descriptors:
         - 'urn:alm:descriptor:com.tectonic.ui:checkbox'

--- a/library/camel-kamelets/src/main/resources/kamelets/aws-sqs-batch-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/aws-sqs-batch-sink.kamelet.yaml
@@ -31,11 +31,13 @@ spec:
   definition:
     title: AWS SQS Batch Sink
     description: |-
-      Send Batch message to an AWS SQS Queue
+      Send Batch message to an AWS SQS Queue.
+
+      Access Key/Secret Key are the basic method for authenticating to the AWS SQS Service. These parameters are optional, because the Kamelet provide also the 'useDefaultCredentialsProvider'.
+      
+      When using a default Credentials Provider the SQS client will load the credentials through this provider and won't use the static credential. This is reason for not having the access key and secret key as mandatory parameter for this Kamelet.
     required:
       - queueNameOrArn
-      - accessKey
-      - secretKey
       - region
       - batchSeparator
     type: object
@@ -86,7 +88,14 @@ spec:
         description: The underlying protocol used to communicate with SQS
         type: string
         example: http or https
-        default: https        
+        default: https
+      useDefaultCredentialsProvider:
+        title: Default Credentials Provider
+        description: Set whether the SNS client should expect to load credentials through a default credentials provider or to expect static credentials to be passed in.
+        type: boolean
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+        default: false        
   dependencies:
     - "camel:aws2-sqs"
     - "camel:kamelet"
@@ -98,10 +107,11 @@ spec:
           uri: "aws2-sqs:{{queueNameOrArn}}"
           parameters:
             autoCreateQueue: "{{autoCreateQueue}}"
-            accessKey: "{{accessKey}}"
-            secretKey: "{{secretKey}}"
+            accessKey: "{{?accessKey}}"
+            secretKey: "{{?secretKey}}"
             region: "{{region}}"
             batchSeparator: "{{batchSeparator}}"
             operation: "sendBatchMessage"
             amazonAWSHost: "{{?amazonAWSHost}}"
-            protocol: "{{?protocol}}"            
+            protocol: "{{?protocol}}"
+            useDefaultCredentialsProvider: "{{useDefaultCredentialsProvider}}"            

--- a/library/camel-kamelets/src/main/resources/kamelets/aws-sqs-fifo-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/aws-sqs-fifo-sink.kamelet.yaml
@@ -30,11 +30,15 @@ metadata:
 spec:
   definition:
     title: AWS SQS FIFO Sink
-    description: Send message to an AWS SQS FIFO Queue
+    description: |-
+
+      Send message to an AWS SQS FIFO Queue.
+
+      Access Key/Secret Key are the basic method for authenticating to the AWS SQS Service. These parameters are optional, because the Kamelet provide also the 'useDefaultCredentialsProvider'.
+      
+      When using a default Credentials Provider the SQS client will load the credentials through this provider and won't use the static credential. This is reason for not having the access key and secret key as mandatory parameter for this Kamelet.
     required:
       - queueNameOrArn
-      - accessKey
-      - secretKey
       - region
     type: object
     properties:
@@ -86,7 +90,14 @@ spec:
         description: The underlying protocol used to communicate with SQS
         type: string
         example: http or https
-        default: https  
+        default: https
+      useDefaultCredentialsProvider:
+        title: Default Credentials Provider
+        description: Set whether the SQS client should expect to load credentials through a default credentials provider or to expect static credentials to be passed in.
+        type: boolean
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+        default: false  
   dependencies:
   - "camel:aws2-sqs"
   - "camel:core"
@@ -123,9 +134,10 @@ spec:
                 uri: "aws2-sqs:{{queueNameOrArn}}"
                 parameters:
                   autoCreateQueue: "{{autoCreateQueue}}"
-                  accessKey: "{{accessKey}}"
-                  secretKey: "{{secretKey}}"
+                  accessKey: "{{?accessKey}}"
+                  secretKey: "{{?secretKey}}"
                   region: "{{region}}"
+                  useDefaultCredentialsProvider: "{{useDefaultCredentialsProvider}}" 
                   messageGroupIdStrategy: "usePropertyValue"
                   messageDeduplicationIdStrategy: "useContentBasedDeduplication"
           otherwise:
@@ -134,9 +146,10 @@ spec:
                 uri: "aws2-sqs:{{queueNameOrArn}}"
                 parameters:
                   autoCreateQueue: "{{autoCreateQueue}}"
-                  accessKey: "{{accessKey}}"
-                  secretKey: "{{secretKey}}"
+                  accessKey: "{{?accessKey}}"
+                  secretKey: "{{?secretKey}}"
                   region: "{{region}}"
+                  useDefaultCredentialsProvider: "{{useDefaultCredentialsProvider}}" 
                   messageGroupIdStrategy: "usePropertyValue"
                   messageDeduplicationIdStrategy: "useExchangeId"
                   amazonAWSHost: "{{?amazonAWSHost}}"

--- a/library/camel-kamelets/src/main/resources/kamelets/aws-sqs-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/aws-sqs-sink.kamelet.yaml
@@ -31,11 +31,13 @@ spec:
   definition:
     title: AWS SQS Sink
     description: |-
-      Send message to an AWS SQS Queue
+      Send message to an AWS SQS Queue.
+
+      Access Key/Secret Key are the basic method for authenticating to the AWS SQS Service. These parameters are optional, because the Kamelet provide also the 'useDefaultCredentialsProvider'.
+      
+      When using a default Credentials Provider the SQS client will load the credentials through this provider and won't use the static credential. This is reason for not having the access key and secret key as mandatory parameter for this Kamelet.
     required:
       - queueNameOrArn
-      - accessKey
-      - secretKey
       - region
     type: object
     properties:
@@ -80,7 +82,14 @@ spec:
         description: The underlying protocol used to communicate with SQS
         type: string
         example: http or https
-        default: https  
+        default: https
+      useDefaultCredentialsProvider:
+        title: Default Credentials Provider
+        description: Set whether the SQS client should expect to load credentials through a default credentials provider or to expect static credentials to be passed in.
+        type: boolean
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+        default: false    
   dependencies:
     - "camel:aws2-sqs"
     - "camel:kamelet"
@@ -92,8 +101,9 @@ spec:
           uri: "aws2-sqs:{{queueNameOrArn}}"
           parameters:
             autoCreateQueue: "{{autoCreateQueue}}"
-            accessKey: "{{accessKey}}"
-            secretKey: "{{secretKey}}"
+            accessKey: "{{?accessKey}}"
+            secretKey: "{{?secretKey}}"
             region: "{{region}}"
             amazonAWSHost: "{{?amazonAWSHost}}"
-            protocol: "{{?protocol}}"            
+            protocol: "{{?protocol}}"
+            useDefaultCredentialsProvider: "{{useDefaultCredentialsProvider}}"            

--- a/library/camel-kamelets/src/main/resources/kamelets/aws-sqs-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/aws-sqs-source.kamelet.yaml
@@ -33,10 +33,12 @@ spec:
     title: "AWS SQS Source"
     description: |-
       Receive data from AWS SQS.
+
+      Access Key/Secret Key are the basic method for authenticating to the AWS SQS Service. These parameters are optional, because the Kamelet provide also the 'useDefaultCredentialsProvider'.
+      
+      When using a default Credentials Provider the SQS client will load the credentials through this provider and won't use the static credential. This is reason for not having the access key and secret key as mandatory parameter for this Kamelet.
     required:
       - queueNameOrArn
-      - accessKey
-      - secretKey
       - region
     type: object
     properties:
@@ -103,6 +105,13 @@ spec:
         x-descriptors:
         - urn:keda:metadata:queueURL
         - urn:keda:required
+      useDefaultCredentialsProvider:
+        title: Default Credentials Provider
+        description: Set whether the SQS client should expect to load credentials through a default credentials provider or to expect static credentials to be passed in.
+        type: boolean
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+        default: false
   dependencies:
     - "camel:aws2-sqs"
     - "camel:kamelet"
@@ -111,11 +120,12 @@ spec:
       uri: "aws2-sqs:{{queueNameOrArn}}"
       parameters:
         autoCreateQueue: "{{autoCreateQueue}}"
-        secretKey: "{{secretKey}}"
-        accessKey: "{{accessKey}}"
+        secretKey: "{{?secretKey}}"
+        accessKey: "{{?accessKey}}"
         region: "{{region}}"
         deleteAfterRead: "{{deleteAfterRead}}"
         amazonAWSHost: "{{?amazonAWSHost}}"
         protocol: "{{?protocol}}"
+        useDefaultCredentialsProvider: "{{useDefaultCredentialsProvider}}"
       steps:
       - to: "kamelet:sink"

--- a/library/camel-kamelets/src/main/resources/kamelets/aws-translate-action.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/aws-translate-action.kamelet.yaml
@@ -31,10 +31,12 @@ spec:
   definition:
     title: "AWS Translate Action"
     description: |-
-      Translate a text in a specific language
+      Translate a text in a specific language.
+
+      Access Key/Secret Key are the basic method for authenticating to the AWS Translate Service. These parameters are optional, because the Kamelet provide also the 'useDefaultCredentialsProvider'.
+      
+      When using a default Credentials Provider the Translate client will load the credentials through this provider and won't use the static credential. This is reason for not having the access key and secret key as mandatory parameter for this Kamelet.
     required:
-      - accessKey
-      - secretKey
       - region
       - sourceLanguage
       - targetLanguage
@@ -71,6 +73,13 @@ spec:
         description: The target language of the translating text. Possible values are ARABIC("ar"), CHINESE_SIMPLIFIED("zh"), CHINESE_TRADITIONAL("zh-TW"), CZECH("cs"), DANISH("da"), DUTCH("nl"), ENGLISH("en"), FINNISH("fi"), FRENCH("fr"), GERMAN("de"), HEBREW("he"), HINDI("hi"), INDONESIAN("id"), ITALIAN("it"), JAPANESE("ja"), KOREAN("ko"), MALAY("ms"), NORWEGIAN("no"), PERSIAN("fa"), POLISH("pl"), PORTUGUESE("pt"), RUSSIAN("ru"), SPANISH("es"), SWEDISH("sv") and TURKISH("tr").
         type: string
         example: en
+      useDefaultCredentialsProvider:
+        title: Default Credentials Provider
+        description: Set whether the Translate client should expect to load credentials through a default credentials provider or to expect static credentials to be passed in.
+        type: boolean
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+        default: false
   dependencies:
     - "camel:dns"
     - "camel:kamelet"
@@ -82,8 +91,9 @@ spec:
       - to:
           uri: "aws2-translate://translate"
           parameters:
-            secretKey: "{{secretKey}}"
-            accessKey: "{{accessKey}}"
+            secretKey: "{{?secretKey}}"
+            accessKey: "{{?accessKey}}"
             region: "{{region}}"
             sourceLanguage: "{{sourceLanguage}}"
             targetLanguage: "{{targetLanguage}}"
+            useDefaultCredentialsProvider: "{{useDefaultCredentialsProvider}}"


### PR DESCRIPTION
Related to #735 