### PR TITLE
aws-sqs-fifo-sink: missing protocol option in the contentBasedDeduplication choice

### DIFF
--- a/kamelets/aws-sqs-fifo-sink.kamelet.yaml
+++ b/kamelets/aws-sqs-fifo-sink.kamelet.yaml
@@ -152,6 +152,8 @@ spec:
                   useDefaultCredentialsProvider: "{{useDefaultCredentialsProvider}}" 
                   messageGroupIdStrategy: "usePropertyValue"
                   messageDeduplicationIdStrategy: "useContentBasedDeduplication"
+                  amazonAWSHost: "{{?amazonAWSHost}}"
+                  protocol: "{{?protocol}}"
                   uriEndpointOverride: "{{?uriEndpointOverride}}"
                   overrideEndpoint: "{{overrideEndpoint}}"
           otherwise:

--- a/library/camel-kamelets/src/main/resources/kamelets/aws-sqs-fifo-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/aws-sqs-fifo-sink.kamelet.yaml
@@ -152,6 +152,8 @@ spec:
                   useDefaultCredentialsProvider: "{{useDefaultCredentialsProvider}}" 
                   messageGroupIdStrategy: "usePropertyValue"
                   messageDeduplicationIdStrategy: "useContentBasedDeduplication"
+                  amazonAWSHost: "{{?amazonAWSHost}}"
+                  protocol: "{{?protocol}}"
                   uriEndpointOverride: "{{?uriEndpointOverride}}"
                   overrideEndpoint: "{{overrideEndpoint}}"
           otherwise:


### PR DESCRIPTION
Fixes #856 