### PR TITLE
New action that gets features from OGC API server.

### DIFF
--- a/kamelets/ogcapi-features-action.kamelet.yaml
+++ b/kamelets/ogcapi-features-action.kamelet.yaml
@@ -33,6 +33,8 @@ spec:
       Returns the items of the collection provided of an OGC API Features server. 
       The collection must be a valid collection name on the server.
       
+      Query can be defined in the body too.
+      
       See https://www.ogc.org/standards/ogcapi-features
     required:
       - url
@@ -88,14 +90,14 @@ spec:
     from:
       uri: "kamelet:source"
       steps:
-      - set-body:
-          simple: ""
       - set-header:
           name: "Accept"
           constant: "application/geo+json"
       - set-header:
           name: "CamelHttpQuery"
-          simple: "limit={{limit}}&bbox={{bbox}}&{{?query}}"
+          simple: "limit={{limit}}&bbox={{bbox}}&{{?query}}&${body}"
+      - set-body:
+          simple: ""
       - to: 
           uri: "{{url}}/collections/{{collection}}/items"
       - remove-header:

--- a/kamelets/ogcapi-features-action.kamelet.yaml
+++ b/kamelets/ogcapi-features-action.kamelet.yaml
@@ -1,0 +1,122 @@
+# ---------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ---------------------------------------------------------------------------
+apiVersion: camel.apache.org/v1alpha1
+kind: Kamelet
+metadata:
+  name: ogcapi-features-action
+  annotations:
+    camel.apache.org/kamelet.support.level: "Preview"
+    camel.apache.org/catalog.version: "main-SNAPSHOT"
+    camel.apache.org/kamelet.icon: "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9Im5vIj8+CjxzdmcKICAgd2lkdGg9IjIxMDAiCiAgIGhlaWdodD0iMjEwMCIKICAgdmlld0JveD0iMCAwIDIxMDAgMjEwMCIKICAgdmVyc2lvbj0iMS4xIgogICB4bWw6c3BhY2U9InByZXNlcnZlIgogICBzdHlsZT0iY2xpcC1ydWxlOmV2ZW5vZGQ7ZmlsbC1ydWxlOmV2ZW5vZGQ7c3Ryb2tlLWxpbmVqb2luOnJvdW5kO3N0cm9rZS1taXRlcmxpbWl0OjIiCiAgIGlkPSJzdmcxMTEwIgogICBzb2RpcG9kaTpkb2NuYW1lPSJPcGVuX0dlb3NwYXRpYWxfQ29uc29ydGl1bV9sb2dvLnN2ZyIKICAgaW5rc2NhcGU6dmVyc2lvbj0iMS4xLjIgKDBhMDBjZjUzMzksIDIwMjItMDItMDQpIgogICB4bWxuczppbmtzY2FwZT0iaHR0cDovL3d3dy5pbmtzY2FwZS5vcmcvbmFtZXNwYWNlcy9pbmtzY2FwZSIKICAgeG1sbnM6c29kaXBvZGk9Imh0dHA6Ly9zb2RpcG9kaS5zb3VyY2Vmb3JnZS5uZXQvRFREL3NvZGlwb2RpLTAuZHRkIgogICB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciCiAgIHhtbG5zOnN2Zz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciCiAgIHhtbG5zOnNlcmlmPSJodHRwOi8vd3d3LnNlcmlmLmNvbS8iPjxkZWZzCiAgIGlkPSJkZWZzMTExNCIgLz48c29kaXBvZGk6bmFtZWR2aWV3CiAgIGlkPSJuYW1lZHZpZXcxMTEyIgogICBwYWdlY29sb3I9IiNmZmZmZmYiCiAgIGJvcmRlcmNvbG9yPSIjNjY2NjY2IgogICBib3JkZXJvcGFjaXR5PSIxLjAiCiAgIGlua3NjYXBlOnBhZ2VzaGFkb3c9IjIiCiAgIGlua3NjYXBlOnBhZ2VvcGFjaXR5PSIwLjAiCiAgIGlua3NjYXBlOnBhZ2VjaGVja2VyYm9hcmQ9IjAiCiAgIHNob3dncmlkPSJmYWxzZSIKICAgaW5rc2NhcGU6em9vbT0iMC4xMjgzNzUiCiAgIGlua3NjYXBlOmN4PSIxNDkxLjcyMzUiCiAgIGlua3NjYXBlOmN5PSIxNDA5LjkzMTgiCiAgIGlua3NjYXBlOndpbmRvdy13aWR0aD0iMTkyMCIKICAgaW5rc2NhcGU6d2luZG93LWhlaWdodD0iOTgzIgogICBpbmtzY2FwZTp3aW5kb3cteD0iMCIKICAgaW5rc2NhcGU6d2luZG93LXk9IjAiCiAgIGlua3NjYXBlOndpbmRvdy1tYXhpbWl6ZWQ9IjEiCiAgIGlua3NjYXBlOmN1cnJlbnQtbGF5ZXI9Ik9HQy0yRC1Mb2NrdXAtdy0tVHJhZGVtYXJrIiAvPgogICAgPGcKICAgaWQ9Ik9HQy0yRC1Mb2NrdXAtdy0tVHJhZGVtYXJrIgogICBzZXJpZjppZD0iT0dDIDJEIExvY2t1cCB3LyBUcmFkZW1hcmsiCiAgIHRyYW5zZm9ybT0ibWF0cml4KDIwLjA2NTEsMCwwLDIwLjA2NTEsLTE0MzUuMDksLTEwMjQuMTQpIj4KICAgICAgICAKICAgICAgICA8ZwogICBpZD0iQ3ViZSIKICAgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoLTM1LjkyNzA1NiwtNDkuNDQ2NTI0KSI+CiAgICAgICAgICAgIDxnCiAgIHRyYW5zZm9ybT0idHJhbnNsYXRlKDE1Ni4yMTcsMTYxLjU2OSkiCiAgIGlkPSJnMTA5OCI+CiAgICAgICAgICAgICAgICA8cGF0aAogICBkPSJNIDAsMTQuNjUzIDAuMDAxLDQzLjk4MyAtNDIuMzEyLDE5LjU1NCAtNDIuMzEzLC0yOS4zMyAwLC00LjkwMSB2IDkuNzc2IGwgLTguNDQ2LC00Ljg3NCAtNC4yMzMsLTIuNDQ1IC0yMS4xNjcsLTEyLjIyMSB2IDI5LjMzIGwgMjUuNCwxNC42NjYgdiAtOS43NzcgbCAtMTIuNywtNy4zMzMgMC4wMDEsLTQuODg4IGggLTAuMDAxIFYgMi40NDUgWiIKICAgc3R5bGU9ImZpbGw6IzAwYjFmZjtmaWxsLXJ1bGU6bm9uemVybyIKICAgaWQ9InBhdGgxMDk2IiAvPgogICAgICAgICAgICA8L2c+CiAgICAgICAgICAgIDxnCiAgIHRyYW5zZm9ybT0idHJhbnNsYXRlKDE2MC40NTUsMTEwLjI2MSkiCiAgIGlkPSJnMTEwMiI+CiAgICAgICAgICAgICAgICA8cGF0aAogICBkPSJNIDAsMjkuMzMgLTI1LjQwMywxNC42NjUgMCwtMC4wMDEgMjUuMzk5LDE0LjY2NSAyMS4xNjcsMTcuMTA5IFogTSAtMC4wMDEsLTkuNzc3IC00Mi4zMzYsMTQuNjY1IC0wLjAwMSwzOS4xMDcgNDIuMzMzLDE0LjY2NSBaIgogICBzdHlsZT0iZmlsbDojMDBiMWZmO2ZpbGwtcnVsZTpub256ZXJvIgogICBpZD0icGF0aDExMDAiIC8+CiAgICAgICAgICAgIDwvZz4KICAgICAgICAgICAgPGcKICAgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMTgxLjY2LDE4MS4yMzkpIgogICBpZD0iZzExMDYiPgogICAgICAgICAgICAgICAgPHBhdGgKICAgZD0ibSAwLC0yNC42ODggOC40NjgsLTQuODg4IDguNDY2LC00Ljg4OSAxMGUtNCw5Ljc3NyA4LjQ0NCwtNC44NzUgdiAtMTkuNDQ0IGwgLTQyLjMxMiwyNC40MjkgdiA5LjY2NiBoIDAuMDAxIGwgLTAuMDAxLDIuOTE4IDAuMDAxLDM2LjE5IC0wLjAyMiwtMC4wMTMgdiAwLjEzNiBMIDI1LjM3OSwtMC4xMjMgdiAtMTkuNjY1IGwgLTguNDQ0LDQuODc3IHYgOS43NzYgTCAtOC40NjYsOS41MyAtOC40NjUsLTE5Ljc5OSBaIgogICBzdHlsZT0iZmlsbDojMDBiMWZmO2ZpbGwtcnVsZTpub256ZXJvIgogICBpZD0icGF0aDExMDQiIC8+CiAgICAgICAgICAgIDwvZz4KICAgICAgICA8L2c+CiAgICA8L2c+Cjwvc3ZnPgo="
+    camel.apache.org/provider: "Apache Software Foundation"
+    camel.apache.org/kamelet.group: "Geospatial"
+  labels:
+    camel.apache.org/kamelet.type: "action"
+spec:
+  definition:
+    title: "OGC Api Feature Get Item Action"
+    description: |-
+      Returns the items of the collection provided of an OGC API Features server. 
+      The collection must be a valid collection name on the server.
+      
+      See https://www.ogc.org/standards/ogcapi-features
+    required:
+      - url
+      - collection
+    type: object
+    properties:
+      url:
+        title: URL
+        description: The URL to fetch for data
+        type: string
+        example: "https://emotional.byteroad.net"
+        pattern: "^(http|https)://.*"
+      collection:
+        title: "Collection"
+        description: "Name of the collection we want to extract items from."
+        type: string
+      bbox:
+        title: "Bounding Box"
+        description: "Bounding Box of the items we want to retrieve."
+        example: "160.6,-55.95,-170,-25.89"
+        default: "-180,-90,180,90"
+        type: string
+      limit:
+        title: "Limit"
+        description: "Maximum number of items to retrieve. Must be a number between 1 and 10 000."
+        type: integer
+        default: 10
+      split:
+        title: "Split by Feature"
+        description: "When true, instead of returning the full geojson, split the message into each feature."
+        type: boolean
+        default: false
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+      query:
+        title: "Query"
+        description: "Separated list by `&` of properties we want to query."
+        example: "property1=1&property2=dos"
+        default: ""
+        type: string
+  types:
+    in:
+      mediaType: text/plain
+    out:
+      mediaType: application/json
+  dependencies:
+    - "camel:core"
+    - "camel:http"
+    - "camel:kamelet"
+    - "camel:jsonpath"
+    - "camel:jackson"
+  template:
+    from:
+      uri: "kamelet:source"
+      steps:
+      - set-body:
+          simple: ""
+      - set-header:
+          name: "Accept"
+          constant: "application/geo+json"
+      - set-header:
+          name: "CamelHttpQuery"
+          simple: "limit={{limit}}&bbox={{bbox}}&{{?query}}"
+      - to: 
+          uri: "{{url}}/collections/{{collection}}/items"
+      - remove-header:
+          name: "Accept"
+      - remove-header:
+          name: "CamelHttpQuery"
+      - convert-body-to:
+          type: "java.lang.String"
+      - choice:
+          when:
+          - simple: "{{split}}"
+            steps:
+            - split:
+                jsonpath: "$.features[*]"
+                steps:
+                  - marshal:
+                      json: {}
+                  - to: "kamelet:sink"
+          otherwise:
+            steps:
+            - to: "kamelet:sink"
+
+
+


### PR DESCRIPTION
See https://www.ogc.org/standards/ogcapi-features

You can either call for a full geoJSON with all the results or iterate over each result using the `split` parameter.

This is a new geospatial API standard that replaces WFS servers.

Kamelet Binding used to test:

```
apiVersion: camel.apache.org/v1alpha1
kind: KameletBinding
metadata:
  name: integration
spec:
  source:
    ref:
      apiVersion: camel.apache.org/v1alpha1
      name: timer-source
      kind: Kamelet
    properties:
      period: '5000000'
      message: 'NONLD_AREA=0.0&NAME=Croydon'
  steps:
  - ref:
      apiVersion: camel.apache.org/v1alpha1
      name: ogcapi-features-action
      kind: Kamelet
    properties:
      collection: activity_level_ldn
      url: https://emotional.byteroad.net/
  sink:
    ref:
      apiVersion: camel.apache.org/v1alpha1
      name: log-sink
      kind: Kamelet
    properties:
      showAll: true

```