### PR TITLE
chore: Overwrite JitPack dependencies for pull request builds

### DIFF
--- a/.github/workflows/yaks-tests.yaml
+++ b/.github/workflows/yaks-tests.yaml
@@ -54,6 +54,17 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v2
+    - name: Set JitPack coordinates for pull requests
+      if: github.event_name == 'pull_request'
+      env:
+        BASE_REF: ${{ github.base_ref }}
+        HEAD_REF: ${{ github.head_ref }}
+        HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+      run: |
+        echo "Set JitPack dependency coordinates to ${HEAD_REPO/\//.}:camel-kamelets-utils:${HEAD_REF/\//'~'}-SNAPSHOT"
+
+        # Overwrite JitPack coordinates in the local Kamelets so the tests can use the utility classes in this PR
+        find kamelets -maxdepth 1 -name '*.kamelet.yaml' -exec sed  -i "s/github:apache.camel-kamelets:camel-kamelets-utils:${BASE_REF}-SNAPSHOT/github:${HEAD_REPO/\//.}:camel-kamelets-utils:${HEAD_REF/\//'~'}-SNAPSHOT/g" {} +
     - name: Get Camel K CLI
       run: |
         curl --fail -L --silent https://github.com/apache/camel-k/releases/download/v${CAMEL_K_VERSION}/camel-k-client-${CAMEL_K_VERSION}-linux-64bit.tar.gz -o kamel.tar.gz
@@ -89,6 +100,7 @@ jobs:
         # TODO replaces the below statement with --operator-env-vars KAMEL_INSTALL_DEFAULT_KAMELETS=false
         # when we use camel k 1.8.0
         kubectl delete kamelets --all
+
         # Install the local kamelets
         find kamelets -maxdepth 1 -name '*.kamelet.yaml' -exec kubectl apply -f {} \;
     - name: Install YAKS


### PR DESCRIPTION
This change in GitHub workflow definition enables PRs to use new/changed utility classes in module camel-kamelets-utils. The workflow overwrites the JitPack dependency coordinates in all Kamelets to point to the actual PR head ref instead of base (e.g. main-SNAPSHOT).

This ensures that the automated tests use the utility classes from that specific PR instead of those from the base branch (e.g. main-SNAPSHOT). So pull request builds are able to have a green GitHub CI workflow even if the base branch is not aware of the utility class before the merge.