### PR TITLE
chore: Avoid NPE on extract/insert field Kamelets

### DIFF
--- a/.github/workflows/yaks-tests.yaml
+++ b/.github/workflows/yaks-tests.yaml
@@ -110,6 +110,7 @@ jobs:
       run: |
         echo "Running tests"
         yaks run test/aws-ddb-sink $YAKS_RUN_OPTIONS
+        yaks run test/extract-field-action $YAKS_RUN_OPTIONS
         yaks run test/insert-field-action $YAKS_RUN_OPTIONS
         yaks run test/mail-sink $YAKS_RUN_OPTIONS
         yaks run test/timer-source $YAKS_RUN_OPTIONS

--- a/kamelets/extract-field-action.kamelet.yaml
+++ b/kamelets/extract-field-action.kamelet.yaml
@@ -32,13 +32,13 @@ spec:
     description: |-
       Extract a field from the message body.
 
-      The extract field action expects an application/json content type. 
+      The extract field action expects an application/json content type.
 
       The field parameter allows you to specify which field of the json the user wants to extract. By default the message body will be overriden with the extracted field.
 
       The optional parameter headerOutput allows the user to specify wheter the extracted field should be stored in a message header named 'CamelKameletsExtractFieldName', leaving the message body untouched.
 
-      The optional parameter headerOutputName allows the user to specify a custom header name instead of the default 'CamelKameletsExtractFieldName'. This parameter must be used in conjunction with headerOutput. 
+      The optional parameter headerOutputName allows the user to specify a custom header name instead of the default 'CamelKameletsExtractFieldName'. This parameter must be used in conjunction with headerOutput.
       If no headerOutputName parameter will be provided, the default 'CamelKameletsExtractFieldName' will be used.
 
       The optional parameter strictHeaderCheck allows to user to enable a strict header name check. If enabled the action will check if the header output name (custom or default) has been used already in the     exchange. If so, the extracted field will be stored in the message body, if not, the extracted field will be stored in the selected header (custom or default).
@@ -77,6 +77,20 @@ spec:
   - "camel:core"
   - "camel:jackson"
   template:
+    beans:
+      - name: extractField
+        type: "#class:org.apache.camel.kamelets.utils.transform.ExtractField"
+        property:
+          - key: field
+            value: '{{field}}'
+          - key: headerOutput
+            value: '{{headerOutput}}'
+          - key: headerOutput
+            value: '{{headerOutput}}'
+          - key: headerOutputName
+            value: '{{headerOutputName}}'
+          - key: strictHeaderCheck
+            value: '{{strictHeaderCheck}}'
     from:
       uri: kamelet:source
       steps:
@@ -88,28 +102,17 @@ spec:
                 name: deserialized
                 constant: "true"
             - unmarshal:
-                json: 
+                json:
                   library: Jackson
                   unmarshalType: com.fasterxml.jackson.databind.JsonNode
-      - set-property:
-          name: "field"
-          constant: "{{field}}"
-      - set-property:
-          name: "headerOutput"
-          constant: "{{headerOutput}}"
-      - set-property:
-          name: "headerOutputName"
-          constant: "{{headerOutputName}}"
-      - set-property:
-          name: "strictHeaderCheck"
-          constant: "{{strictHeaderCheck}}"
-      - bean: "org.apache.camel.kamelets.utils.transform.ExtractField"
+      - process:
+          ref: "{{extractField}}"
       - choice:
           when:
           - simple: "${exchangeProperty[deserialized]} == 'true'"
             steps:
             - marshal:
-                json: 
+                json:
                   library: Jackson
                   unmarshalType: com.fasterxml.jackson.databind.JsonNode
             - set-header:

--- a/kamelets/insert-field-action.kamelet.yaml
+++ b/kamelets/insert-field-action.kamelet.yaml
@@ -32,7 +32,7 @@ spec:
     description: |-
       Adds a custom field with a simple language parsed value to the message in transit.
 
-      The extract field action expected an application/json content type. 
+      The extract field action expected an application/json content type.
 
       If for example you have an array like '{ "foo":"John", "bar":30 }' and your action has been configured with field as 'element' and value as 'hello', you'll get '{ "foo":"John", "bar":30, "element":"hello" }'
     required:
@@ -54,6 +54,14 @@ spec:
   - "camel:jackson"
   - "camel:kamelet"
   template:
+    beans:
+      - name: insertField
+        type: "#class:org.apache.camel.kamelets.utils.transform.InsertField"
+        property:
+          - key: field
+            value: '{{field}}'
+          - key: value
+            value: '{{value}}'
     from:
       uri: kamelet:source
       steps:
@@ -65,22 +73,17 @@ spec:
                 name: deserialized
                 constant: "true"
             - unmarshal:
-                json: 
+                json:
                   library: Jackson
                   unmarshalType: com.fasterxml.jackson.databind.JsonNode
-      - set-property:
-          name: "field"
-          constant: "{{field}}"
-      - set-property:
-          name: "value"
-          simple: "{{value}}"
-      - bean: "org.apache.camel.kamelets.utils.transform.InsertField"
+      - process:
+          ref: "{{insertField}}"
       - choice:
           when:
           - simple: "${exchangeProperty[deserialized]} == 'true'"
             steps:
             - marshal:
-                json: 
+                json:
                   library: Jackson
                   unmarshalType: com.fasterxml.jackson.databind.JsonNode
             - set-header:

--- a/library/camel-kamelets-utils/src/main/java/org/apache/camel/kamelets/utils/transform/InsertField.java
+++ b/library/camel-kamelets-utils/src/main/java/org/apache/camel/kamelets/utils/transform/InsertField.java
@@ -20,13 +20,37 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.apache.camel.Exchange;
-import org.apache.camel.ExchangeProperty;
 import org.apache.camel.InvalidPayloadException;
+import org.apache.camel.Processor;
 
-public class InsertField {
+public class InsertField implements Processor {
 
-    public JsonNode process(@ExchangeProperty("field") String field, @ExchangeProperty("value") String value, Exchange ex) throws InvalidPayloadException {
+    String field;
+    String value;
+
+    /**
+     * Default constructor.
+     */
+    public InsertField() {
+    }
+
+    /**
+     * Constructor using fields.
+     * @param field the field name to insert.
+     * @param value the value of the new field.
+     */
+    public InsertField(String field, String value) {
+        this.field = field;
+        this.value = value;
+    }
+
+    public void process(Exchange ex) throws InvalidPayloadException {
         JsonNode body = ex.getMessage().getBody(JsonNode.class);
+
+        if (body == null) {
+            throw new InvalidPayloadException(ex, JsonNode.class);
+        }
+
         switch (body.getNodeType()) {
             case ARRAY:
                 ((ArrayNode) body).add(value);
@@ -38,7 +62,15 @@ public class InsertField {
                 ((ObjectNode) body).put(field, value);
                 break;
         }
-        return body;
+
+        ex.getMessage().setBody(body);
     }
 
+    public void setField(String field) {
+        this.field = field;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
 }

--- a/library/camel-kamelets-utils/src/test/java/org/apache/camel/kamelets/utils/transform/ExtractFieldTest.java
+++ b/library/camel-kamelets-utils/src/test/java/org/apache/camel/kamelets/utils/transform/ExtractFieldTest.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.kamelets.utils.transform;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.camel.Exchange;
+import org.apache.camel.InvalidPayloadException;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.apache.camel.support.DefaultExchange;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class ExtractFieldTest {
+
+    private DefaultCamelContext camelContext;
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    private ExtractField processor;
+
+    private final String baseJson = "{" +
+                "\"name\":\"Rajesh Koothrappali\"" +
+            "}";
+
+    @BeforeEach
+    void setup() {
+        camelContext = new DefaultCamelContext();
+        processor = new ExtractField();
+    }
+
+    @Test
+    void shouldExtractFieldFromJsonNode() throws Exception {
+        Exchange exchange = new DefaultExchange(camelContext);
+
+        exchange.getMessage().setBody(mapper.readTree(baseJson));
+
+        processor.setField("name");
+        processor.process(exchange);
+
+        Assertions.assertEquals("Rajesh Koothrappali", exchange.getMessage().getBody(String.class));
+    }
+
+    @Test
+    void shouldExtractFieldToHeader() throws Exception {
+        Exchange exchange = new DefaultExchange(camelContext);
+
+        exchange.getMessage().setBody(mapper.readTree(baseJson));
+
+        processor.setField("name");
+        processor.setHeaderOutput(true);
+        processor.setHeaderOutputName("name");
+        processor.process(exchange);
+
+        Assertions.assertEquals(baseJson, exchange.getMessage().getBody(String.class));
+        Assertions.assertEquals("Rajesh Koothrappali", exchange.getMessage().getHeader("name"));
+    }
+
+    @Test
+    void shouldExtractFieldToHeaderWithStrictHeaderCheck() throws Exception {
+        Exchange exchange = new DefaultExchange(camelContext);
+
+        exchange.getMessage().setBody(mapper.readTree(baseJson));
+
+        processor.setField("name");
+        processor.setHeaderOutput(true);
+        processor.setHeaderOutputName("name");
+        processor.setStrictHeaderCheck(true);
+        processor.process(exchange);
+
+        Assertions.assertEquals(baseJson, exchange.getMessage().getBody(String.class));
+        Assertions.assertEquals("Rajesh Koothrappali", exchange.getMessage().getHeader("name"));
+
+        exchange.getMessage().setHeader("name", "somethingElse");
+
+        processor.process(exchange);
+
+        Assertions.assertEquals("Rajesh Koothrappali", exchange.getMessage().getBody(String.class));
+        Assertions.assertEquals("somethingElse", exchange.getMessage().getHeader("name"));
+    }
+
+    @Test
+    void shouldExtractFieldToDefaultHeader() throws Exception {
+        Exchange exchange = new DefaultExchange(camelContext);
+
+        exchange.getMessage().setBody(mapper.readTree(baseJson));
+
+        processor.setField("name");
+        processor.setHeaderOutput(true);
+        processor.process(exchange);
+
+        Assertions.assertEquals(baseJson, exchange.getMessage().getBody(String.class));
+        Assertions.assertEquals("Rajesh Koothrappali", exchange.getMessage().getHeader(ExtractField.EXTRACTED_FIELD_HEADER));
+
+        exchange = new DefaultExchange(camelContext);
+
+        exchange.getMessage().setBody(mapper.readTree(baseJson));
+
+        processor.setHeaderOutputName("none");
+        processor.process(exchange);
+
+        Assertions.assertEquals(baseJson, exchange.getMessage().getBody(String.class));
+        Assertions.assertEquals("Rajesh Koothrappali", exchange.getMessage().getHeader(ExtractField.EXTRACTED_FIELD_HEADER));
+    }
+
+    @Test
+    void shouldFailOnInvalidPayloadType() {
+        Exchange exchange = new DefaultExchange(camelContext);
+        exchange.getMessage().setBody(baseJson);
+        Assertions.assertThrows(InvalidPayloadException.class, () -> processor.process(exchange));
+    }
+
+}

--- a/library/camel-kamelets/src/main/resources/kamelets/extract-field-action.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/extract-field-action.kamelet.yaml
@@ -32,13 +32,13 @@ spec:
     description: |-
       Extract a field from the message body.
 
-      The extract field action expects an application/json content type. 
+      The extract field action expects an application/json content type.
 
       The field parameter allows you to specify which field of the json the user wants to extract. By default the message body will be overriden with the extracted field.
 
       The optional parameter headerOutput allows the user to specify wheter the extracted field should be stored in a message header named 'CamelKameletsExtractFieldName', leaving the message body untouched.
 
-      The optional parameter headerOutputName allows the user to specify a custom header name instead of the default 'CamelKameletsExtractFieldName'. This parameter must be used in conjunction with headerOutput. 
+      The optional parameter headerOutputName allows the user to specify a custom header name instead of the default 'CamelKameletsExtractFieldName'. This parameter must be used in conjunction with headerOutput.
       If no headerOutputName parameter will be provided, the default 'CamelKameletsExtractFieldName' will be used.
 
       The optional parameter strictHeaderCheck allows to user to enable a strict header name check. If enabled the action will check if the header output name (custom or default) has been used already in the     exchange. If so, the extracted field will be stored in the message body, if not, the extracted field will be stored in the selected header (custom or default).
@@ -77,6 +77,20 @@ spec:
   - "camel:core"
   - "camel:jackson"
   template:
+    beans:
+      - name: extractField
+        type: "#class:org.apache.camel.kamelets.utils.transform.ExtractField"
+        property:
+          - key: field
+            value: '{{field}}'
+          - key: headerOutput
+            value: '{{headerOutput}}'
+          - key: headerOutput
+            value: '{{headerOutput}}'
+          - key: headerOutputName
+            value: '{{headerOutputName}}'
+          - key: strictHeaderCheck
+            value: '{{strictHeaderCheck}}'
     from:
       uri: kamelet:source
       steps:
@@ -88,28 +102,17 @@ spec:
                 name: deserialized
                 constant: "true"
             - unmarshal:
-                json: 
+                json:
                   library: Jackson
                   unmarshalType: com.fasterxml.jackson.databind.JsonNode
-      - set-property:
-          name: "field"
-          constant: "{{field}}"
-      - set-property:
-          name: "headerOutput"
-          constant: "{{headerOutput}}"
-      - set-property:
-          name: "headerOutputName"
-          constant: "{{headerOutputName}}"
-      - set-property:
-          name: "strictHeaderCheck"
-          constant: "{{strictHeaderCheck}}"
-      - bean: "org.apache.camel.kamelets.utils.transform.ExtractField"
+      - process:
+          ref: "{{extractField}}"
       - choice:
           when:
           - simple: "${exchangeProperty[deserialized]} == 'true'"
             steps:
             - marshal:
-                json: 
+                json:
                   library: Jackson
                   unmarshalType: com.fasterxml.jackson.databind.JsonNode
             - set-header:

--- a/library/camel-kamelets/src/main/resources/kamelets/insert-field-action.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/insert-field-action.kamelet.yaml
@@ -32,7 +32,7 @@ spec:
     description: |-
       Adds a custom field with a simple language parsed value to the message in transit.
 
-      The extract field action expected an application/json content type. 
+      The extract field action expected an application/json content type.
 
       If for example you have an array like '{ "foo":"John", "bar":30 }' and your action has been configured with field as 'element' and value as 'hello', you'll get '{ "foo":"John", "bar":30, "element":"hello" }'
     required:
@@ -54,6 +54,14 @@ spec:
   - "camel:jackson"
   - "camel:kamelet"
   template:
+    beans:
+      - name: insertField
+        type: "#class:org.apache.camel.kamelets.utils.transform.InsertField"
+        property:
+          - key: field
+            value: '{{field}}'
+          - key: value
+            value: '{{value}}'
     from:
       uri: kamelet:source
       steps:
@@ -65,22 +73,17 @@ spec:
                 name: deserialized
                 constant: "true"
             - unmarshal:
-                json: 
+                json:
                   library: Jackson
                   unmarshalType: com.fasterxml.jackson.databind.JsonNode
-      - set-property:
-          name: "field"
-          constant: "{{field}}"
-      - set-property:
-          name: "value"
-          simple: "{{value}}"
-      - bean: "org.apache.camel.kamelets.utils.transform.InsertField"
+      - process:
+          ref: "{{insertField}}"
       - choice:
           when:
           - simple: "${exchangeProperty[deserialized]} == 'true'"
             steps:
             - marshal:
-                json: 
+                json:
                   library: Jackson
                   unmarshalType: com.fasterxml.jackson.databind.JsonNode
             - set-header:

--- a/test/extract-field-action/extract-field-action-binding.yaml
+++ b/test/extract-field-action/extract-field-action-binding.yaml
@@ -1,0 +1,41 @@
+# ---------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ---------------------------------------------------------------------------
+
+apiVersion: camel.apache.org/v1alpha1
+kind: KameletBinding
+metadata:
+  name: extract-field-action-binding
+spec:
+  source:
+    ref:
+      kind: Kamelet
+      apiVersion: camel.apache.org/v1alpha1
+      name: timer-source
+    properties:
+      period: 5000
+      contentType: application/json
+      message: >
+        ${input}
+  steps:
+    - ref:
+        kind: Kamelet
+        apiVersion: camel.apache.org/v1alpha1
+        name: extract-field-action
+      properties:
+        field: ${field}
+  sink:
+    uri: http://test-extract-service.${YAKS_NAMESPACE}/result

--- a/test/extract-field-action/extract-field-action.feature
+++ b/test/extract-field-action/extract-field-action.feature
@@ -1,0 +1,47 @@
+# ---------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ---------------------------------------------------------------------------
+
+Feature: Extract field Kamelet action
+
+  Background:
+    Given HTTP server timeout is 15000 ms
+    Given HTTP server "test-extract-service"
+    Given variable field = "subject"
+
+  Scenario: Create Http server
+    Given create Kubernetes service test-extract-service with target port 8080
+
+  Scenario: Create Kamelet binding
+    Given Camel K resource polling configuration
+      | maxAttempts          | 200   |
+      | delayBetweenAttempts | 2000  |
+    Given variable input is
+    """
+    { "id": "citrus:randomUUID()", "${field}": "Camel K rocks!" }
+    """
+    When load KameletBinding extract-field-action-binding.yaml
+    Then Camel K integration extract-field-action-binding should be running
+    And Camel K integration extract-field-action-binding should print Routes startup
+
+  Scenario: Verify output message sent
+    Given expect HTTP request body: "Camel K rocks!"
+    When receive POST /result
+    Then send HTTP 200 OK
+
+  Scenario: Remove resources
+    Given delete KameletBinding extract-field-action-binding
+    And delete Kubernetes service test-extract-service

--- a/test/extract-field-action/yaks-config.yaml
+++ b/test/extract-field-action/yaks-config.yaml
@@ -1,0 +1,33 @@
+# ---------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ---------------------------------------------------------------------------
+
+config:
+  namespace:
+    temporary: false
+  runtime:
+    env:
+      - name: YAKS_CAMELK_AUTO_REMOVE_RESOURCES
+        value: false
+      - name: YAKS_KUBERNETES_AUTO_REMOVE_RESOURCES
+        value: false
+    resources:
+      - extract-field-action-binding.yaml
+  dump:
+    enabled: true
+    failedOnly: true
+    includes:
+      - app=camel-k


### PR DESCRIPTION
extract/insert field action Kamelets throwing nasty Nullpointer exceptions when there is a body provided other than JsonNode.

The PR adds proper error thrown in this situation and also adds some improvements such as
- Add YAKS e2e test for extract field
- Add unit tests on extract/insert field action Kamelets
- Use and set bean properties instead of exchange properties