### PR TITLE
AWS DDB Streams: IteratorType has been renamed and sequenceNumberProvider is not an option anymore

### DIFF
--- a/kamelets/aws-ddb-streams-source.kamelet.yaml
+++ b/kamelets/aws-ddb-streams-source.kamelet.yaml
@@ -66,17 +66,11 @@ spec:
         description: The AWS region to connect to
         type: string
         example: eu-west-1
-      iteratorType:
-        title: Iterator Type
-        description: Defines where in the DynaboDB stream to start getting records. Note that using TRIM_HORIZON can cause a significant delay before the stream has caught up to real-time. if {AT,AFTER}_SEQUENCE_NUMBER are used, then a sequenceNumberProvider MUST be supplied. There are 4 enums and the value can be one of TRIM_HORIZON, LATEST, AT_SEQUENCE_NUMBER, AFTER_SEQUENCE_NUMBER
+      streamIteratorType:
+        title: Stream Iterator Type
+        description: Defines where in the DynamoDB stream to start getting records. Note that using FROM_START can cause a significant delay before the stream has caught up to real-time. There are 2 enums and the value can be one of FROM_LATEST and FROM_START
         type: string
-        default: LATEST
-      sequenceNumberProvider:
-        title: Sequence Number Provider
-        description: Provider for the sequence number when using one of the two ShardIteratorType AT_SEQUENCE_NUMBER or AFTER_SEQUENCE_NUMBER iterator types. Can be a registry reference or a literal sequence number.
-        type: string
-        example: "900000000005745712447"
-        default: "000000000000000000000"
+        default: FROM_LATEST
       useDefaultCredentialsProvider:
         title: Default Credentials Provider
         description: Set whether the AWS DynamoDB Streams client should expect to load credentials through a default credentials provider or to expect static credentials to be passed in.
@@ -109,8 +103,7 @@ spec:
         secretKey: "{{?secretKey}}"
         accessKey: "{{?accessKey}}"
         region: "{{region}}"
-        iteratorType: "{{iteratorType}}"
-        sequenceNumberProvider: "{{sequenceNumberProvider}}"
+        streamIteratorType: "{{streamIteratorType}}"
         useDefaultCredentialsProvider: "{{useDefaultCredentialsProvider}}"
         uriEndpointOverride: "{{?uriEndpointOverride}}"
         overrideEndpoint: "{{overrideEndpoint}}"

--- a/library/camel-kamelets/src/main/resources/kamelets/aws-ddb-streams-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/aws-ddb-streams-source.kamelet.yaml
@@ -66,17 +66,11 @@ spec:
         description: The AWS region to connect to
         type: string
         example: eu-west-1
-      iteratorType:
-        title: Iterator Type
-        description: Defines where in the DynaboDB stream to start getting records. Note that using TRIM_HORIZON can cause a significant delay before the stream has caught up to real-time. if {AT,AFTER}_SEQUENCE_NUMBER are used, then a sequenceNumberProvider MUST be supplied. There are 4 enums and the value can be one of TRIM_HORIZON, LATEST, AT_SEQUENCE_NUMBER, AFTER_SEQUENCE_NUMBER
+      streamIteratorType:
+        title: Stream Iterator Type
+        description: Defines where in the DynamoDB stream to start getting records. Note that using FROM_START can cause a significant delay before the stream has caught up to real-time. There are 2 enums and the value can be one of FROM_LATEST and FROM_START
         type: string
-        default: LATEST
-      sequenceNumberProvider:
-        title: Sequence Number Provider
-        description: Provider for the sequence number when using one of the two ShardIteratorType AT_SEQUENCE_NUMBER or AFTER_SEQUENCE_NUMBER iterator types. Can be a registry reference or a literal sequence number.
-        type: string
-        example: "900000000005745712447"
-        default: "000000000000000000000"
+        default: FROM_LATEST
       useDefaultCredentialsProvider:
         title: Default Credentials Provider
         description: Set whether the AWS DynamoDB Streams client should expect to load credentials through a default credentials provider or to expect static credentials to be passed in.
@@ -109,8 +103,7 @@ spec:
         secretKey: "{{?secretKey}}"
         accessKey: "{{?accessKey}}"
         region: "{{region}}"
-        iteratorType: "{{iteratorType}}"
-        sequenceNumberProvider: "{{sequenceNumberProvider}}"
+        streamIteratorType: "{{streamIteratorType}}"
         useDefaultCredentialsProvider: "{{useDefaultCredentialsProvider}}"
         uriEndpointOverride: "{{?uriEndpointOverride}}"
         overrideEndpoint: "{{overrideEndpoint}}"


### PR DESCRIPTION
Fixes #898 