### PR TITLE
Fix IBM MQ kamelets to use general MQConnectionFactory

### DIFF
--- a/kamelets/jms-ibm-mq-sink.kamelet.yaml
+++ b/kamelets/jms-ibm-mq-sink.kamelet.yaml
@@ -55,7 +55,7 @@ spec:
         title: "IBM MQ Server Port"
         description: "IBM MQ Server port"
         type: integer
-        example: 1414
+        default: 1414
       destinationType:
         title: "Destination Type"
         description: "The JMS destination type (queue or topic)"
@@ -95,7 +95,7 @@ spec:
   template:
     beans:
       - name: wmqConnectionFactory
-        type: "#class:com.ibm.mq.jms.MQQueueConnectionFactory"
+        type: "#class:com.ibm.mq.jms.MQConnectionFactory"
         property:
           - key: XMSC_WMQ_HOST_NAME
             value: '{{serverName}}'

--- a/kamelets/jms-ibm-mq-source.kamelet.yaml
+++ b/kamelets/jms-ibm-mq-source.kamelet.yaml
@@ -55,7 +55,7 @@ spec:
         title: "IBM MQ Server Port"
         description: "IBM MQ Server port"
         type: integer
-        example: 1414
+        default: 1414
       destinationType:
         title: "Destination Type"
         description: "The JMS destination type (queue or topic)"
@@ -95,7 +95,7 @@ spec:
   template:
     beans:
       - name: wmqConnectionFactory
-        type: "#class:com.ibm.mq.jms.MQQueueConnectionFactory"
+        type: "#class:com.ibm.mq.jms.MQConnectionFactory"
         property:
           - key: XMSC_WMQ_HOST_NAME
             value: '{{serverName}}'

--- a/library/camel-kamelets/src/main/resources/kamelets/jms-ibm-mq-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/jms-ibm-mq-sink.kamelet.yaml
@@ -55,7 +55,7 @@ spec:
         title: "IBM MQ Server Port"
         description: "IBM MQ Server port"
         type: integer
-        example: 1414
+        default: 1414
       destinationType:
         title: "Destination Type"
         description: "The JMS destination type (queue or topic)"
@@ -95,7 +95,7 @@ spec:
   template:
     beans:
       - name: wmqConnectionFactory
-        type: "#class:com.ibm.mq.jms.MQQueueConnectionFactory"
+        type: "#class:com.ibm.mq.jms.MQConnectionFactory"
         property:
           - key: XMSC_WMQ_HOST_NAME
             value: '{{serverName}}'

--- a/library/camel-kamelets/src/main/resources/kamelets/jms-ibm-mq-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/jms-ibm-mq-source.kamelet.yaml
@@ -55,7 +55,7 @@ spec:
         title: "IBM MQ Server Port"
         description: "IBM MQ Server port"
         type: integer
-        example: 1414
+        default: 1414
       destinationType:
         title: "Destination Type"
         description: "The JMS destination type (queue or topic)"
@@ -95,7 +95,7 @@ spec:
   template:
     beans:
       - name: wmqConnectionFactory
-        type: "#class:com.ibm.mq.jms.MQQueueConnectionFactory"
+        type: "#class:com.ibm.mq.jms.MQConnectionFactory"
         property:
           - key: XMSC_WMQ_HOST_NAME
             value: '{{serverName}}'

--- a/templates/bindings/core/jms-ibm-mq-sink-binding.yaml
+++ b/templates/bindings/core/jms-ibm-mq-sink-binding.yaml
@@ -4,15 +4,15 @@
       parameters:
         period: 1000
         message: "Hello Camel to IBM MQ"
-    steps:
-      - to:
-          uri: "kamelet:jms-ibm-mq-sink"
-          parameters:
-            serverName: "10.103.41.245"
-            serverPort: "1414"
-            destinationType: "queue"
-            destinationName: "DEV.QUEUE.1"
-            queueManager: QM1
-            channel: DEV.APP.SVRCONN
-            username: app
-            password: passw0rd
+      steps:
+        - to:
+            uri: "kamelet:jms-ibm-mq-sink"
+            parameters:
+              serverName: "10.105.157.79"
+              serverPort: "1414"
+              destinationType: "queue"
+              destinationName: "DEV.QUEUE.1"
+              queueManager: QM1
+              channel: DEV.APP.SVRCONN
+              username: app
+              password: passw0rd

--- a/templates/bindings/core/jms-ibm-mq-source-binding.yaml
+++ b/templates/bindings/core/jms-ibm-mq-source-binding.yaml
@@ -2,7 +2,7 @@
     from:
       uri: "kamelet:jms-ibm-mq-source"
       parameters:
-        serverName: "10.103.41.245"
+        serverName: "10.105.157.79"
         serverPort: "1414"
         destinationType: "queue"
         destinationName: "DEV.QUEUE.1"
@@ -10,6 +10,6 @@
         channel: DEV.APP.SVRCONN
         username: app
         password: passw0rd
-    steps:
-      - to:
-          uri: kamelet:log-sink
+      steps:
+        - to:
+            uri: kamelet:log-sink


### PR DESCRIPTION
* Currently it uses MQQueueConnectionFactory, which is specific for Queues. It should use MQConnectionFactory, which can be used for queues and topics.
* Add a default property `serverPort: 1414`
* Fix the [yaml dsl routes used in camel 3.15](https://camel.apache.org/manual/camel-3x-upgrade-guide-3_15.html#_camel_yaml_dsl)

Fix https://github.com/apache/camel-kamelets/issues/921