### PR TITLE
aws-kinesis-source kamelets incompatible with camel 3.16

### DIFF
--- a/kamelets/aws-kinesis-source.kamelet.yaml
+++ b/kamelets/aws-kinesis-source.kamelet.yaml
@@ -102,6 +102,4 @@ spec:
         uriEndpointOverride: "{{?uriEndpointOverride}}"
         overrideEndpoint: "{{overrideEndpoint}}"
       steps:
-      - set-body:
-          simple: "${body.data().asInputStream()}"
       - to: "kamelet:sink"

--- a/library/camel-kamelets/src/main/resources/kamelets/aws-kinesis-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/aws-kinesis-source.kamelet.yaml
@@ -102,6 +102,4 @@ spec:
         uriEndpointOverride: "{{?uriEndpointOverride}}"
         overrideEndpoint: "{{overrideEndpoint}}"
       steps:
-      - set-body:
-          simple: "${body.data().asInputStream()}"
       - to: "kamelet:sink"


### PR DESCRIPTION
Fixes #908 