### PR TITLE
Missing optional in chatId parameter

### DIFF
--- a/kamelets/telegram-sink.kamelet.yaml
+++ b/kamelets/telegram-sink.kamelet.yaml
@@ -120,6 +120,6 @@ spec:
           uri: "telegram:bots"
           parameters:
             authorizationToken: "{{authorizationToken}}"
-            chatId: "{{chatId}}"
+            chatId: "{{?chatId}}"
       - marshal:
           json: {}


### PR DESCRIPTION
If chatId is not provided as parameter on the kamelet binding, camel complains because it tries to use, literally `{{chatId}}` as parameter.