### PR TITLE
Update non-working examples in Kamelet Catalog docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,12 @@ Kamelets submitted with tests that verify their correctness **MUST** be labeled 
 
 **NOTE**: there's no way at the moment to inject credentials for external systems into the CI in order to write more advanced tests, but we can expect we'll find an usable strategy in the long run
 
+### Kamelet Binding Examples
+
+Binding examples are highly encouraged to be added under `templates/bindings/camel-k` directory for Kamelet Binding and `templates/bindings/core` for the YAML routes.
+
+When the Kamelet Catalog documentation is generated, the examples in each Kamelet documentation page are automatically generated, but the generator code is not wise enough and it may generate a Kamelet Binding that doesn't work, requiring additional steps. In this case, the binding example should be added to the above mentioned directories, and add the comment marker at the first line `"# example_for_kamelet_doc"` only in the Camel K Kamelet Binding example (in `templates/bindings/camel-k`). When the documentation mechanism runs, it will source this binding example into the kamelet documentation page as example.
+
 ## Releasing
 
 This project is released as standard Apache Camel module.

--- a/templates/bindings/camel-k/avro-deserialize-action-binding.yaml
+++ b/templates/bindings/camel-k/avro-deserialize-action-binding.yaml
@@ -1,3 +1,4 @@
+# example_for_kamelet_doc
 apiVersion: camel.apache.org/v1alpha1
 kind: KameletBinding
 metadata:
@@ -9,14 +10,28 @@ spec:
       apiVersion: camel.apache.org/v1alpha1
       name: timer-source
     properties:
-      message: "Hello"
+      message: '{"first":"Ada","last":"Lovelace"}'
   steps:
+  - ref:
+      kind: Kamelet
+      apiVersion: camel.apache.org/v1alpha1
+      name: json-deserialize-action
+  - ref:
+      kind: Kamelet
+      apiVersion: camel.apache.org/v1alpha1
+      name: avro-serialize-action
+    properties:
+      schema: "{\"type\": \"record\", \"namespace\": \"com.example\", \"name\": \"FullName\", \"fields\": [{\"name\": \"first\", \"type\": \"string\"},{\"name\": \"last\", \"type\": \"string\"}]}"
   - ref:
       kind: Kamelet
       apiVersion: camel.apache.org/v1alpha1
       name: avro-deserialize-action
     properties:
       schema: "{\"type\": \"record\", \"namespace\": \"com.example\", \"name\": \"FullName\", \"fields\": [{\"name\": \"first\", \"type\": \"string\"},{\"name\": \"last\", \"type\": \"string\"}]}"
+  - ref:
+      kind: Kamelet
+      apiVersion: camel.apache.org/v1alpha1
+      name: json-serialize-action
   sink:
     ref:
       kind: KafkaTopic

--- a/templates/bindings/camel-k/avro-serialize-action-binding.yaml
+++ b/templates/bindings/camel-k/avro-serialize-action-binding.yaml
@@ -1,3 +1,4 @@
+# example_for_kamelet_doc
 apiVersion: camel.apache.org/v1alpha1
 kind: KameletBinding
 metadata:
@@ -9,8 +10,12 @@ spec:
       apiVersion: camel.apache.org/v1alpha1
       name: timer-source
     properties:
-      message: "Hello"
+      message: '{"first":"Ada","last":"Lovelace"}'
   steps:
+  - ref:
+      kind: Kamelet
+      apiVersion: camel.apache.org/v1alpha1
+      name: json-deserialize-action
   - ref:
       kind: Kamelet
       apiVersion: camel.apache.org/v1alpha1

--- a/templates/bindings/camel-k/caffeine-action-binding.yaml
+++ b/templates/bindings/camel-k/caffeine-action-binding.yaml
@@ -1,3 +1,4 @@
+# example_for_kamelet_doc
 apiVersion: camel.apache.org/v1alpha1
 kind: KameletBinding
 metadata:
@@ -9,12 +10,69 @@ spec:
       apiVersion: camel.apache.org/v1alpha1
       name: timer-source
     properties:
-      message: "Hello"
+      message: '{"foo":"bar"}'
+      period: 10000
   steps:
   - ref:
       kind: Kamelet
       apiVersion: camel.apache.org/v1alpha1
+      name: json-deserialize-action
+  - ref:
+      kind: Kamelet
+      apiVersion: camel.apache.org/v1alpha1
+      name: log-sink
+  - ref:
+      kind: Kamelet
+      apiVersion: camel.apache.org/v1alpha1
+      name: insert-header-action
+    properties:
+      name: "caffeine-key"
+      value: "my-key"
+  - ref:
+      kind: Kamelet
+      apiVersion: camel.apache.org/v1alpha1
+      name: insert-header-action
+    properties:
+      name: "caffeine-operation"
+      value: "PUT"
+  - ref:
+      kind: Kamelet
+      apiVersion: camel.apache.org/v1alpha1
       name: caffeine-action
+    properties:
+      cacheName: "my-cache"
+  # extract the foo field from the body, cleaning the body
+  - ref:
+      kind: Kamelet
+      apiVersion: camel.apache.org/v1alpha1
+      name: extract-field-action
+    properties:
+      field: '{"foo"}'
+  - ref:
+      kind: Kamelet
+      apiVersion: camel.apache.org/v1alpha1
+      name: log-sink
+  - ref:
+      kind: Kamelet
+      apiVersion: camel.apache.org/v1alpha1
+      name: insert-header-action
+    properties:
+      name: "caffeine-key"
+      value: "my-key"
+  - ref:
+      kind: Kamelet
+      apiVersion: camel.apache.org/v1alpha1
+      name: insert-header-action
+    properties:
+      name: "caffeine-operation"
+      value: "GET"
+  # retrieve the json payload from the cache and put into the body
+  - ref:
+      kind: Kamelet
+      apiVersion: camel.apache.org/v1alpha1
+      name: caffeine-action
+    properties:
+      cacheName: "my-cache"
   sink:
     ref:
       kind: KafkaTopic

--- a/templates/bindings/camel-k/has-header-filter-action-binding.yaml
+++ b/templates/bindings/camel-k/has-header-filter-action-binding.yaml
@@ -1,3 +1,4 @@
+# example_for_kamelet_doc
 apiVersion: camel.apache.org/v1alpha1
 kind: KameletBinding
 metadata:
@@ -14,9 +15,16 @@ spec:
   - ref:
       kind: Kamelet
       apiVersion: camel.apache.org/v1alpha1
+      name: insert-header-action
+    properties:
+      name: "my-header"
+      value: "my-value"
+  - ref:
+      kind: Kamelet
+      apiVersion: camel.apache.org/v1alpha1
       name: has-header-filter-action
     properties:
-      name: "headerName"
+      name: "my-header"
   sink:
     ref:
       kind: KafkaTopic

--- a/templates/bindings/camel-k/insert-field-action-binding.yaml
+++ b/templates/bindings/camel-k/insert-field-action-binding.yaml
@@ -1,3 +1,4 @@
+# example_for_kamelet_doc
 apiVersion: camel.apache.org/v1alpha1
 kind: KameletBinding
 metadata:
@@ -9,8 +10,12 @@ spec:
       apiVersion: camel.apache.org/v1alpha1
       name: timer-source
     properties:
-      message: "Hello"
+      message: '{"foo":"John"}'
   steps:
+  - ref:
+      kind: Kamelet
+      apiVersion: camel.apache.org/v1alpha1
+      name: json-deserialize-action
   - ref:
       kind: Kamelet
       apiVersion: camel.apache.org/v1alpha1

--- a/templates/bindings/camel-k/protobuf-deserialize-action-binding.yaml
+++ b/templates/bindings/camel-k/protobuf-deserialize-action-binding.yaml
@@ -1,3 +1,4 @@
+# example_for_kamelet_doc
 apiVersion: camel.apache.org/v1alpha1
 kind: KameletBinding
 metadata:
@@ -9,8 +10,18 @@ spec:
       apiVersion: camel.apache.org/v1alpha1
       name: timer-source
     properties:
-      message: "Hello"
+      message: '{"first": "John", "last":"Doe"}'
   steps:
+  - ref:
+      kind: Kamelet
+      apiVersion: camel.apache.org/v1alpha1
+      name: json-deserialize-action
+  - ref:
+      kind: Kamelet
+      apiVersion: camel.apache.org/v1alpha1
+      name: protobuf-serialize-action
+    properties:
+      schema: "message Person { required string first = 1; required string last = 2; }"
   - ref:
       kind: Kamelet
       apiVersion: camel.apache.org/v1alpha1

--- a/templates/bindings/camel-k/protobuf-serialize-action-binding.yaml
+++ b/templates/bindings/camel-k/protobuf-serialize-action-binding.yaml
@@ -1,3 +1,4 @@
+# example_for_kamelet_doc
 apiVersion: camel.apache.org/v1alpha1
 kind: KameletBinding
 metadata:
@@ -9,8 +10,12 @@ spec:
       apiVersion: camel.apache.org/v1alpha1
       name: timer-source
     properties:
-      message: "Hello"
+      message: '{"first": "John", "last":"Doe"}'
   steps:
+  - ref:
+      kind: Kamelet
+      apiVersion: camel.apache.org/v1alpha1
+      name: json-deserialize-action
   - ref:
       kind: Kamelet
       apiVersion: camel.apache.org/v1alpha1

--- a/templates/bindings/core/avro-deserialize-action-binding.yaml
+++ b/templates/bindings/core/avro-deserialize-action-binding.yaml
@@ -3,11 +3,19 @@
       uri: "kamelet:timer-source"
       parameters:
         period: 1000
-        message: "{ \"foo\": \"John\"}"
+        message: '{"first":"Ada","last":"Lovelace"}'
     steps:
+      - to:
+          uri: "kamelet:json-deserialize-action"
+      - to:
+          uri: "kamelet:avro-serialize-action"
+          parameters:
+            schema: "{\"type\": \"record\", \"namespace\": \"com.example\", \"name\": \"FullName\", \"fields\": [{\"name\": \"first\", \"type\": \"string\"},{\"name\": \"last\", \"type\": \"string\"}]}"
       - to:
           uri: "kamelet:avro-deserialize-action"
           parameters:
             schema: "{\"type\": \"record\", \"namespace\": \"com.example\", \"name\": \"FullName\", \"fields\": [{\"name\": \"first\", \"type\": \"string\"},{\"name\": \"last\", \"type\": \"string\"}]}"
+      - to:
+          uri: "kamelet:json-serialize-action"
       - to:
           uri: "log:info"

--- a/templates/bindings/core/avro-serialize-action-binding.yaml
+++ b/templates/bindings/core/avro-serialize-action-binding.yaml
@@ -3,8 +3,10 @@
       uri: "kamelet:timer-source"
       parameters:
         period: 1000
-        message: "{ \"foo\": \"John\"}"
+        message: '{"first":"Ada","last":"Lovelace"}'
     steps:
+      - to:
+          uri: "kamelet:json-deserialize-action"
       - to:
           uri: "kamelet:avro-serialize-action"
           parameters:

--- a/templates/bindings/core/caffeine-action-binding.yaml
+++ b/templates/bindings/core/caffeine-action-binding.yaml
@@ -2,10 +2,48 @@
     from:
       uri: "kamelet:timer-source"
       parameters:
-        period: 1000
-        message: "{ \"foo\": \"John\"}"
+        period: 10000
+        message: '{"foo":"bar"}'
     steps:
       - to:
+          uri: "kamelet:json-deserialize-action"
+      - to:
+          uri: "log:info"
+      - to:
+          uri: "kamelet:insert-header-action"
+          parameters:
+            name: "caffeine-key"
+            value: "my-key"
+      - to:
+          uri: "kamelet:insert-header-action"
+          parameters:
+            name: "caffeine-operation"
+            value: "PUT"
+      - to:
           uri: "kamelet:caffeine-action"
+          parameters:
+            cacheName: "my-cache"
+      # extract the foo field from the body, cleaning the body
+      - to:
+          uri: "kamelet:extract-field-action"
+          parameters:
+            field: '{"foo"}'
+      - to:
+          uri: "log:info"
+      - to:
+          uri: "kamelet:insert-header-action"
+          parameters:
+            name: "caffeine-key"
+            value: "my-key"
+      - to:
+          uri: "kamelet:insert-header-action"
+          parameters:
+            name: "caffeine-operation"
+            value: "GET"
+      # retrieve the json payload from the cache and put into the body
+      - to:
+          uri: "kamelet:caffeine-action"
+          parameters:
+            cacheName: "my-cache"
       - to:
           uri: "log:info"

--- a/templates/bindings/core/has-header-filter-action-binding.yaml
+++ b/templates/bindings/core/has-header-filter-action-binding.yaml
@@ -6,8 +6,13 @@
         message: "{ \"foo\": \"John\"}"
     steps:
       - to:
+          uri: "kamelet:insert-header-action"
+          parameters:
+            name: "my-header"
+            value: "my-value"
+      - to:
           uri: "kamelet:has-header-filter-action"
           parameters:
-            name: "headerName"
+            name: "my-header"
       - to:
           uri: "log:info"

--- a/templates/bindings/core/insert-field-action-binding.yaml
+++ b/templates/bindings/core/insert-field-action-binding.yaml
@@ -3,12 +3,14 @@
       uri: "kamelet:timer-source"
       parameters:
         period: 1000
-        message: "{ \"foo\": \"John\"}"
+        message: '{"foo": "John"}'
     steps:
+      - to:
+          uri: "kamelet:json-deserialize-action"
       - to:
           uri: "kamelet:insert-field-action"
           parameters:
             field: "The Field"
-        value: "The Value"
+            value: "The Value"
       - to:
           uri: "log:info"

--- a/templates/bindings/core/protobuf-deserialize-action-binding.yaml
+++ b/templates/bindings/core/protobuf-deserialize-action-binding.yaml
@@ -3,8 +3,14 @@
       uri: "kamelet:timer-source"
       parameters:
         period: 1000
-        message: "{ \"foo\": \"John\"}"
+        message: '{"first": "John", "last":"Doe"}'
     steps:
+      - to:
+          uri: "kamelet:json-deserialize-action"
+      - to:
+          uri: "kamelet:protobuf-serialize-action"
+          parameters:
+            schema: "message Person { required string first = 1; required string last = 2; }"
       - to:
           uri: "kamelet:protobuf-deserialize-action"
           parameters:

--- a/templates/bindings/core/protobuf-serialize-action-binding.yaml
+++ b/templates/bindings/core/protobuf-serialize-action-binding.yaml
@@ -3,8 +3,10 @@
       uri: "kamelet:timer-source"
       parameters:
         period: 1000
-        message: "{ \"foo\": \"John\"}"
+        message: '{"first": "John", "last":"Doe"}'
     steps:
+      - to:
+          uri: "kamelet:json-deserialize-action"
       - to:
           uri: "kamelet:protobuf-serialize-action"
           parameters:


### PR DESCRIPTION
Fix https://github.com/apache/camel-kamelets/issues/866

* There are some generated kamelet bindings are invalid, the auto
  generation cannot resolve all the required steps, so there is
  a need to create it manually
* Add a comment marker in kamelet binding examples for the auto
  generation to skip its creation
* The doc generation source the kamelet binding example file when it
  doesn't auto generate the example
* the camel-kamelets directory is hardcoded in kamelets.js as it is
  assumed this generation mechanism already assumes this directory