### PR TITLE
fix #877 fix #876 : range is a string, correct usage of spreadsheetId…

### DIFF
--- a/kamelets/google-sheets-source.kamelet.yaml
+++ b/kamelets/google-sheets-source.kamelet.yaml
@@ -32,19 +32,13 @@ spec:
     description: |-
       Receive data from Google Sheets.
     required:
-      - index
       - spreadsheetId
       - clientId
       - accessToken
       - refreshToken
       - clientSecret
-      - applicationName
     type: object
     properties:
-      index:
-        title: Index
-        description: An index for the google sheets endpoint
-        type: string
       spreadsheetId:
         title: Spreadsheet ID
         description: The Spreadsheet ID to be used as events source
@@ -102,11 +96,9 @@ spec:
         - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: true
       range:
-        title: Consume from now
+        title: Cells Range to get Data from
         description: the range of rows and columns in a sheet to get data from.
-        type: boolean
-        x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+        type: string
         example: "A1:B3"
   types:
     out:
@@ -117,17 +109,16 @@ spec:
   - "camel:google-sheets"
   template:
     from:
-      uri: "google-sheets-stream://{{index}}"
+      uri: "google-sheets-stream://{{spreadsheetId}}"
       parameters:
         clientId: "{{clientId}}"
-        spreadsheetId: "{{spreadsheetId}}"
         accessToken: "{{accessToken}}"
         refreshToken: "{{refreshToken}}"
         clientSecret: "{{clientSecret}}"
         delay: "{{delay}}"
-        applicationName: "{{applicationName}}"
+        applicationName: "{{?applicationName}}"
         splitResults: "{{splitResults}}"
-        range: "{{range}}"
+        range: "{{?range}}"
         repeatCount: "{{?repeatCount}}"
       steps:
       - marshal:

--- a/library/camel-kamelets/src/main/resources/kamelets/google-sheets-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/google-sheets-source.kamelet.yaml
@@ -32,19 +32,13 @@ spec:
     description: |-
       Receive data from Google Sheets.
     required:
-      - index
       - spreadsheetId
       - clientId
       - accessToken
       - refreshToken
       - clientSecret
-      - applicationName
     type: object
     properties:
-      index:
-        title: Index
-        description: An index for the google sheets endpoint
-        type: string
       spreadsheetId:
         title: Spreadsheet ID
         description: The Spreadsheet ID to be used as events source
@@ -102,11 +96,9 @@ spec:
         - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: true
       range:
-        title: Consume from now
+        title: Cells Range to get Data from
         description: the range of rows and columns in a sheet to get data from.
-        type: boolean
-        x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+        type: string
         example: "A1:B3"
   types:
     out:
@@ -117,17 +109,16 @@ spec:
   - "camel:google-sheets"
   template:
     from:
-      uri: "google-sheets-stream://{{index}}"
+      uri: "google-sheets-stream://{{spreadsheetId}}"
       parameters:
         clientId: "{{clientId}}"
-        spreadsheetId: "{{spreadsheetId}}"
         accessToken: "{{accessToken}}"
         refreshToken: "{{refreshToken}}"
         clientSecret: "{{clientSecret}}"
         delay: "{{delay}}"
-        applicationName: "{{applicationName}}"
+        applicationName: "{{?applicationName}}"
         splitResults: "{{splitResults}}"
-        range: "{{range}}"
+        range: "{{?range}}"
         repeatCount: "{{?repeatCount}}"
       steps:
       - marshal:


### PR DESCRIPTION
… option.

Google Sheets Source Kamelet: Range is a String and not a boolean
Google Sheets Source Kamelet: Review the Kamelet