### PR TITLE
Use OpenJDK 11 when building with JitPack

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,2 @@
+jdk:
+  - openjdk11


### PR DESCRIPTION
Relates to #792 