### PR TITLE
Fix identation of steps in yaml dsl examples

### DIFF
--- a/templates/bindings/core/avro-deserialize-action-binding.yaml
+++ b/templates/bindings/core/avro-deserialize-action-binding.yaml
@@ -4,18 +4,18 @@
       parameters:
         period: 1000
         message: '{"first":"Ada","last":"Lovelace"}'
-    steps:
-      - to:
-          uri: "kamelet:json-deserialize-action"
-      - to:
-          uri: "kamelet:avro-serialize-action"
-          parameters:
-            schema: "{\"type\": \"record\", \"namespace\": \"com.example\", \"name\": \"FullName\", \"fields\": [{\"name\": \"first\", \"type\": \"string\"},{\"name\": \"last\", \"type\": \"string\"}]}"
-      - to:
-          uri: "kamelet:avro-deserialize-action"
-          parameters:
-            schema: "{\"type\": \"record\", \"namespace\": \"com.example\", \"name\": \"FullName\", \"fields\": [{\"name\": \"first\", \"type\": \"string\"},{\"name\": \"last\", \"type\": \"string\"}]}"
-      - to:
-          uri: "kamelet:json-serialize-action"
-      - to:
-          uri: "log:info"
+      steps:
+        - to:
+            uri: "kamelet:json-deserialize-action"
+        - to:
+            uri: "kamelet:avro-serialize-action"
+            parameters:
+              schema: "{\"type\": \"record\", \"namespace\": \"com.example\", \"name\": \"FullName\", \"fields\": [{\"name\": \"first\", \"type\": \"string\"},{\"name\": \"last\", \"type\": \"string\"}]}"
+        - to:
+            uri: "kamelet:avro-deserialize-action"
+            parameters:
+              schema: "{\"type\": \"record\", \"namespace\": \"com.example\", \"name\": \"FullName\", \"fields\": [{\"name\": \"first\", \"type\": \"string\"},{\"name\": \"last\", \"type\": \"string\"}]}"
+        - to:
+            uri: "kamelet:json-serialize-action"
+        - to:
+            uri: "log:info"

--- a/templates/bindings/core/avro-serialize-action-binding.yaml
+++ b/templates/bindings/core/avro-serialize-action-binding.yaml
@@ -4,12 +4,12 @@
       parameters:
         period: 1000
         message: '{"first":"Ada","last":"Lovelace"}'
-    steps:
-      - to:
-          uri: "kamelet:json-deserialize-action"
-      - to:
-          uri: "kamelet:avro-serialize-action"
-          parameters:
-            schema: "{\"type\": \"record\", \"namespace\": \"com.example\", \"name\": \"FullName\", \"fields\": [{\"name\": \"first\", \"type\": \"string\"},{\"name\": \"last\", \"type\": \"string\"}]}"
-      - to:
-          uri: "log:info"
+      steps:
+        - to:
+            uri: "kamelet:json-deserialize-action"
+        - to:
+            uri: "kamelet:avro-serialize-action"
+            parameters:
+              schema: "{\"type\": \"record\", \"namespace\": \"com.example\", \"name\": \"FullName\", \"fields\": [{\"name\": \"first\", \"type\": \"string\"},{\"name\": \"last\", \"type\": \"string\"}]}"
+        - to:
+            uri: "log:info"

--- a/templates/bindings/core/aws-cloudwatch-sink-binding.yaml
+++ b/templates/bindings/core/aws-cloudwatch-sink-binding.yaml
@@ -4,12 +4,11 @@
       parameters:
         period: 1000
         message: "Hello Camel JBang"
-    steps:
-      - to:
-          uri: "kamelet:aws-cloudwatch-sink"
-          parameters:
-            accessKey: "The Access Key"
-            cwNamespace: "The Cloud Watch Namespace"
-            region: "eu-west-1"
-            secretKey: "The Secret Key"
-    
+      steps:
+        - to:
+            uri: "kamelet:aws-cloudwatch-sink"
+            parameters:
+              accessKey: "The Access Key"
+              cwNamespace: "The Cloud Watch Namespace"
+              region: "eu-west-1"
+              secretKey: "The Secret Key"

--- a/templates/bindings/core/aws-ddb-streams-source-binding.yaml
+++ b/templates/bindings/core/aws-ddb-streams-source-binding.yaml
@@ -6,7 +6,6 @@
         region: "eu-west-1"
         secretKey: "The Secret Key"
         table: "The Table"
-    steps:
-      - to:
-          uri: "log:info"
-    
+      steps:
+        - to:
+            uri: "log:info"

--- a/templates/bindings/core/aws-ec2-sink-binding.yaml
+++ b/templates/bindings/core/aws-ec2-sink-binding.yaml
@@ -4,11 +4,10 @@
       parameters:
         period: 1000
         message: "Hello Camel JBang"
-    steps:
-      - to:
-          uri: "kamelet:aws-ec2-sink"
-          parameters:
-            accessKey: "The Access Key"
-            region: "eu-west-1"
-            secretKey: "The Secret Key"
-    
+      steps:
+        - to:
+            uri: "kamelet:aws-ec2-sink"
+            parameters:
+              accessKey: "The Access Key"
+              region: "eu-west-1"
+              secretKey: "The Secret Key"

--- a/templates/bindings/core/aws-kinesis-firehose-sink-binding.yaml
+++ b/templates/bindings/core/aws-kinesis-firehose-sink-binding.yaml
@@ -4,12 +4,12 @@
       parameters:
         period: 1000
         message: "Hello Camel JBang"
-    steps:
-      - to:
-          uri: "kamelet:aws-kinesis-firehose-sink"
-          parameters:
-            accessKey: "The Access Key"
-            region: "eu-west-1"
-            secretKey: "The Secret Key"
-            streamName: "The Stream Name"
-    
+      steps:
+        - to:
+            uri: "kamelet:aws-kinesis-firehose-sink"
+            parameters:
+              accessKey: "The Access Key"
+              region: "eu-west-1"
+              secretKey: "The Secret Key"
+              streamName: "The Stream Name"
+

--- a/templates/bindings/core/aws-kinesis-sink-binding.yaml
+++ b/templates/bindings/core/aws-kinesis-sink-binding.yaml
@@ -4,12 +4,11 @@
       parameters:
         period: 1000
         message: "Hello Camel JBang"
-    steps:
-      - to:
-          uri: "kamelet:aws-kinesis-sink"
-          parameters:
-            accessKey: "The Access Key"
-            region: "eu-west-1"
-            secretKey: "The Secret Key"
-            stream: "The Stream Name"
-    
+      steps:
+        - to:
+            uri: "kamelet:aws-kinesis-sink"
+            parameters:
+              accessKey: "The Access Key"
+              region: "eu-west-1"
+              secretKey: "The Secret Key"
+              stream: "The Stream Name"

--- a/templates/bindings/core/aws-kinesis-source-binding.yaml
+++ b/templates/bindings/core/aws-kinesis-source-binding.yaml
@@ -6,7 +6,6 @@
         region: "eu-west-1"
         secretKey: "The Secret Key"
         stream: "The Stream Name"
-    steps:
-      - to:
-          uri: "log:info"
-    
+      steps:
+        - to:
+            uri: "log:info"

--- a/templates/bindings/core/aws-lambda-sink-binding.yaml
+++ b/templates/bindings/core/aws-lambda-sink-binding.yaml
@@ -4,12 +4,11 @@
       parameters:
         period: 1000
         message: "Hello Camel JBang"
-    steps:
-      - to:
-          uri: "kamelet:aws-lambda-sink"
-          parameters:
-            accessKey: "The Access Key"
-            function: "The Function Name"
-            region: "eu-west-1"
-            secretKey: "The Secret Key"
-    
+      steps:
+        - to:
+            uri: "kamelet:aws-lambda-sink"
+            parameters:
+              accessKey: "The Access Key"
+              function: "The Function Name"
+              region: "eu-west-1"
+              secretKey: "The Secret Key"

--- a/templates/bindings/core/aws-redshift-sink-binding.yaml
+++ b/templates/bindings/core/aws-redshift-sink-binding.yaml
@@ -4,13 +4,12 @@
       parameters:
         period: 1000
         message: "Hello Camel JBang"
-    steps:
-      - to:
-          uri: "kamelet:aws-redshift-sink"
-          parameters:
-            databaseName: "The Database Name"
-            password: "The Password"
-            query: "INSERT INTO accounts (username,city) VALUES (:#username,:#city)"
-            serverName: "localhost"
-            username: "The Username"
-    
+      steps:
+        - to:
+            uri: "kamelet:aws-redshift-sink"
+            parameters:
+              databaseName: "The Database Name"
+              password: "The Password"
+              query: "INSERT INTO accounts (username,city) VALUES (:#username,:#city)"
+              serverName: "localhost"
+              username: "The Username"

--- a/templates/bindings/core/aws-redshift-source-binding.yaml
+++ b/templates/bindings/core/aws-redshift-source-binding.yaml
@@ -7,7 +7,6 @@
         query: "INSERT INTO accounts (username,city) VALUES (:#username,:#city)"
         serverName: "localhost"
         username: "The Username"
-    steps:
-      - to:
-          uri: "log:info"
-    
+      steps:
+        - to:
+            uri: "log:info"

--- a/templates/bindings/core/aws-s3-sink-binding.yaml
+++ b/templates/bindings/core/aws-s3-sink-binding.yaml
@@ -4,12 +4,11 @@
       parameters:
         period: 1000
         message: "Hello Camel JBang"
-    steps:
-      - to:
-          uri: "kamelet:aws-s3-sink"
-          parameters:
-            accessKey: "The Access Key"
-            bucketNameOrArn: "The Bucket Name"
-            region: "eu-west-1"
-            secretKey: "The Secret Key"
-    
+      steps:
+        - to:
+            uri: "kamelet:aws-s3-sink"
+            parameters:
+              accessKey: "The Access Key"
+              bucketNameOrArn: "The Bucket Name"
+              region: "eu-west-1"
+              secretKey: "The Secret Key"

--- a/templates/bindings/core/aws-s3-source-binding.yaml
+++ b/templates/bindings/core/aws-s3-source-binding.yaml
@@ -6,7 +6,6 @@
         bucketNameOrArn: "The Bucket Name"
         region: "eu-west-1"
         secretKey: "The Secret Key"
-    steps:
-      - to:
-          uri: "log:info"
-    
+      steps:
+        - to:
+            uri: "log:info"

--- a/templates/bindings/core/aws-s3-streaming-upload-sink-binding.yaml
+++ b/templates/bindings/core/aws-s3-streaming-upload-sink-binding.yaml
@@ -4,13 +4,12 @@
       parameters:
         period: 1000
         message: "Hello Camel JBang"
-    steps:
-      - to:
-          uri: "kamelet:aws-s3-streaming-upload-sink"
-          parameters:
-            accessKey: "The Access Key"
-            bucketNameOrArn: "The Bucket Name"
-            keyName: "The Key Name"
-            region: "eu-west-1"
-            secretKey: "The Secret Key"
-    
+      steps:
+        - to:
+            uri: "kamelet:aws-s3-streaming-upload-sink"
+            parameters:
+              accessKey: "The Access Key"
+              bucketNameOrArn: "The Bucket Name"
+              keyName: "The Key Name"
+              region: "eu-west-1"
+              secretKey: "The Secret Key"

--- a/templates/bindings/core/aws-secrets-manager-sink-binding.yaml
+++ b/templates/bindings/core/aws-secrets-manager-sink-binding.yaml
@@ -4,11 +4,10 @@
       parameters:
         period: 1000
         message: "Hello Camel JBang"
-    steps:
-      - to:
-          uri: "kamelet:aws-secrets-manager-sink"
-          parameters:
-            accessKey: "The Access Key"
-            region: "eu-west-1"
-            secretKey: "The Secret Key"
-    
+      steps:
+        - to:
+            uri: "kamelet:aws-secrets-manager-sink"
+            parameters:
+              accessKey: "The Access Key"
+              region: "eu-west-1"
+              secretKey: "The Secret Key"

--- a/templates/bindings/core/aws-sns-fifo-sink-binding.yaml
+++ b/templates/bindings/core/aws-sns-fifo-sink-binding.yaml
@@ -4,12 +4,11 @@
       parameters:
         period: 1000
         message: "Hello Camel JBang"
-    steps:
-      - to:
-          uri: "kamelet:aws-sns-fifo-sink"
-          parameters:
-            accessKey: "The Access Key"
-            region: "eu-west-1"
-            secretKey: "The Secret Key"
-            topicNameOrArn: "The Topic Name"
-    
+      steps:
+        - to:
+            uri: "kamelet:aws-sns-fifo-sink"
+            parameters:
+              accessKey: "The Access Key"
+              region: "eu-west-1"
+              secretKey: "The Secret Key"
+              topicNameOrArn: "The Topic Name"

--- a/templates/bindings/core/aws-sns-sink-binding.yaml
+++ b/templates/bindings/core/aws-sns-sink-binding.yaml
@@ -4,12 +4,11 @@
       parameters:
         period: 1000
         message: "Hello Camel JBang"
-    steps:
-      - to:
-          uri: "kamelet:aws-sns-sink"
-          parameters:
-            accessKey: "The Access Key"
-            region: "eu-west-1"
-            secretKey: "The Secret Key"
-            topicNameOrArn: "The Topic Name"
-    
+      steps:
+        - to:
+            uri: "kamelet:aws-sns-sink"
+            parameters:
+              accessKey: "The Access Key"
+              region: "eu-west-1"
+              secretKey: "The Secret Key"
+              topicNameOrArn: "The Topic Name"

--- a/templates/bindings/core/aws-sqs-batch-sink-binding.yaml
+++ b/templates/bindings/core/aws-sqs-batch-sink-binding.yaml
@@ -4,13 +4,12 @@
       parameters:
         period: 1000
         message: "Hello Camel JBang"
-    steps:
-      - to:
-          uri: "kamelet:aws-sqs-batch-sink"
-          parameters:
-            accessKey: "The Access Key"
-            batchSeparator: ","
-            queueNameOrArn: "The Queue Name"
-            region: "eu-west-1"
-            secretKey: "The Secret Key"
-    
+      steps:
+        - to:
+            uri: "kamelet:aws-sqs-batch-sink"
+            parameters:
+              accessKey: "The Access Key"
+              batchSeparator: ","
+              queueNameOrArn: "The Queue Name"
+              region: "eu-west-1"
+              secretKey: "The Secret Key"

--- a/templates/bindings/core/aws-sqs-fifo-sink-binding.yaml
+++ b/templates/bindings/core/aws-sqs-fifo-sink-binding.yaml
@@ -4,12 +4,11 @@
       parameters:
         period: 1000
         message: "Hello Camel JBang"
-    steps:
-      - to:
-          uri: "kamelet:aws-sqs-fifo-sink"
-          parameters:
-            accessKey: "The Access Key"
-            queueNameOrArn: "The Queue Name"
-            region: "eu-west-1"
-            secretKey: "The Secret Key"
-    
+      steps:
+        - to:
+            uri: "kamelet:aws-sqs-fifo-sink"
+            parameters:
+              accessKey: "The Access Key"
+              queueNameOrArn: "The Queue Name"
+              region: "eu-west-1"
+              secretKey: "The Secret Key"

--- a/templates/bindings/core/aws-sqs-sink-binding.yaml
+++ b/templates/bindings/core/aws-sqs-sink-binding.yaml
@@ -4,12 +4,11 @@
       parameters:
         period: 1000
         message: "Hello Camel JBang"
-    steps:
-      - to:
-          uri: "kamelet:aws-sqs-sink"
-          parameters:
-            accessKey: "The Access Key"
-            queueNameOrArn: "The Queue Name"
-            region: "eu-west-1"
-            secretKey: "The Secret Key"
-    
+      steps:
+        - to:
+            uri: "kamelet:aws-sqs-sink"
+            parameters:
+              accessKey: "The Access Key"
+              queueNameOrArn: "The Queue Name"
+              region: "eu-west-1"
+              secretKey: "The Secret Key"

--- a/templates/bindings/core/aws-sqs-source-binding.yaml
+++ b/templates/bindings/core/aws-sqs-source-binding.yaml
@@ -6,7 +6,6 @@
         queueNameOrArn: "The Queue Name"
         region: "eu-west-1"
         secretKey: "The Secret Key"
-    steps:
-      - to:
-          uri: "log:info"
-    
+      steps:
+        - to:
+            uri: "log:info"

--- a/templates/bindings/core/aws-translate-action-binding.yaml
+++ b/templates/bindings/core/aws-translate-action-binding.yaml
@@ -4,14 +4,14 @@
       parameters:
         period: 1000
         message: "{ \"foo\": \"John\"}"
-    steps:
-      - to:
-          uri: "kamelet:aws-translate-action"
-          parameters:
-            accessKey: "The Access Key"
-        region: "eu-west-1"
-        secretKey: "The Secret Key"
-        sourceLanguage: "it"
-        targetLanguage: "en"
-      - to:
-          uri: "log:info"
+      steps:
+        - to:
+            uri: "kamelet:aws-translate-action"
+            parameters:
+              accessKey: "The Access Key"
+          region: "eu-west-1"
+          secretKey: "The Secret Key"
+          sourceLanguage: "it"
+          targetLanguage: "en"
+        - to:
+            uri: "log:info"

--- a/templates/bindings/core/azure-cosmosdb-source-binding.yaml
+++ b/templates/bindings/core/azure-cosmosdb-source-binding.yaml
@@ -6,7 +6,6 @@
         containerName: "The Container Name"
         databaseEndpoint: "The Database Endpoint"
         databaseName: "The Database Name"
-    steps:
-      - to:
-          uri: "log:info"
-    
+      steps:
+        - to:
+            uri: "log:info"

--- a/templates/bindings/core/azure-eventhubs-sink-binding.yaml
+++ b/templates/bindings/core/azure-eventhubs-sink-binding.yaml
@@ -4,12 +4,11 @@
       parameters:
         period: 1000
         message: "Hello Camel JBang"
-    steps:
-      - to:
-          uri: "kamelet:azure-eventhubs-sink"
-          parameters:
-            eventhubName: "The Eventhubs Name"
-            namespaceName: "The Eventhubs Namespace"
-            sharedAccessKey: "The Share Access Key"
-            sharedAccessName: "The Share Access Name"
-    
+      steps:
+        - to:
+            uri: "kamelet:azure-eventhubs-sink"
+            parameters:
+              eventhubName: "The Eventhubs Name"
+              namespaceName: "The Eventhubs Namespace"
+              sharedAccessKey: "The Share Access Key"
+              sharedAccessName: "The Share Access Name"

--- a/templates/bindings/core/azure-eventhubs-source-binding.yaml
+++ b/templates/bindings/core/azure-eventhubs-source-binding.yaml
@@ -9,7 +9,6 @@
         namespaceName: "The Eventhubs Namespace"
         sharedAccessKey: "The Share Access Key"
         sharedAccessName: "The Share Access Name"
-    steps:
-      - to:
-          uri: "log:info"
-    
+      steps:
+        - to:
+            uri: "log:info"

--- a/templates/bindings/core/azure-storage-blob-sink-binding.yaml
+++ b/templates/bindings/core/azure-storage-blob-sink-binding.yaml
@@ -4,11 +4,10 @@
       parameters:
         period: 1000
         message: "Hello Camel JBang"
-    steps:
-      - to:
-          uri: "kamelet:azure-storage-blob-sink"
-          parameters:
-            accessKey: "The Access Key"
-            accountName: "The Account Name"
-            containerName: "The Container Name"
-    
+      steps:
+        - to:
+            uri: "kamelet:azure-storage-blob-sink"
+            parameters:
+              accessKey: "The Access Key"
+              accountName: "The Account Name"
+              containerName: "The Container Name"

--- a/templates/bindings/core/azure-storage-blob-source-binding.yaml
+++ b/templates/bindings/core/azure-storage-blob-source-binding.yaml
@@ -5,7 +5,6 @@
         accessKey: "The Access Key"
         accountName: "The Account Name"
         containerName: "The Container Name"
-    steps:
-      - to:
-          uri: "log:info"
-    
+      steps:
+        - to:
+            uri: "log:info"

--- a/templates/bindings/core/azure-storage-queue-sink-binding.yaml
+++ b/templates/bindings/core/azure-storage-queue-sink-binding.yaml
@@ -4,11 +4,10 @@
       parameters:
         period: 1000
         message: "Hello Camel JBang"
-    steps:
-      - to:
-          uri: "kamelet:azure-storage-queue-sink"
-          parameters:
-            accessKey: "The Access Key"
-            accountName: "The Account Name"
-            queueName: "The Queue Name"
-    
+      steps:
+        - to:
+            uri: "kamelet:azure-storage-queue-sink"
+            parameters:
+              accessKey: "The Access Key"
+              accountName: "The Account Name"
+              queueName: "The Queue Name"

--- a/templates/bindings/core/azure-storage-queue-source-binding.yaml
+++ b/templates/bindings/core/azure-storage-queue-source-binding.yaml
@@ -5,7 +5,6 @@
         accessKey: "The Access Key"
         accountName: "The Account Name"
         queueName: "The Queue Name"
-    steps:
-      - to:
-          uri: "log:info"
-    
+      steps:
+        - to:
+            uri: "log:info"

--- a/templates/bindings/core/bitcoin-source-binding.yaml
+++ b/templates/bindings/core/bitcoin-source-binding.yaml
@@ -1,7 +1,6 @@
 - route:
     from:
       uri: "kamelet:bitcoin-source"
-    steps:
-      - to:
-          uri: "log:info"
-    
+      steps:
+        - to:
+            uri: "log:info"

--- a/templates/bindings/core/caffeine-action-binding.yaml
+++ b/templates/bindings/core/caffeine-action-binding.yaml
@@ -4,46 +4,46 @@
       parameters:
         period: 10000
         message: '{"foo":"bar"}'
-    steps:
-      - to:
-          uri: "kamelet:json-deserialize-action"
-      - to:
-          uri: "log:info"
-      - to:
-          uri: "kamelet:insert-header-action"
-          parameters:
-            name: "caffeine-key"
-            value: "my-key"
-      - to:
-          uri: "kamelet:insert-header-action"
-          parameters:
-            name: "caffeine-operation"
-            value: "PUT"
-      - to:
-          uri: "kamelet:caffeine-action"
-          parameters:
-            cacheName: "my-cache"
-      # extract the foo field from the body, cleaning the body
-      - to:
-          uri: "kamelet:extract-field-action"
-          parameters:
-            field: '{"foo"}'
-      - to:
-          uri: "log:info"
-      - to:
-          uri: "kamelet:insert-header-action"
-          parameters:
-            name: "caffeine-key"
-            value: "my-key"
-      - to:
-          uri: "kamelet:insert-header-action"
-          parameters:
-            name: "caffeine-operation"
-            value: "GET"
-      # retrieve the json payload from the cache and put into the body
-      - to:
-          uri: "kamelet:caffeine-action"
-          parameters:
-            cacheName: "my-cache"
-      - to:
-          uri: "log:info"
+      steps:
+        - to:
+            uri: "kamelet:json-deserialize-action"
+        - to:
+            uri: "log:info"
+        - to:
+            uri: "kamelet:insert-header-action"
+            parameters:
+              name: "caffeine-key"
+              value: "my-key"
+        - to:
+            uri: "kamelet:insert-header-action"
+            parameters:
+              name: "caffeine-operation"
+              value: "PUT"
+        - to:
+            uri: "kamelet:caffeine-action"
+            parameters:
+              cacheName: "my-cache"
+        # extract the foo field from the body, cleaning the body
+        - to:
+            uri: "kamelet:extract-field-action"
+            parameters:
+              field: '{"foo"}'
+        - to:
+            uri: "log:info"
+        - to:
+            uri: "kamelet:insert-header-action"
+            parameters:
+              name: "caffeine-key"
+              value: "my-key"
+        - to:
+            uri: "kamelet:insert-header-action"
+            parameters:
+              name: "caffeine-operation"
+              value: "GET"
+        # retrieve the json payload from the cache and put into the body
+        - to:
+            uri: "kamelet:caffeine-action"
+            parameters:
+              cacheName: "my-cache"
+        - to:
+            uri: "log:info"

--- a/templates/bindings/core/cassandra-sink-binding.yaml
+++ b/templates/bindings/core/cassandra-sink-binding.yaml
@@ -4,12 +4,11 @@
       parameters:
         period: 1000
         message: "Hello Camel JBang"
-    steps:
-      - to:
-          uri: "kamelet:cassandra-sink"
-          parameters:
-            connectionHost: "localhost"
-            connectionPort: 9042
-            keyspace: "customers"
-            query: "The Query"
-    
+      steps:
+        - to:
+            uri: "kamelet:cassandra-sink"
+            parameters:
+              connectionHost: "localhost"
+              connectionPort: 9042
+              keyspace: "customers"
+              query: "The Query"

--- a/templates/bindings/core/cassandra-source-binding.yaml
+++ b/templates/bindings/core/cassandra-source-binding.yaml
@@ -6,7 +6,6 @@
         connectionPort: 9042
         keyspace: "customers"
         query: "The Query"
-    steps:
-      - to:
-          uri: "log:info"
-    
+      steps:
+        - to:
+            uri: "log:info"

--- a/templates/bindings/core/chuck-norris-source-binding.yaml
+++ b/templates/bindings/core/chuck-norris-source-binding.yaml
@@ -1,7 +1,6 @@
 - route:
     from:
       uri: "kamelet:chuck-norris-source"
-    steps:
-      - to:
-          uri: "log:info"
-    
+      steps:
+        - to:
+            uri: "log:info"

--- a/templates/bindings/core/chunk-template-action-binding.yaml
+++ b/templates/bindings/core/chunk-template-action-binding.yaml
@@ -4,10 +4,10 @@
       parameters:
         period: 1000
         message: "{ \"foo\": \"John\"}"
-    steps:
-      - to:
-          uri: "kamelet:chunk-template-action"
-          parameters:
-            template: "The Template"
-      - to:
-          uri: "log:info"
+      steps:
+        - to:
+            uri: "kamelet:chunk-template-action"
+            parameters:
+              template: "The Template"
+        - to:
+            uri: "log:info"

--- a/templates/bindings/core/couchbase-sink-binding.yaml
+++ b/templates/bindings/core/couchbase-sink-binding.yaml
@@ -4,11 +4,10 @@
       parameters:
         period: 1000
         message: "Hello Camel JBang"
-    steps:
-      - to:
-          uri: "kamelet:couchbase-sink"
-          parameters:
-            bucket: "The Bucket"
-            couchbaseHostname: "The Hostname"
-            protocol: "The Protocol"
-    
+      steps:
+        - to:
+            uri: "kamelet:couchbase-sink"
+            parameters:
+              bucket: "The Bucket"
+              couchbaseHostname: "The Hostname"
+              protocol: "The Protocol"

--- a/templates/bindings/core/cron-source-binding.yaml
+++ b/templates/bindings/core/cron-source-binding.yaml
@@ -4,7 +4,6 @@
       parameters:
         message: "hello world"
         schedule: "0/3 10 * * * ?"
-    steps:
-      - to:
-          uri: "log:info"
-    
+      steps:
+        - to:
+            uri: "log:info"

--- a/templates/bindings/core/delay-action-binding.yaml
+++ b/templates/bindings/core/delay-action-binding.yaml
@@ -4,10 +4,10 @@
       parameters:
         period: 1000
         message: "{ \"foo\": \"John\"}"
-    steps:
-      - to:
-          uri: "kamelet:delay-action"
-          parameters:
-            milliseconds: 1000
-      - to:
-          uri: "log:info"
+      steps:
+        - to:
+            uri: "kamelet:delay-action"
+            parameters:
+              milliseconds: 1000
+        - to:
+            uri: "log:info"

--- a/templates/bindings/core/dns-dig-action-binding.yaml
+++ b/templates/bindings/core/dns-dig-action-binding.yaml
@@ -4,8 +4,8 @@
       parameters:
         period: 1000
         message: "{ \"foo\": \"John\"}"
-    steps:
-      - to:
-          uri: "kamelet:dns-dig-action"
-      - to:
-          uri: "log:info"
+      steps:
+        - to:
+            uri: "kamelet:dns-dig-action"
+        - to:
+            uri: "log:info"

--- a/templates/bindings/core/dns-ip-action-binding.yaml
+++ b/templates/bindings/core/dns-ip-action-binding.yaml
@@ -4,8 +4,8 @@
       parameters:
         period: 1000
         message: "{ \"foo\": \"John\"}"
-    steps:
-      - to:
-          uri: "kamelet:dns-ip-action"
-      - to:
-          uri: "log:info"
+      steps:
+        - to:
+            uri: "kamelet:dns-ip-action"
+        - to:
+            uri: "log:info"

--- a/templates/bindings/core/dns-lookup-action-binding.yaml
+++ b/templates/bindings/core/dns-lookup-action-binding.yaml
@@ -4,8 +4,8 @@
       parameters:
         period: 1000
         message: "{ \"foo\": \"John\"}"
-    steps:
-      - to:
-          uri: "kamelet:dns-lookup-action"
-      - to:
-          uri: "log:info"
+      steps:
+        - to:
+            uri: "kamelet:dns-lookup-action"
+        - to:
+            uri: "log:info"

--- a/templates/bindings/core/dropbox-sink-binding.yaml
+++ b/templates/bindings/core/dropbox-sink-binding.yaml
@@ -4,11 +4,10 @@
       parameters:
         period: 1000
         message: "Hello Camel JBang"
-    steps:
-      - to:
-          uri: "kamelet:dropbox-sink"
-          parameters:
-            accessToken: "The Dropbox Access Token"
-            clientIdentifier: "The Client Identifier"
-            remotePath: "The Remote Path"
-    
+      steps:
+        - to:
+            uri: "kamelet:dropbox-sink"
+            parameters:
+              accessToken: "The Dropbox Access Token"
+              clientIdentifier: "The Client Identifier"
+              remotePath: "The Remote Path"

--- a/templates/bindings/core/dropbox-source-binding.yaml
+++ b/templates/bindings/core/dropbox-source-binding.yaml
@@ -6,7 +6,6 @@
         clientIdentifier: "The Client Identifier"
         query: "The Queries"
         remotePath: "The Remote Path"
-    steps:
-      - to:
-          uri: "log:info"
-    
+      steps:
+        - to:
+            uri: "log:info"

--- a/templates/bindings/core/earthquake-source-binding.yaml
+++ b/templates/bindings/core/earthquake-source-binding.yaml
@@ -1,7 +1,6 @@
 - route:
     from:
       uri: "kamelet:earthquake-source"
-    steps:
-      - to:
-          uri: "log:info"
-    
+      steps:
+        - to:
+            uri: "log:info"

--- a/templates/bindings/core/elasticsearch-index-sink-binding.yaml
+++ b/templates/bindings/core/elasticsearch-index-sink-binding.yaml
@@ -4,10 +4,9 @@
       parameters:
         period: 1000
         message: "Hello Camel JBang"
-    steps:
-      - to:
-          uri: "kamelet:elasticsearch-index-sink"
-          parameters:
-            clusterName: "quickstart"
-            hostAddresses: "quickstart-es-http:9200"
-    
+      steps:
+        - to:
+            uri: "kamelet:elasticsearch-index-sink"
+            parameters:
+              clusterName: "quickstart"
+              hostAddresses: "quickstart-es-http:9200"

--- a/templates/bindings/core/elasticsearch-search-source-binding.yaml
+++ b/templates/bindings/core/elasticsearch-search-source-binding.yaml
@@ -6,7 +6,6 @@
         hostAddresses: "The Host Addresses"
         indexName: "The Index in ElasticSearch"
         query: "The Query"
-    steps:
-      - to:
-          uri: "log:info"
-    
+      steps:
+        - to:
+            uri: "log:info"

--- a/templates/bindings/core/exec-sink-binding.yaml
+++ b/templates/bindings/core/exec-sink-binding.yaml
@@ -4,9 +4,8 @@
       parameters:
         period: 1000
         message: "Hello Camel JBang"
-    steps:
-      - to:
-          uri: "kamelet:exec-sink"
-          parameters:
-            executable: "The Executable Command"
-    
+      steps:
+        - to:
+            uri: "kamelet:exec-sink"
+            parameters:
+              executable: "The Executable Command"

--- a/templates/bindings/core/extract-field-action-binding.yaml
+++ b/templates/bindings/core/extract-field-action-binding.yaml
@@ -4,10 +4,10 @@
       parameters:
         period: 1000
         message: "{ \"foo\": \"John\"}"
-    steps:
-      - to:
-          uri: "kamelet:extract-field-action"
-          parameters:
-            field: "The Field"
-      - to:
-          uri: "log:info"
+      steps:
+        - to:
+            uri: "kamelet:extract-field-action"
+            parameters:
+              field: "The Field"
+        - to:
+            uri: "log:info"

--- a/templates/bindings/core/fhir-source-binding.yaml
+++ b/templates/bindings/core/fhir-source-binding.yaml
@@ -5,7 +5,6 @@
         password: "The Password"
         serverUrl: "The Server URL"
         username: "The Username"
-    steps:
-      - to:
-          uri: "log:info"
-    
+      steps:
+        - to:
+            uri: "log:info"

--- a/templates/bindings/core/file-watch-source-binding.yaml
+++ b/templates/bindings/core/file-watch-source-binding.yaml
@@ -3,7 +3,6 @@
       uri: "kamelet:file-watch-source"
       parameters:
         filePath: "The Path to Watch"
-    steps:
-      - to:
-          uri: "log:info"
-    
+      steps:
+        - to:
+            uri: "log:info"

--- a/templates/bindings/core/freemarker-template-action-binding.yaml
+++ b/templates/bindings/core/freemarker-template-action-binding.yaml
@@ -4,10 +4,10 @@
       parameters:
         period: 1000
         message: "{ \"foo\": \"John\"}"
-    steps:
-      - to:
-          uri: "kamelet:freemarker-template-action"
-          parameters:
-            template: "The Template"
-      - to:
-          uri: "log:info"
+      steps:
+        - to:
+            uri: "kamelet:freemarker-template-action"
+            parameters:
+              template: "The Template"
+        - to:
+            uri: "log:info"

--- a/templates/bindings/core/ftp-sink-binding.yaml
+++ b/templates/bindings/core/ftp-sink-binding.yaml
@@ -4,12 +4,11 @@
       parameters:
         period: 1000
         message: "Hello Camel JBang"
-    steps:
-      - to:
-          uri: "kamelet:ftp-sink"
-          parameters:
-            connectionHost: "The Connection Host"
-            directoryName: "The Directory Name"
-            password: "The Password"
-            username: "The Username"
-    
+      steps:
+        - to:
+            uri: "kamelet:ftp-sink"
+            parameters:
+              connectionHost: "The Connection Host"
+              directoryName: "The Directory Name"
+              password: "The Password"
+              username: "The Username"

--- a/templates/bindings/core/ftp-source-binding.yaml
+++ b/templates/bindings/core/ftp-source-binding.yaml
@@ -6,7 +6,6 @@
         directoryName: "The Directory Name"
         password: "The Password"
         username: "The Username"
-    steps:
-      - to:
-          uri: "log:info"
-    
+      steps:
+        - to:
+            uri: "log:info"

--- a/templates/bindings/core/ftps-sink-binding.yaml
+++ b/templates/bindings/core/ftps-sink-binding.yaml
@@ -4,12 +4,11 @@
       parameters:
         period: 1000
         message: "Hello Camel JBang"
-    steps:
-      - to:
-          uri: "kamelet:ftps-sink"
-          parameters:
-            connectionHost: "The Connection Host"
-            directoryName: "The Directory Name"
-            password: "The Password"
-            username: "The Username"
-    
+      steps:
+        - to:
+            uri: "kamelet:ftps-sink"
+            parameters:
+              connectionHost: "The Connection Host"
+              directoryName: "The Directory Name"
+              password: "The Password"
+              username: "The Username"

--- a/templates/bindings/core/ftps-source-binding.yaml
+++ b/templates/bindings/core/ftps-source-binding.yaml
@@ -6,7 +6,6 @@
         directoryName: "The Directory Name"
         password: "The Password"
         username: "The Username"
-    steps:
-      - to:
-          uri: "log:info"
-    
+      steps:
+        - to:
+            uri: "log:info"

--- a/templates/bindings/core/github-commit-source-binding.yaml
+++ b/templates/bindings/core/github-commit-source-binding.yaml
@@ -6,7 +6,6 @@
         oauthToken: "The OAuth Token"
         repoName: "The Repository Name"
         repoOwner: "The Repository Owner"
-    steps:
-      - to:
-          uri: "log:info"
-    
+      steps:
+        - to:
+            uri: "log:info"

--- a/templates/bindings/core/github-event-source-binding.yaml
+++ b/templates/bindings/core/github-event-source-binding.yaml
@@ -5,7 +5,6 @@
         oauthToken: "The OAuth Token"
         repoName: "The Repository Name"
         repoOwner: "The Repository Owner"
-    steps:
-      - to:
-          uri: "log:info"
-    
+      steps:
+        - to:
+            uri: "log:info"

--- a/templates/bindings/core/github-source-binding.yaml
+++ b/templates/bindings/core/github-source-binding.yaml
@@ -5,7 +5,6 @@
         oauthToken: "The OAuth Token"
         repoName: "The Repository Name"
         repoOwner: "The Repository Owner"
-    steps:
-      - to:
-          uri: "log:info"
-    
+      steps:
+        - to:
+            uri: "log:info"

--- a/templates/bindings/core/github-tag-source-binding.yaml
+++ b/templates/bindings/core/github-tag-source-binding.yaml
@@ -5,7 +5,6 @@
         oauthToken: "The OAuth Token"
         repoName: "The Repository Name"
         repoOwner: "The Repository Owner"
-    steps:
-      - to:
-          uri: "log:info"
-    
+      steps:
+        - to:
+            uri: "log:info"

--- a/templates/bindings/core/google-calendar-source-binding.yaml
+++ b/templates/bindings/core/google-calendar-source-binding.yaml
@@ -9,7 +9,6 @@
         clientSecret: "The Client Secret"
         index: "The Index"
         refreshToken: "The Refresh Token"
-    steps:
-      - to:
-          uri: "log:info"
-    
+      steps:
+        - to:
+            uri: "log:info"

--- a/templates/bindings/core/google-functions-sink-binding.yaml
+++ b/templates/bindings/core/google-functions-sink-binding.yaml
@@ -4,12 +4,11 @@
       parameters:
         period: 1000
         message: "Hello Camel JBang"
-    steps:
-      - to:
-          uri: "kamelet:google-functions-sink"
-          parameters:
-            functionName: "The Function Name"
-            projectId: "The Project Id"
-            region: "The Region"
-            serviceAccountKey: "The Service Account Key"
-    
+      steps:
+        - to:
+            uri: "kamelet:google-functions-sink"
+            parameters:
+              functionName: "The Function Name"
+              projectId: "The Project Id"
+              region: "The Region"
+              serviceAccountKey: "The Service Account Key"

--- a/templates/bindings/core/google-mail-source-binding.yaml
+++ b/templates/bindings/core/google-mail-source-binding.yaml
@@ -8,7 +8,6 @@
         clientSecret: "The Client Secret"
         index: "The Index"
         refreshToken: "The Refresh Token"
-    steps:
-      - to:
-          uri: "log:info"
-    
+      steps:
+        - to:
+            uri: "log:info"

--- a/templates/bindings/core/google-pubsub-sink-binding.yaml
+++ b/templates/bindings/core/google-pubsub-sink-binding.yaml
@@ -4,11 +4,10 @@
       parameters:
         period: 1000
         message: "Hello Camel JBang"
-    steps:
-      - to:
-          uri: "kamelet:google-pubsub-sink"
-          parameters:
-            destinationName: "The Destination Name"
-            projectId: "The Project Id"
-            serviceAccountKey: "The Service Account Key"
-    
+      steps:
+        - to:
+            uri: "kamelet:google-pubsub-sink"
+            parameters:
+              destinationName: "The Destination Name"
+              projectId: "The Project Id"
+              serviceAccountKey: "The Service Account Key"

--- a/templates/bindings/core/google-pubsub-source-binding.yaml
+++ b/templates/bindings/core/google-pubsub-source-binding.yaml
@@ -5,7 +5,6 @@
         projectId: "The Project Id"
         serviceAccountKey: "The Service Account Key"
         subscriptionName: "The Subscription Name"
-    steps:
-      - to:
-          uri: "log:info"
-    
+      steps:
+        - to:
+            uri: "log:info"

--- a/templates/bindings/core/google-sheets-source-binding.yaml
+++ b/templates/bindings/core/google-sheets-source-binding.yaml
@@ -9,7 +9,6 @@
         index: "The Index"
         refreshToken: "The Refresh Token"
         spreadsheetId: "The Spreadsheet ID"
-    steps:
-      - to:
-          uri: "log:info"
-    
+      steps:
+        - to:
+            uri: "log:info"

--- a/templates/bindings/core/google-storage-sink-binding.yaml
+++ b/templates/bindings/core/google-storage-sink-binding.yaml
@@ -4,10 +4,9 @@
       parameters:
         period: 1000
         message: "Hello Camel JBang"
-    steps:
-      - to:
-          uri: "kamelet:google-storage-sink"
-          parameters:
-            bucketNameOrArn: "The Bucket Name Or ARN"
-            serviceAccountKey: "The Service Account Key"
-    
+      steps:
+        - to:
+            uri: "kamelet:google-storage-sink"
+            parameters:
+              bucketNameOrArn: "The Bucket Name Or ARN"
+              serviceAccountKey: "The Service Account Key"

--- a/templates/bindings/core/google-storage-source-binding.yaml
+++ b/templates/bindings/core/google-storage-source-binding.yaml
@@ -4,7 +4,6 @@
       parameters:
         bucketNameOrArn: "The Bucket Name Or ARN"
         serviceAccountKey: "The Service Account Key"
-    steps:
-      - to:
-          uri: "log:info"
-    
+      steps:
+        - to:
+            uri: "log:info"

--- a/templates/bindings/core/has-header-filter-action-binding.yaml
+++ b/templates/bindings/core/has-header-filter-action-binding.yaml
@@ -4,15 +4,15 @@
       parameters:
         period: 1000
         message: "{ \"foo\": \"John\"}"
-    steps:
-      - to:
-          uri: "kamelet:insert-header-action"
-          parameters:
-            name: "my-header"
-            value: "my-value"
-      - to:
-          uri: "kamelet:has-header-filter-action"
-          parameters:
-            name: "my-header"
-      - to:
-          uri: "log:info"
+      steps:
+        - to:
+            uri: "kamelet:insert-header-action"
+            parameters:
+              name: "my-header"
+              value: "my-value"
+        - to:
+            uri: "kamelet:has-header-filter-action"
+            parameters:
+              name: "my-header"
+        - to:
+            uri: "log:info"

--- a/templates/bindings/core/header-matches-filter-action-binding.yaml
+++ b/templates/bindings/core/header-matches-filter-action-binding.yaml
@@ -4,10 +4,10 @@
       parameters:
         period: 1000
         message: "{ \"foo\": \"John\"}"
-    steps:
-      - to:
-          uri: "kamelet:header-matches-filter-action"
-          parameters:
-            regex: "The Regex"
-      - to:
-          uri: "log:info"
+      steps:
+        - to:
+            uri: "kamelet:header-matches-filter-action"
+            parameters:
+              regex: "The Regex"
+        - to:
+            uri: "log:info"

--- a/templates/bindings/core/hoist-field-action-binding.yaml
+++ b/templates/bindings/core/hoist-field-action-binding.yaml
@@ -4,10 +4,10 @@
       parameters:
         period: 1000
         message: "{ \"foo\": \"John\"}"
-    steps:
-      - to:
-          uri: "kamelet:hoist-field-action"
-          parameters:
-            field: "The Field"
-      - to:
-          uri: "log:info"
+      steps:
+        - to:
+            uri: "kamelet:hoist-field-action"
+            parameters:
+              field: "The Field"
+        - to:
+            uri: "log:info"

--- a/templates/bindings/core/http-secured-sink-binding.yaml
+++ b/templates/bindings/core/http-secured-sink-binding.yaml
@@ -4,9 +4,8 @@
       parameters:
         period: 1000
         message: "Hello Camel JBang"
-    steps:
-      - to:
-          uri: "kamelet:http-secured-sink"
-          parameters:
-            url: "https://my-service/path"
-    
+      steps:
+        - to:
+            uri: "kamelet:http-secured-sink"
+            parameters:
+              url: "https://my-service/path"

--- a/templates/bindings/core/http-secured-source-binding.yaml
+++ b/templates/bindings/core/http-secured-source-binding.yaml
@@ -3,7 +3,6 @@
       uri: "kamelet:http-secured-source"
       parameters:
         url: "https://gist.githubusercontent.com/nicolaferraro/e3c72ace3c751f9f88273896611ce5fe/raw/3b6f54060bacb56b6719b7386a4645cb59ad6cc1/quote.json"
-    steps:
-      - to:
-          uri: "log:info"
-    
+      steps:
+        - to:
+            uri: "log:info"

--- a/templates/bindings/core/http-sink-binding.yaml
+++ b/templates/bindings/core/http-sink-binding.yaml
@@ -4,9 +4,8 @@
       parameters:
         period: 1000
         message: "Hello Camel JBang"
-    steps:
-      - to:
-          uri: "kamelet:http-sink"
-          parameters:
-            url: "https://my-service/path"
-    
+      steps:
+        - to:
+            uri: "kamelet:http-sink"
+            parameters:
+              url: "https://my-service/path"

--- a/templates/bindings/core/http-source-binding.yaml
+++ b/templates/bindings/core/http-source-binding.yaml
@@ -3,7 +3,6 @@
       uri: "kamelet:http-source"
       parameters:
         url: "https://gist.githubusercontent.com/nicolaferraro/e3c72ace3c751f9f88273896611ce5fe/raw/3b6f54060bacb56b6719b7386a4645cb59ad6cc1/quote.json"
-    steps:
-      - to:
-          uri: "log:info"
-    
+      steps:
+        - to:
+            uri: "log:info"

--- a/templates/bindings/core/infinispan-sink-binding.yaml
+++ b/templates/bindings/core/infinispan-sink-binding.yaml
@@ -4,12 +4,11 @@
       parameters:
         period: 1000
         message: "Hello Camel JBang"
-    steps:
-      - to:
-          uri: "kamelet:infinispan-sink"
-          parameters:
-            cacheName: "The Cache Name"
-            hosts: "The Hosts"
-            password: "The Password"
-            username: "The Username"
-    
+      steps:
+        - to:
+            uri: "kamelet:infinispan-sink"
+            parameters:
+              cacheName: "The Cache Name"
+              hosts: "The Hosts"
+              password: "The Password"
+              username: "The Username"

--- a/templates/bindings/core/infinispan-source-binding.yaml
+++ b/templates/bindings/core/infinispan-source-binding.yaml
@@ -6,7 +6,6 @@
         hosts: "The Hosts"
         password: "The Password"
         username: "The Username"
-    steps:
-      - to:
-          uri: "log:info"
-    
+      steps:
+        - to:
+            uri: "log:info"

--- a/templates/bindings/core/insert-field-action-binding.yaml
+++ b/templates/bindings/core/insert-field-action-binding.yaml
@@ -4,13 +4,13 @@
       parameters:
         period: 1000
         message: '{"foo": "John"}'
-    steps:
-      - to:
-          uri: "kamelet:json-deserialize-action"
-      - to:
-          uri: "kamelet:insert-field-action"
-          parameters:
-            field: "The Field"
-            value: "The Value"
-      - to:
-          uri: "log:info"
+      steps:
+        - to:
+            uri: "kamelet:json-deserialize-action"
+        - to:
+            uri: "kamelet:insert-field-action"
+            parameters:
+              field: "The Field"
+              value: "The Value"
+        - to:
+            uri: "log:info"

--- a/templates/bindings/core/insert-header-action-binding.yaml
+++ b/templates/bindings/core/insert-header-action-binding.yaml
@@ -4,11 +4,11 @@
       parameters:
         period: 1000
         message: "{ \"foo\": \"John\"}"
-    steps:
-      - to:
-          uri: "kamelet:insert-header-action"
-          parameters:
-            name: "headername"
-        value: "The Value"
-      - to:
-          uri: "log:info"
+      steps:
+        - to:
+            uri: "kamelet:insert-header-action"
+            parameters:
+              name: "headername"
+          value: "The Value"
+        - to:
+            uri: "log:info"

--- a/templates/bindings/core/is-tombstone-filter-action-binding.yaml
+++ b/templates/bindings/core/is-tombstone-filter-action-binding.yaml
@@ -4,8 +4,8 @@
       parameters:
         period: 1000
         message: "{ \"foo\": \"John\"}"
-    steps:
-      - to:
-          uri: "kamelet:is-tombstone-filter-action"
-      - to:
-          uri: "log:info"
+      steps:
+        - to:
+            uri: "kamelet:is-tombstone-filter-action"
+        - to:
+            uri: "log:info"

--- a/templates/bindings/core/jira-source-binding.yaml
+++ b/templates/bindings/core/jira-source-binding.yaml
@@ -5,7 +5,6 @@
         jiraUrl: "http://my_jira.com:8081"
         password: "The Password"
         username: "The Username"
-    steps:
-      - to:
-          uri: "log:info"
-    
+      steps:
+        - to:
+            uri: "log:info"

--- a/templates/bindings/core/jms-amqp-10-sink-binding.yaml
+++ b/templates/bindings/core/jms-amqp-10-sink-binding.yaml
@@ -4,10 +4,9 @@
       parameters:
         period: 1000
         message: "Hello Camel JBang"
-    steps:
-      - to:
-          uri: "kamelet:jms-amqp-10-sink"
-          parameters:
-            destinationName: "The Destination Name"
-            remoteURI: "amqp://my-host:31616"
-    
+      steps:
+        - to:
+            uri: "kamelet:jms-amqp-10-sink"
+            parameters:
+              destinationName: "The Destination Name"
+              remoteURI: "amqp://my-host:31616"

--- a/templates/bindings/core/jms-amqp-10-source-binding.yaml
+++ b/templates/bindings/core/jms-amqp-10-source-binding.yaml
@@ -4,7 +4,6 @@
       parameters:
         destinationName: "The Destination Name"
         remoteURI: "amqp://my-host:31616"
-    steps:
-      - to:
-          uri: "log:info"
-    
+      steps:
+        - to:
+            uri: "log:info"

--- a/templates/bindings/core/jms-apache-artemis-sink-binding.yaml
+++ b/templates/bindings/core/jms-apache-artemis-sink-binding.yaml
@@ -4,10 +4,9 @@
       parameters:
         period: 1000
         message: "Hello Camel JBang"
-    steps:
-      - to:
-          uri: "kamelet:jms-apache-artemis-sink"
-          parameters:
-            brokerURL: "tcp://my-host:61616"
-            destinationName: "person"
-    
+      steps:
+        - to:
+            uri: "kamelet:jms-apache-artemis-sink"
+            parameters:
+              brokerURL: "tcp://my-host:61616"
+              destinationName: "person"

--- a/templates/bindings/core/jms-apache-artemis-source-binding.yaml
+++ b/templates/bindings/core/jms-apache-artemis-source-binding.yaml
@@ -4,7 +4,6 @@
       parameters:
         brokerURL: "tcp://k3s-node-master.usersys.redhat.com:31616"
         destinationName: "The Destination Name"
-    steps:
-      - to:
-          uri: "log:info"
-    
+      steps:
+        - to:
+            uri: "log:info"

--- a/templates/bindings/core/jolt-transformation-action-binding.yaml
+++ b/templates/bindings/core/jolt-transformation-action-binding.yaml
@@ -4,10 +4,10 @@
       parameters:
         period: 1000
         message: "{ \"foo\": \"John\"}"
-    steps:
-      - to:
-          uri: "kamelet:jolt-transformation-action"
-          parameters:
-            template: "The Template"
-      - to:
-          uri: "log:info"
+      steps:
+        - to:
+            uri: "kamelet:jolt-transformation-action"
+            parameters:
+              template: "The Template"
+        - to:
+            uri: "log:info"

--- a/templates/bindings/core/json-deserialize-action-binding.yaml
+++ b/templates/bindings/core/json-deserialize-action-binding.yaml
@@ -4,8 +4,8 @@
       parameters:
         period: 1000
         message: "{ \"foo\": \"John\"}"
-    steps:
-      - to:
-          uri: "kamelet:json-deserialize-action"
-      - to:
-          uri: "log:info"
+      steps:
+        - to:
+            uri: "kamelet:json-deserialize-action"
+        - to:
+            uri: "log:info"

--- a/templates/bindings/core/json-patch-action-binding.yaml
+++ b/templates/bindings/core/json-patch-action-binding.yaml
@@ -4,10 +4,10 @@
       parameters:
         period: 1000
         message: "{ \"foo\": \"John\"}"
-    steps:
-      - to:
-          uri: "kamelet:json-patch-action"
-          parameters:
-            template: "The Template"
-      - to:
-          uri: "log:info"
+      steps:
+        - to:
+            uri: "kamelet:json-patch-action"
+            parameters:
+              template: "The Template"
+        - to:
+            uri: "log:info"

--- a/templates/bindings/core/json-schema-validator-action-binding.yaml
+++ b/templates/bindings/core/json-schema-validator-action-binding.yaml
@@ -4,10 +4,10 @@
       parameters:
         period: 1000
         message: "{ \"foo\": \"John\"}"
-    steps:
-      - to:
-          uri: "kamelet:json-schema-validator-action"
-          parameters:
-            template: "The Template"
-      - to:
-          uri: "log:info"
+      steps:
+        - to:
+            uri: "kamelet:json-schema-validator-action"
+            parameters:
+              template: "The Template"
+        - to:
+            uri: "log:info"

--- a/templates/bindings/core/json-serialize-action-binding.yaml
+++ b/templates/bindings/core/json-serialize-action-binding.yaml
@@ -4,8 +4,8 @@
       parameters:
         period: 1000
         message: "{ \"foo\": \"John\"}"
-    steps:
-      - to:
-          uri: "kamelet:json-serialize-action"
-      - to:
-          uri: "log:info"
+      steps:
+        - to:
+            uri: "kamelet:json-serialize-action"
+        - to:
+            uri: "log:info"

--- a/templates/bindings/core/jsonata-action-binding.yaml
+++ b/templates/bindings/core/jsonata-action-binding.yaml
@@ -4,10 +4,10 @@
       parameters:
         period: 1000
         message: "{ \"foo\": \"John\"}"
-    steps:
-      - to:
-          uri: "kamelet:jsonata-action"
-          parameters:
-            template: "The Template"
-      - to:
-          uri: "log:info"
+      steps:
+        - to:
+            uri: "kamelet:jsonata-action"
+            parameters:
+              template: "The Template"
+        - to:
+            uri: "log:info"

--- a/templates/bindings/core/kafka-manual-commit-action-binding.yaml
+++ b/templates/bindings/core/kafka-manual-commit-action-binding.yaml
@@ -4,8 +4,8 @@
       parameters:
         period: 1000
         message: "{ \"foo\": \"John\"}"
-    steps:
-      - to:
-          uri: "kamelet:kafka-manual-commit-action"
-      - to:
-          uri: "log:info"
+      steps:
+        - to:
+            uri: "kamelet:kafka-manual-commit-action"
+        - to:
+            uri: "log:info"

--- a/templates/bindings/core/kafka-not-secured-sink-binding.yaml
+++ b/templates/bindings/core/kafka-not-secured-sink-binding.yaml
@@ -4,10 +4,9 @@
       parameters:
         period: 1000
         message: "Hello Camel JBang"
-    steps:
-      - to:
-          uri: "kamelet:kafka-not-secured-sink"
-          parameters:
-            bootstrapServers: "The Bootstrap Servers"
-            topic: "The Topic Names"
-    
+      steps:
+        - to:
+            uri: "kamelet:kafka-not-secured-sink"
+            parameters:
+              bootstrapServers: "The Bootstrap Servers"
+              topic: "The Topic Names"

--- a/templates/bindings/core/kafka-not-secured-source-binding.yaml
+++ b/templates/bindings/core/kafka-not-secured-source-binding.yaml
@@ -4,7 +4,6 @@
       parameters:
         bootstrapServers: "The Bootstrap Servers"
         topic: "The Topic Names"
-    steps:
-      - to:
-          uri: "log:info"
-    
+      steps:
+        - to:
+            uri: "log:info"

--- a/templates/bindings/core/kafka-sink-binding.yaml
+++ b/templates/bindings/core/kafka-sink-binding.yaml
@@ -4,12 +4,11 @@
       parameters:
         period: 1000
         message: "Hello Camel JBang"
-    steps:
-      - to:
-          uri: "kamelet:kafka-sink"
-          parameters:
-            bootstrapServers: "The Bootstrap Servers"
-            password: "The Password"
-            topic: "The Topic Names"
-            user: "The Username"
-    
+      steps:
+        - to:
+            uri: "kamelet:kafka-sink"
+            parameters:
+              bootstrapServers: "The Bootstrap Servers"
+              password: "The Password"
+              topic: "The Topic Names"
+              user: "The Username"

--- a/templates/bindings/core/kafka-source-binding.yaml
+++ b/templates/bindings/core/kafka-source-binding.yaml
@@ -6,7 +6,6 @@
         password: "The Password"
         topic: "The Topic Names"
         user: "The Username"
-    steps:
-      - to:
-          uri: "log:info"
-    
+      steps:
+        - to:
+            uri: "log:info"

--- a/templates/bindings/core/kubernetes-namespaces-source-binding.yaml
+++ b/templates/bindings/core/kubernetes-namespaces-source-binding.yaml
@@ -4,7 +4,6 @@
       parameters:
         masterUrl: "The Kubernetes Master URL"
         token: "The Oauth Token"
-    steps:
-      - to:
-          uri: "log:info"
-    
+      steps:
+        - to:
+            uri: "log:info"

--- a/templates/bindings/core/kubernetes-nodes-source-binding.yaml
+++ b/templates/bindings/core/kubernetes-nodes-source-binding.yaml
@@ -4,7 +4,6 @@
       parameters:
         masterUrl: "The Kubernetes Master URL"
         token: "The Oauth Token"
-    steps:
-      - to:
-          uri: "log:info"
-    
+      steps:
+        - to:
+            uri: "log:info"

--- a/templates/bindings/core/kubernetes-pods-source-binding.yaml
+++ b/templates/bindings/core/kubernetes-pods-source-binding.yaml
@@ -4,7 +4,6 @@
       parameters:
         masterUrl: "The Kubernetes Master URL"
         token: "The Oauth Token"
-    steps:
-      - to:
-          uri: "log:info"
-    
+      steps:
+        - to:
+            uri: "log:info"

--- a/templates/bindings/core/log-sink-binding.yaml
+++ b/templates/bindings/core/log-sink-binding.yaml
@@ -4,7 +4,6 @@
       parameters:
         period: 1000
         message: "Hello Camel JBang"
-    steps:
-      - to:
-          uri: "kamelet:log-sink"
-    
+      steps:
+        - to:
+            uri: "kamelet:log-sink"

--- a/templates/bindings/core/mail-imap-source-binding.yaml
+++ b/templates/bindings/core/mail-imap-source-binding.yaml
@@ -5,7 +5,6 @@
         connectionHost: "imap.gmail.com"
         password: "The Password"
         username: "The Username"
-    steps:
-      - to:
-          uri: "log:info"
-    
+      steps:
+        - to:
+            uri: "log:info"

--- a/templates/bindings/core/mail-sink-binding.yaml
+++ b/templates/bindings/core/mail-sink-binding.yaml
@@ -4,11 +4,10 @@
       parameters:
         period: 1000
         message: "Hello Camel JBang"
-    steps:
-      - to:
-          uri: "kamelet:mail-sink"
-          parameters:
-            connectionHost: "smtp.gmail.com"
-            password: "The Password"
-            username: "The Username"
-    
+      steps:
+        - to:
+            uri: "kamelet:mail-sink"
+            parameters:
+              connectionHost: "smtp.gmail.com"
+              password: "The Password"
+              username: "The Username"

--- a/templates/bindings/core/mariadb-sink-binding.yaml
+++ b/templates/bindings/core/mariadb-sink-binding.yaml
@@ -4,13 +4,12 @@
       parameters:
         period: 1000
         message: "Hello Camel JBang"
-    steps:
-      - to:
-          uri: "kamelet:mariadb-sink"
-          parameters:
-            databaseName: "The Database Name"
-            password: "The Password"
-            query: "INSERT INTO accounts (username,city) VALUES (:#username,:#city)"
-            serverName: "localhost"
-            username: "The Username"
-    
+      steps:
+        - to:
+            uri: "kamelet:mariadb-sink"
+            parameters:
+              databaseName: "The Database Name"
+              password: "The Password"
+              query: "INSERT INTO accounts (username,city) VALUES (:#username,:#city)"
+              serverName: "localhost"
+              username: "The Username"

--- a/templates/bindings/core/mariadb-source-binding.yaml
+++ b/templates/bindings/core/mariadb-source-binding.yaml
@@ -7,7 +7,6 @@
         query: "INSERT INTO accounts (username,city) VALUES (:#username,:#city)"
         serverName: "localhost"
         username: "The Username"
-    steps:
-      - to:
-          uri: "log:info"
-    
+      steps:
+        - to:
+            uri: "log:info"

--- a/templates/bindings/core/mask-field-action-binding.yaml
+++ b/templates/bindings/core/mask-field-action-binding.yaml
@@ -4,11 +4,11 @@
       parameters:
         period: 1000
         message: "{ \"foo\": \"John\"}"
-    steps:
-      - to:
-          uri: "kamelet:mask-field-action"
-          parameters:
-            fields: "The Fields"
-        replacement: "The Replacement"
-      - to:
-          uri: "log:info"
+      steps:
+        - to:
+            uri: "kamelet:mask-field-action"
+            parameters:
+              fields: "The Fields"
+          replacement: "The Replacement"
+        - to:
+            uri: "log:info"

--- a/templates/bindings/core/message-timestamp-router-action-binding.yaml
+++ b/templates/bindings/core/message-timestamp-router-action-binding.yaml
@@ -4,10 +4,10 @@
       parameters:
         period: 1000
         message: "{ \"foo\": \"John\"}"
-    steps:
-      - to:
-          uri: "kamelet:message-timestamp-router-action"
-          parameters:
-            timestampKeys: "The Timestamp Keys"
-      - to:
-          uri: "log:info"
+      steps:
+        - to:
+            uri: "kamelet:message-timestamp-router-action"
+            parameters:
+              timestampKeys: "The Timestamp Keys"
+        - to:
+            uri: "log:info"

--- a/templates/bindings/core/minio-sink-binding.yaml
+++ b/templates/bindings/core/minio-sink-binding.yaml
@@ -4,12 +4,11 @@
       parameters:
         period: 1000
         message: "Hello Camel JBang"
-    steps:
-      - to:
-          uri: "kamelet:minio-sink"
-          parameters:
-            accessKey: "The Access Key"
-            bucketName: "The Bucket Name"
-            endpoint: "http://localhost:9000"
-            secretKey: "The Secret Key"
-    
+      steps:
+        - to:
+            uri: "kamelet:minio-sink"
+            parameters:
+              accessKey: "The Access Key"
+              bucketName: "The Bucket Name"
+              endpoint: "http://localhost:9000"
+              secretKey: "The Secret Key"

--- a/templates/bindings/core/minio-source-binding.yaml
+++ b/templates/bindings/core/minio-source-binding.yaml
@@ -6,7 +6,6 @@
         bucketName: "The Bucket Name"
         endpoint: "http://localhost:9000"
         secretKey: "The Secret Key"
-    steps:
-      - to:
-          uri: "log:info"
-    
+      steps:
+        - to:
+            uri: "log:info"

--- a/templates/bindings/core/mongodb-sink-binding.yaml
+++ b/templates/bindings/core/mongodb-sink-binding.yaml
@@ -4,11 +4,10 @@
       parameters:
         period: 1000
         message: "Hello Camel JBang"
-    steps:
-      - to:
-          uri: "kamelet:mongodb-sink"
-          parameters:
-            collection: "The MongoDB Collection"
-            database: "The MongoDB Database"
-            hosts: "The MongoDB Hosts"
-    
+      steps:
+        - to:
+            uri: "kamelet:mongodb-sink"
+            parameters:
+              collection: "The MongoDB Collection"
+              database: "The MongoDB Database"
+              hosts: "The MongoDB Hosts"

--- a/templates/bindings/core/mongodb-source-binding.yaml
+++ b/templates/bindings/core/mongodb-source-binding.yaml
@@ -5,7 +5,6 @@
         collection: "The MongoDB Collection"
         database: "The MongoDB Database"
         hosts: "The MongoDB Hosts"
-    steps:
-      - to:
-          uri: "log:info"
-    
+      steps:
+        - to:
+            uri: "log:info"

--- a/templates/bindings/core/mqtt-sink-binding.yaml
+++ b/templates/bindings/core/mqtt-sink-binding.yaml
@@ -4,10 +4,9 @@
       parameters:
         period: 1000
         message: "Hello Camel JBang"
-    steps:
-      - to:
-          uri: "kamelet:mqtt-sink"
-          parameters:
-            brokerUrl: "tcp://mosquitto:1883"
-            topic: "mytopic"
-    
+      steps:
+        - to:
+            uri: "kamelet:mqtt-sink"
+            parameters:
+              brokerUrl: "tcp://mosquitto:1883"
+              topic: "mytopic"

--- a/templates/bindings/core/mqtt-source-binding.yaml
+++ b/templates/bindings/core/mqtt-source-binding.yaml
@@ -4,7 +4,6 @@
       parameters:
         brokerUrl: "tcp://mosquitto:1883"
         topic: "mytopic"
-    steps:
-      - to:
-          uri: "log:info"
-    
+      steps:
+        - to:
+            uri: "log:info"

--- a/templates/bindings/core/mustache-template-action-binding.yaml
+++ b/templates/bindings/core/mustache-template-action-binding.yaml
@@ -4,10 +4,10 @@
       parameters:
         period: 1000
         message: "{ \"foo\": \"John\"}"
-    steps:
-      - to:
-          uri: "kamelet:mustache-template-action"
-          parameters:
-            template: "The Template"
-      - to:
-          uri: "log:info"
+      steps:
+        - to:
+            uri: "kamelet:mustache-template-action"
+            parameters:
+              template: "The Template"
+        - to:
+            uri: "log:info"

--- a/templates/bindings/core/mvel-template-action-binding.yaml
+++ b/templates/bindings/core/mvel-template-action-binding.yaml
@@ -4,10 +4,10 @@
       parameters:
         period: 1000
         message: "{ \"foo\": \"John\"}"
-    steps:
-      - to:
-          uri: "kamelet:mvel-template-action"
-          parameters:
-            template: "The Template"
-      - to:
-          uri: "log:info"
+      steps:
+        - to:
+            uri: "kamelet:mvel-template-action"
+            parameters:
+              template: "The Template"
+        - to:
+            uri: "log:info"

--- a/templates/bindings/core/mysql-sink-binding.yaml
+++ b/templates/bindings/core/mysql-sink-binding.yaml
@@ -4,13 +4,12 @@
       parameters:
         period: 1000
         message: "Hello Camel JBang"
-    steps:
-      - to:
-          uri: "kamelet:mysql-sink"
-          parameters:
-            databaseName: "The Database Name"
-            password: "The Password"
-            query: "INSERT INTO accounts (username,city) VALUES (:#username,:#city)"
-            serverName: "localhost"
-            username: "The Username"
-    
+      steps:
+        - to:
+            uri: "kamelet:mysql-sink"
+            parameters:
+              databaseName: "The Database Name"
+              password: "The Password"
+              query: "INSERT INTO accounts (username,city) VALUES (:#username,:#city)"
+              serverName: "localhost"
+              username: "The Username"

--- a/templates/bindings/core/mysql-source-binding.yaml
+++ b/templates/bindings/core/mysql-source-binding.yaml
@@ -7,7 +7,6 @@
         query: "INSERT INTO accounts (username,city) VALUES (:#username,:#city)"
         serverName: "localhost"
         username: "The Username"
-    steps:
-      - to:
-          uri: "log:info"
-    
+      steps:
+        - to:
+            uri: "log:info"

--- a/templates/bindings/core/nats-sink-binding.yaml
+++ b/templates/bindings/core/nats-sink-binding.yaml
@@ -4,10 +4,9 @@
       parameters:
         period: 1000
         message: "Hello Camel JBang"
-    steps:
-      - to:
-          uri: "kamelet:nats-sink"
-          parameters:
-            servers: "The Servers"
-            topic: "The Topic"
-    
+      steps:
+        - to:
+            uri: "kamelet:nats-sink"
+            parameters:
+              servers: "The Servers"
+              topic: "The Topic"

--- a/templates/bindings/core/nats-source-binding.yaml
+++ b/templates/bindings/core/nats-source-binding.yaml
@@ -4,7 +4,6 @@
       parameters:
         servers: "The Servers"
         topic: "The Topic"
-    steps:
-      - to:
-          uri: "log:info"
-    
+      steps:
+        - to:
+            uri: "log:info"

--- a/templates/bindings/core/openai-classification-action-binding.yaml
+++ b/templates/bindings/core/openai-classification-action-binding.yaml
@@ -4,10 +4,10 @@
       parameters:
         period: 1000
         message: "{ \"foo\": \"John\"}"
-    steps:
-      - to:
-          uri: "kamelet:openai-classification-action"
-          parameters:
-            authorizationToken: "The Authorization Token"
-      - to:
-          uri: "log:info"
+      steps:
+        - to:
+            uri: "kamelet:openai-classification-action"
+            parameters:
+              authorizationToken: "The Authorization Token"
+        - to:
+            uri: "log:info"

--- a/templates/bindings/core/openai-completion-action-binding.yaml
+++ b/templates/bindings/core/openai-completion-action-binding.yaml
@@ -4,10 +4,10 @@
       parameters:
         period: 1000
         message: "{ \"foo\": \"John\"}"
-    steps:
-      - to:
-          uri: "kamelet:openai-completion-action"
-          parameters:
-            authorizationToken: "The Authorization Token"
-      - to:
-          uri: "log:info"
+      steps:
+        - to:
+            uri: "kamelet:openai-completion-action"
+            parameters:
+              authorizationToken: "The Authorization Token"
+        - to:
+            uri: "log:info"

--- a/templates/bindings/core/pdf-action-binding.yaml
+++ b/templates/bindings/core/pdf-action-binding.yaml
@@ -4,8 +4,8 @@
       parameters:
         period: 1000
         message: "{ \"foo\": \"John\"}"
-    steps:
-      - to:
-          uri: "kamelet:pdf-action"
-      - to:
-          uri: "log:info"
+      steps:
+        - to:
+            uri: "kamelet:pdf-action"
+        - to:
+            uri: "log:info"

--- a/templates/bindings/core/postgresql-sink-binding.yaml
+++ b/templates/bindings/core/postgresql-sink-binding.yaml
@@ -4,13 +4,12 @@
       parameters:
         period: 1000
         message: "Hello Camel JBang"
-    steps:
-      - to:
-          uri: "kamelet:postgresql-sink"
-          parameters:
-            databaseName: "The Database Name"
-            password: "The Password"
-            query: "INSERT INTO accounts (username,city) VALUES (:#username,:#city)"
-            serverName: "localhost"
-            username: "The Username"
-    
+      steps:
+        - to:
+            uri: "kamelet:postgresql-sink"
+            parameters:
+              databaseName: "The Database Name"
+              password: "The Password"
+              query: "INSERT INTO accounts (username,city) VALUES (:#username,:#city)"
+              serverName: "localhost"
+              username: "The Username"

--- a/templates/bindings/core/postgresql-source-binding.yaml
+++ b/templates/bindings/core/postgresql-source-binding.yaml
@@ -7,7 +7,6 @@
         query: "INSERT INTO accounts (username,city) VALUES (:#username,:#city)"
         serverName: "localhost"
         username: "The Username"
-    steps:
-      - to:
-          uri: "log:info"
-    
+      steps:
+        - to:
+            uri: "log:info"

--- a/templates/bindings/core/predicate-filter-action-binding.yaml
+++ b/templates/bindings/core/predicate-filter-action-binding.yaml
@@ -4,10 +4,10 @@
       parameters:
         period: 1000
         message: "{ \"foo\": \"John\"}"
-    steps:
-      - to:
-          uri: "kamelet:predicate-filter-action"
-          parameters:
-            expression: "@.foo =~ /.*John/"
-      - to:
-          uri: "log:info"
+      steps:
+        - to:
+            uri: "kamelet:predicate-filter-action"
+            parameters:
+              expression: "@.foo =~ /.*John/"
+        - to:
+            uri: "log:info"

--- a/templates/bindings/core/protobuf-deserialize-action-binding.yaml
+++ b/templates/bindings/core/protobuf-deserialize-action-binding.yaml
@@ -4,16 +4,16 @@
       parameters:
         period: 1000
         message: '{"first": "John", "last":"Doe"}'
-    steps:
-      - to:
-          uri: "kamelet:json-deserialize-action"
-      - to:
-          uri: "kamelet:protobuf-serialize-action"
-          parameters:
-            schema: "message Person { required string first = 1; required string last = 2; }"
-      - to:
-          uri: "kamelet:protobuf-deserialize-action"
-          parameters:
-            schema: "message Person { required string first = 1; required string last = 2; }"
-      - to:
-          uri: "log:info"
+      steps:
+        - to:
+            uri: "kamelet:json-deserialize-action"
+        - to:
+            uri: "kamelet:protobuf-serialize-action"
+            parameters:
+              schema: "message Person { required string first = 1; required string last = 2; }"
+        - to:
+            uri: "kamelet:protobuf-deserialize-action"
+            parameters:
+              schema: "message Person { required string first = 1; required string last = 2; }"
+        - to:
+            uri: "log:info"

--- a/templates/bindings/core/protobuf-serialize-action-binding.yaml
+++ b/templates/bindings/core/protobuf-serialize-action-binding.yaml
@@ -4,12 +4,12 @@
       parameters:
         period: 1000
         message: '{"first": "John", "last":"Doe"}'
-    steps:
-      - to:
-          uri: "kamelet:json-deserialize-action"
-      - to:
-          uri: "kamelet:protobuf-serialize-action"
-          parameters:
-            schema: "message Person { required string first = 1; required string last = 2; }"
-      - to:
-          uri: "log:info"
+      steps:
+        - to:
+            uri: "kamelet:json-deserialize-action"
+        - to:
+            uri: "kamelet:protobuf-serialize-action"
+            parameters:
+              schema: "message Person { required string first = 1; required string last = 2; }"
+        - to:
+            uri: "log:info"

--- a/templates/bindings/core/pulsar-sink-binding.yaml
+++ b/templates/bindings/core/pulsar-sink-binding.yaml
@@ -4,13 +4,12 @@
       parameters:
         period: 1000
         message: "Hello Camel JBang"
-    steps:
-      - to:
-          uri: "kamelet:pulsar-sink"
-          parameters:
-            namespaceName: "The Pulsar Namespace Name"
-            serviceUrl: "The Service URL"
-            tenant: "The Tenant Name"
-            topic: "The Topic Name"
-            topicType: "The Topic Type"
-    
+      steps:
+        - to:
+            uri: "kamelet:pulsar-sink"
+            parameters:
+              namespaceName: "The Pulsar Namespace Name"
+              serviceUrl: "The Service URL"
+              tenant: "The Tenant Name"
+              topic: "The Topic Name"
+              topicType: "The Topic Type"

--- a/templates/bindings/core/pulsar-source-binding.yaml
+++ b/templates/bindings/core/pulsar-source-binding.yaml
@@ -7,7 +7,6 @@
         tenant: "The Tenant Name"
         topic: "The Topic Name"
         topicType: "The Topic Type"
-    steps:
-      - to:
-          uri: "log:info"
-    
+      steps:
+        - to:
+            uri: "log:info"

--- a/templates/bindings/core/rabbitmq-source-binding.yaml
+++ b/templates/bindings/core/rabbitmq-source-binding.yaml
@@ -4,7 +4,6 @@
       parameters:
         addresses: "localhost:5672"
         exchangeName: "The Exchange name"
-    steps:
-      - to:
-          uri: "log:info"
-    
+      steps:
+        - to:
+            uri: "log:info"

--- a/templates/bindings/core/redis-sink-binding.yaml
+++ b/templates/bindings/core/redis-sink-binding.yaml
@@ -4,10 +4,9 @@
       parameters:
         period: 1000
         message: "Hello Camel JBang"
-    steps:
-      - to:
-          uri: "kamelet:redis-sink"
-          parameters:
-            redisHost: "The Redis Host"
-            redisPort: "The Redis Port"
-    
+      steps:
+        - to:
+            uri: "kamelet:redis-sink"
+            parameters:
+              redisHost: "The Redis Host"
+              redisPort: "The Redis Port"

--- a/templates/bindings/core/redis-source-binding.yaml
+++ b/templates/bindings/core/redis-source-binding.yaml
@@ -4,7 +4,6 @@
       parameters:
         redisHost: "The Redis Host"
         redisPort: "The Redis Port"
-    steps:
-      - to:
-          uri: "log:info"
-    
+      steps:
+        - to:
+            uri: "log:info"

--- a/templates/bindings/core/regex-router-action-binding.yaml
+++ b/templates/bindings/core/regex-router-action-binding.yaml
@@ -4,11 +4,11 @@
       parameters:
         period: 1000
         message: "{ \"foo\": \"John\"}"
-    steps:
-      - to:
-          uri: "kamelet:regex-router-action"
-          parameters:
-            regex: "The Regex"
-        replacement: "The Replacement"
-      - to:
-          uri: "log:info"
+      steps:
+        - to:
+            uri: "kamelet:regex-router-action"
+            parameters:
+              regex: "The Regex"
+          replacement: "The Replacement"
+        - to:
+            uri: "log:info"

--- a/templates/bindings/core/replace-field-action-binding.yaml
+++ b/templates/bindings/core/replace-field-action-binding.yaml
@@ -4,12 +4,12 @@
       parameters:
         period: 1000
         message: "{ \"foo\": \"John\"}"
-    steps:
-      - to:
-          uri: "kamelet:replace-field-action"
-          parameters:
-            disabled: "The Disabled"
-        enabled: "The Enabled"
-        renames: "foo:bar,c1:c2"
-      - to:
-          uri: "log:info"
+      steps:
+        - to:
+            uri: "kamelet:replace-field-action"
+            parameters:
+              disabled: "The Disabled"
+          enabled: "The Enabled"
+          renames: "foo:bar,c1:c2"
+        - to:
+            uri: "log:info"

--- a/templates/bindings/core/salesforce-source-binding.yaml
+++ b/templates/bindings/core/salesforce-source-binding.yaml
@@ -8,7 +8,6 @@
         query: "SELECT Id, Name, Email, Phone FROM Contact"
         topicName: "ContactTopic"
         userName: "The Username"
-    steps:
-      - to:
-          uri: "log:info"
-    
+      steps:
+        - to:
+            uri: "log:info"

--- a/templates/bindings/core/sftp-sink-binding.yaml
+++ b/templates/bindings/core/sftp-sink-binding.yaml
@@ -4,12 +4,11 @@
       parameters:
         period: 1000
         message: "Hello Camel JBang"
-    steps:
-      - to:
-          uri: "kamelet:sftp-sink"
-          parameters:
-            connectionHost: "The Connection Host"
-            directoryName: "The Directory Name"
-            password: "The Password"
-            username: "The Username"
-    
+      steps:
+        - to:
+            uri: "kamelet:sftp-sink"
+            parameters:
+              connectionHost: "The Connection Host"
+              directoryName: "The Directory Name"
+              password: "The Password"
+              username: "The Username"

--- a/templates/bindings/core/sftp-source-binding.yaml
+++ b/templates/bindings/core/sftp-source-binding.yaml
@@ -6,7 +6,6 @@
         directoryName: "The Directory Name"
         password: "The Password"
         username: "The Username"
-    steps:
-      - to:
-          uri: "log:info"
-    
+      steps:
+        - to:
+            uri: "log:info"

--- a/templates/bindings/core/slack-sink-binding.yaml
+++ b/templates/bindings/core/slack-sink-binding.yaml
@@ -4,10 +4,9 @@
       parameters:
         period: 1000
         message: "Hello Camel JBang"
-    steps:
-      - to:
-          uri: "kamelet:slack-sink"
-          parameters:
-            channel: "#myroom"
-            webhookUrl: "The Webhook URL"
-    
+      steps:
+        - to:
+            uri: "kamelet:slack-sink"
+            parameters:
+              channel: "#myroom"
+              webhookUrl: "The Webhook URL"

--- a/templates/bindings/core/slack-source-binding.yaml
+++ b/templates/bindings/core/slack-source-binding.yaml
@@ -4,7 +4,6 @@
       parameters:
         channel: "#myroom"
         token: "The Token"
-    steps:
-      - to:
-          uri: "log:info"
-    
+      steps:
+        - to:
+            uri: "log:info"

--- a/templates/bindings/core/solr-sink-binding.yaml
+++ b/templates/bindings/core/solr-sink-binding.yaml
@@ -4,10 +4,9 @@
       parameters:
         period: 1000
         message: "Hello Camel JBang"
-    steps:
-      - to:
-          uri: "kamelet:solr-sink"
-          parameters:
-            collection: "The Collection"
-            servers: "The Servers"
-    
+      steps:
+        - to:
+            uri: "kamelet:solr-sink"
+            parameters:
+              collection: "The Collection"
+              servers: "The Servers"

--- a/templates/bindings/core/solr-source-binding.yaml
+++ b/templates/bindings/core/solr-source-binding.yaml
@@ -5,7 +5,6 @@
         collection: "The Collection"
         query: "The Query"
         servers: "The Servers"
-    steps:
-      - to:
-          uri: "log:info"
-    
+      steps:
+        - to:
+            uri: "log:info"

--- a/templates/bindings/core/sqlserver-sink-binding.yaml
+++ b/templates/bindings/core/sqlserver-sink-binding.yaml
@@ -4,13 +4,12 @@
       parameters:
         period: 1000
         message: "Hello Camel JBang"
-    steps:
-      - to:
-          uri: "kamelet:sqlserver-sink"
-          parameters:
-            databaseName: "The Database Name"
-            password: "The Password"
-            query: "INSERT INTO accounts (username,city) VALUES (:#username,:#city)"
-            serverName: "localhost"
-            username: "The Username"
-    
+      steps:
+        - to:
+            uri: "kamelet:sqlserver-sink"
+            parameters:
+              databaseName: "The Database Name"
+              password: "The Password"
+              query: "INSERT INTO accounts (username,city) VALUES (:#username,:#city)"
+              serverName: "localhost"
+              username: "The Username"

--- a/templates/bindings/core/sqlserver-source-binding.yaml
+++ b/templates/bindings/core/sqlserver-source-binding.yaml
@@ -7,7 +7,6 @@
         query: "INSERT INTO accounts (username,city) VALUES (:#username,:#city)"
         serverName: "localhost"
         username: "The Username"
-    steps:
-      - to:
-          uri: "log:info"
-    
+      steps:
+        - to:
+            uri: "log:info"

--- a/templates/bindings/core/ssh-sink-binding.yaml
+++ b/templates/bindings/core/ssh-sink-binding.yaml
@@ -4,11 +4,10 @@
       parameters:
         period: 1000
         message: "Hello Camel JBang"
-    steps:
-      - to:
-          uri: "kamelet:ssh-sink"
-          parameters:
-            connectionHost: "The Connection Host"
-            password: "The Password"
-            username: "The Username"
-    
+      steps:
+        - to:
+            uri: "kamelet:ssh-sink"
+            parameters:
+              connectionHost: "The Connection Host"
+              password: "The Password"
+              username: "The Username"

--- a/templates/bindings/core/ssh-source-binding.yaml
+++ b/templates/bindings/core/ssh-source-binding.yaml
@@ -6,7 +6,6 @@
         password: "The Password"
         pollCommand: "date"
         username: "The Username"
-    steps:
-      - to:
-          uri: "log:info"
-    
+      steps:
+        - to:
+            uri: "log:info"

--- a/templates/bindings/core/string-template-action-binding.yaml
+++ b/templates/bindings/core/string-template-action-binding.yaml
@@ -4,10 +4,10 @@
       parameters:
         period: 1000
         message: "{ \"foo\": \"John\"}"
-    steps:
-      - to:
-          uri: "kamelet:string-template-action"
-          parameters:
-            template: "The Template"
-      - to:
-          uri: "log:info"
+      steps:
+        - to:
+            uri: "kamelet:string-template-action"
+            parameters:
+              template: "The Template"
+        - to:
+            uri: "log:info"

--- a/templates/bindings/core/telegram-sink-binding.yaml
+++ b/templates/bindings/core/telegram-sink-binding.yaml
@@ -4,9 +4,8 @@
       parameters:
         period: 1000
         message: "Hello Camel JBang"
-    steps:
-      - to:
-          uri: "kamelet:telegram-sink"
-          parameters:
-            authorizationToken: "The Token"
-    
+      steps:
+        - to:
+            uri: "kamelet:telegram-sink"
+            parameters:
+              authorizationToken: "The Token"

--- a/templates/bindings/core/telegram-source-binding.yaml
+++ b/templates/bindings/core/telegram-source-binding.yaml
@@ -3,7 +3,6 @@
       uri: "kamelet:telegram-source"
       parameters:
         authorizationToken: "The Token"
-    steps:
-      - to:
-          uri: "log:info"
-    
+      steps:
+        - to:
+            uri: "log:info"

--- a/templates/bindings/core/throttle-action-binding.yaml
+++ b/templates/bindings/core/throttle-action-binding.yaml
@@ -4,10 +4,10 @@
       parameters:
         period: 1000
         message: "{ \"foo\": \"John\"}"
-    steps:
-      - to:
-          uri: "kamelet:throttle-action"
-          parameters:
-            messages: 10
-      - to:
-          uri: "log:info"
+      steps:
+        - to:
+            uri: "kamelet:throttle-action"
+            parameters:
+              messages: 10
+        - to:
+            uri: "log:info"

--- a/templates/bindings/core/timer-source-binding.yaml
+++ b/templates/bindings/core/timer-source-binding.yaml
@@ -3,7 +3,6 @@
       uri: "kamelet:timer-source"
       parameters:
         message: "hello world"
-    steps:
-      - to:
-          uri: "log:info"
-    
+      steps:
+        - to:
+            uri: "log:info"

--- a/templates/bindings/core/timestamp-router-action-binding.yaml
+++ b/templates/bindings/core/timestamp-router-action-binding.yaml
@@ -4,8 +4,8 @@
       parameters:
         period: 1000
         message: "{ \"foo\": \"John\"}"
-    steps:
-      - to:
-          uri: "kamelet:timestamp-router-action"
-      - to:
-          uri: "log:info"
+      steps:
+        - to:
+            uri: "kamelet:timestamp-router-action"
+        - to:
+            uri: "log:info"

--- a/templates/bindings/core/topic-name-matches-filter-action-binding.yaml
+++ b/templates/bindings/core/topic-name-matches-filter-action-binding.yaml
@@ -4,10 +4,10 @@
       parameters:
         period: 1000
         message: "{ \"foo\": \"John\"}"
-    steps:
-      - to:
-          uri: "kamelet:topic-name-matches-filter-action"
-          parameters:
-            regex: "The Regex"
-      - to:
-          uri: "log:info"
+      steps:
+        - to:
+            uri: "kamelet:topic-name-matches-filter-action"
+            parameters:
+              regex: "The Regex"
+        - to:
+            uri: "log:info"

--- a/templates/bindings/core/twitter-directmessage-source-binding.yaml
+++ b/templates/bindings/core/twitter-directmessage-source-binding.yaml
@@ -7,7 +7,6 @@
         apiKey: "The API Key"
         apiKeySecret: "The API Key Secret"
         user: "ApacheCamel"
-    steps:
-      - to:
-          uri: "log:info"
-    
+      steps:
+        - to:
+            uri: "log:info"

--- a/templates/bindings/core/twitter-search-source-binding.yaml
+++ b/templates/bindings/core/twitter-search-source-binding.yaml
@@ -7,7 +7,6 @@
         apiKey: "The API Key"
         apiKeySecret: "The API Key Secret"
         keywords: "Apache Camel"
-    steps:
-      - to:
-          uri: "log:info"
-    
+      steps:
+        - to:
+            uri: "log:info"

--- a/templates/bindings/core/twitter-timeline-source-binding.yaml
+++ b/templates/bindings/core/twitter-timeline-source-binding.yaml
@@ -7,7 +7,6 @@
         apiKey: "The API Key"
         apiKeySecret: "The API Key Secret"
         user: "ApacheCamel"
-    steps:
-      - to:
-          uri: "log:info"
-    
+      steps:
+        - to:
+            uri: "log:info"

--- a/templates/bindings/core/value-to-key-action-binding.yaml
+++ b/templates/bindings/core/value-to-key-action-binding.yaml
@@ -4,10 +4,10 @@
       parameters:
         period: 1000
         message: "{ \"foo\": \"John\"}"
-    steps:
-      - to:
-          uri: "kamelet:value-to-key-action"
-          parameters:
-            fields: "The Fields"
-      - to:
-          uri: "log:info"
+      steps:
+        - to:
+            uri: "kamelet:value-to-key-action"
+            parameters:
+              fields: "The Fields"
+        - to:
+            uri: "log:info"

--- a/templates/bindings/core/velocity-template-action-binding.yaml
+++ b/templates/bindings/core/velocity-template-action-binding.yaml
@@ -4,10 +4,10 @@
       parameters:
         period: 1000
         message: "{ \"foo\": \"John\"}"
-    steps:
-      - to:
-          uri: "kamelet:velocity-template-action"
-          parameters:
-            template: "The Template"
-      - to:
-          uri: "log:info"
+      steps:
+        - to:
+            uri: "kamelet:velocity-template-action"
+            parameters:
+              template: "The Template"
+        - to:
+            uri: "log:info"

--- a/templates/bindings/core/webhook-source-binding.yaml
+++ b/templates/bindings/core/webhook-source-binding.yaml
@@ -4,4 +4,3 @@
     steps:
       - to:
           uri: "log:info"
-    

--- a/templates/bindings/core/websocket-source-binding.yaml
+++ b/templates/bindings/core/websocket-source-binding.yaml
@@ -3,7 +3,6 @@
       uri: "kamelet:websocket-source"
       parameters:
         resourceUri: "The Resource Uri"
-    steps:
-      - to:
-          uri: "log:info"
-    
+      steps:
+        - to:
+            uri: "log:info"

--- a/templates/bindings/core/wttrin-source-binding.yaml
+++ b/templates/bindings/core/wttrin-source-binding.yaml
@@ -1,7 +1,6 @@
 - route:
     from:
       uri: "kamelet:wttrin-source"
-    steps:
-      - to:
-          uri: "log:info"
-    
+      steps:
+        - to:
+            uri: "log:info"

--- a/templates/bindings/core/xj-identity-action-binding.yaml
+++ b/templates/bindings/core/xj-identity-action-binding.yaml
@@ -4,10 +4,10 @@
       parameters:
         period: 1000
         message: "{ \"foo\": \"John\"}"
-    steps:
-      - to:
-          uri: "kamelet:xj-identity-action"
-          parameters:
-            direction: "The Direction"
-      - to:
-          uri: "log:info"
+      steps:
+        - to:
+            uri: "kamelet:xj-identity-action"
+            parameters:
+              direction: "The Direction"
+        - to:
+            uri: "log:info"

--- a/templates/bindings/core/xj-template-action-binding.yaml
+++ b/templates/bindings/core/xj-template-action-binding.yaml
@@ -4,11 +4,11 @@
       parameters:
         period: 1000
         message: "{ \"foo\": \"John\"}"
-    steps:
-      - to:
-          uri: "kamelet:xj-template-action"
-          parameters:
-            direction: "The Direction"
-        template: "The Template"
-      - to:
-          uri: "log:info"
+      steps:
+        - to:
+            uri: "kamelet:xj-template-action"
+            parameters:
+              direction: "The Direction"
+          template: "The Template"
+        - to:
+            uri: "log:info"


### PR DESCRIPTION

Running any yaml dsl binding examples from `templates/bindings/core` directory, there is a parser error:
``
Failed to start application (with profile prod): org.apache.camel.dsl.yaml.common.exception.UnsupportedFieldException: Unsupported field (steps) for node: <org.snakeyaml.engine.v2.nodes.MappingNode (tag=tag:yaml.org,2002:map, values={ key=<org.snakeyaml.engine.v2.nodes.ScalarNode (tag=tag:yaml.org,2002:str, value=from)>; value=67671827 }{ key=<org.snakeyaml.engine.v2.nodes.ScalarNode (tag=tag:yaml.org,2002:str, value=steps)>; value=2031927175 })>
``

Related to a [camel change in yaml dsl](https://camel.apache.org/manual/camel-3x-upgrade-guide-3_15.html#_camel_yaml_dsl)
