### PR TITLE
Upgrade to Camel 3.19.0: Remove AWS SDK Utils from AWS Kamelets

### DIFF
--- a/kamelets/aws-cloudwatch-sink.kamelet.yaml
+++ b/kamelets/aws-cloudwatch-sink.kamelet.yaml
@@ -97,7 +97,6 @@ spec:
     - "camel:core"
     - "camel:aws2-cw"
     - "camel:kamelet"
-    - "mvn:software.amazon.awssdk:utils:2.17.223"
   template:
     from:
       uri: kamelet:source

--- a/kamelets/aws-ddb-sink.kamelet.yaml
+++ b/kamelets/aws-ddb-sink.kamelet.yaml
@@ -106,7 +106,6 @@ spec:
   - "camel:jackson"
   - "camel:aws2-ddb"
   - "camel:kamelet"
-  - "mvn:software.amazon.awssdk:utils:2.17.223"
   template:
     from:
       uri: "kamelet:source"

--- a/kamelets/aws-ddb-streams-source.kamelet.yaml
+++ b/kamelets/aws-ddb-streams-source.kamelet.yaml
@@ -101,7 +101,6 @@ spec:
   - "camel:gson"
   - "camel:aws2-ddb"
   - "camel:kamelet"
-  - "mvn:software.amazon.awssdk:utils:2.17.223"
   template:
     from:
       uri: "aws2-ddbstream:{{table}}"

--- a/kamelets/aws-ec2-sink.kamelet.yaml
+++ b/kamelets/aws-ec2-sink.kamelet.yaml
@@ -87,7 +87,6 @@ spec:
     - "camel:core"
     - "camel:aws2-ec2"
     - "camel:kamelet"
-    - "mvn:software.amazon.awssdk:utils:2.17.223"
   template:
     from:
       uri: kamelet:source

--- a/kamelets/aws-eventbridge-sink.kamelet.yaml
+++ b/kamelets/aws-eventbridge-sink.kamelet.yaml
@@ -96,7 +96,6 @@ spec:
     - "camel:core"
     - "camel:aws2-eventbridge"
     - "camel:kamelet"
-    - "mvn:software.amazon.awssdk:utils:2.17.223"
   template:
     from:
       uri: "kamelet:source"

--- a/kamelets/aws-kinesis-firehose-sink.kamelet.yaml
+++ b/kamelets/aws-kinesis-firehose-sink.kamelet.yaml
@@ -87,7 +87,6 @@ spec:
   dependencies:
     - "camel:aws2-kinesis"
     - "camel:kamelet"
-    - "mvn:software.amazon.awssdk:utils:2.17.223"
   template:
     from:
       uri: kamelet:source

--- a/kamelets/aws-kinesis-sink.kamelet.yaml
+++ b/kamelets/aws-kinesis-sink.kamelet.yaml
@@ -98,7 +98,6 @@ spec:
     - "camel:core"
     - "camel:aws2-kinesis"
     - "camel:kamelet"
-    - "mvn:software.amazon.awssdk:utils:2.17.223"
   template:
     from:
       uri: kamelet:source

--- a/kamelets/aws-kinesis-source.kamelet.yaml
+++ b/kamelets/aws-kinesis-source.kamelet.yaml
@@ -96,7 +96,6 @@ spec:
     - "camel:aws2-kinesis"
     - "camel:kamelet"
     - "camel:core"
-    - "mvn:software.amazon.awssdk:utils:2.17.223"
   template:
     from:
       uri: aws2-kinesis:{{stream}}

--- a/kamelets/aws-lambda-sink.kamelet.yaml
+++ b/kamelets/aws-lambda-sink.kamelet.yaml
@@ -76,7 +76,6 @@ spec:
   dependencies:
     - "camel:aws2-lambda"
     - "camel:kamelet"
-    - "mvn:software.amazon.awssdk:utils:2.17.223"
   template:
     from:
       uri: kamelet:source

--- a/kamelets/aws-s3-sink.kamelet.yaml
+++ b/kamelets/aws-s3-sink.kamelet.yaml
@@ -103,7 +103,6 @@ spec:
     - "camel:core"
     - "camel:aws2-s3"
     - "camel:kamelet"
-    - "mvn:software.amazon.awssdk:utils:2.17.223"
   template:
     from:
       uri: "kamelet:source"

--- a/kamelets/aws-s3-source.kamelet.yaml
+++ b/kamelets/aws-s3-source.kamelet.yaml
@@ -108,7 +108,6 @@ spec:
   dependencies:
     - "camel:aws2-s3"
     - "camel:kamelet"
-    - "mvn:software.amazon.awssdk:utils:2.17.223"
   template:
     from:
       uri: "aws2-s3:{{bucketNameOrArn}}"

--- a/kamelets/aws-s3-streaming-upload-sink.kamelet.yaml
+++ b/kamelets/aws-s3-streaming-upload-sink.kamelet.yaml
@@ -123,7 +123,6 @@ spec:
   dependencies:
     - "camel:aws2-s3"
     - "camel:kamelet"
-    - "mvn:software.amazon.awssdk:utils:2.17.223"
   template:
     from:
       uri: "kamelet:source"

--- a/kamelets/aws-secrets-manager-sink.kamelet.yaml
+++ b/kamelets/aws-secrets-manager-sink.kamelet.yaml
@@ -78,7 +78,6 @@ spec:
     - "camel:core"
     - "camel:aws-secrets-manager"
     - "camel:kamelet"
-    - "mvn:software.amazon.awssdk:utils:2.17.223"
   template:
     from:
       uri: "kamelet:source"

--- a/kamelets/aws-ses-sink.kamelet.yaml
+++ b/kamelets/aws-ses-sink.kamelet.yaml
@@ -87,7 +87,6 @@ spec:
     - "camel:core"
     - "camel:aws2-ses"
     - "camel:kamelet"
-    - "mvn:software.amazon.awssdk:utils:2.17.223"
   template:
     from:
       uri: "kamelet:source"

--- a/kamelets/aws-sns-fifo-sink.kamelet.yaml
+++ b/kamelets/aws-sns-fifo-sink.kamelet.yaml
@@ -106,7 +106,6 @@ spec:
   - "camel:aws2-sns"
   - "camel:core"
   - "camel:kamelet"
-  - "mvn:software.amazon.awssdk:utils:2.17.223"
   template:
     from:
       uri: kamelet:source

--- a/kamelets/aws-sns-sink.kamelet.yaml
+++ b/kamelets/aws-sns-sink.kamelet.yaml
@@ -97,7 +97,6 @@ spec:
     - "camel:core"
     - "camel:aws2-sns"
     - "camel:kamelet"
-    - "mvn:software.amazon.awssdk:utils:2.17.223"
   template:
     from:
       uri: kamelet:source

--- a/kamelets/aws-sqs-batch-sink.kamelet.yaml
+++ b/kamelets/aws-sqs-batch-sink.kamelet.yaml
@@ -111,7 +111,6 @@ spec:
   dependencies:
     - "camel:aws2-sqs"
     - "camel:kamelet"
-    - "mvn:software.amazon.awssdk:utils:2.17.223"
   template:
     from:
       uri: kamelet:source

--- a/kamelets/aws-sqs-fifo-sink.kamelet.yaml
+++ b/kamelets/aws-sqs-fifo-sink.kamelet.yaml
@@ -114,7 +114,6 @@ spec:
   - "camel:aws2-sqs"
   - "camel:core"
   - "camel:kamelet"
-  - "mvn:software.amazon.awssdk:utils:2.17.223"
   template:
     from:
       uri: kamelet:source

--- a/kamelets/aws-sqs-sink.kamelet.yaml
+++ b/kamelets/aws-sqs-sink.kamelet.yaml
@@ -105,7 +105,6 @@ spec:
   dependencies:
     - "camel:aws2-sqs"
     - "camel:kamelet"
-    - "mvn:software.amazon.awssdk:utils:2.17.223"
   template:
     from:
       uri: kamelet:source

--- a/kamelets/aws-sqs-source.kamelet.yaml
+++ b/kamelets/aws-sqs-source.kamelet.yaml
@@ -132,7 +132,6 @@ spec:
   dependencies:
     - "camel:aws2-sqs"
     - "camel:kamelet"
-    - "mvn:software.amazon.awssdk:utils:2.17.223"
   template:
     from:
       uri: "aws2-sqs:{{queueNameOrArn}}"

--- a/kamelets/aws-translate-action.kamelet.yaml
+++ b/kamelets/aws-translate-action.kamelet.yaml
@@ -84,7 +84,6 @@ spec:
     - "camel:dns"
     - "camel:kamelet"
     - "camel:aws2-translate"
-    - "mvn:software.amazon.awssdk:utils:2.17.223"
   template:
     from:
       uri: "kamelet:source"

--- a/library/camel-kamelets-catalog/src/test/java/org/apache/camel/kamelets/catalog/KameletsCatalogTest.java
+++ b/library/camel-kamelets-catalog/src/test/java/org/apache/camel/kamelets/catalog/KameletsCatalogTest.java
@@ -102,7 +102,7 @@ public class KameletsCatalogTest {
     @Test
     void testGetKameletsDependencies() throws Exception {
         List<String> deps = catalog.getKameletDependencies("aws-sqs-source");
-        assertEquals(3, deps.size());
+        assertEquals(2, deps.size());
         deps = catalog.getKameletDependencies("cassandra-sink");
         assertEquals(3, deps.size());
         assertEquals("camel:jackson", deps.get(0));

--- a/library/camel-kamelets/src/main/resources/kamelets/aws-cloudwatch-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/aws-cloudwatch-sink.kamelet.yaml
@@ -97,7 +97,6 @@ spec:
     - "camel:core"
     - "camel:aws2-cw"
     - "camel:kamelet"
-    - "mvn:software.amazon.awssdk:utils:2.17.223"
   template:
     from:
       uri: kamelet:source

--- a/library/camel-kamelets/src/main/resources/kamelets/aws-ddb-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/aws-ddb-sink.kamelet.yaml
@@ -106,7 +106,6 @@ spec:
   - "camel:jackson"
   - "camel:aws2-ddb"
   - "camel:kamelet"
-  - "mvn:software.amazon.awssdk:utils:2.17.223"
   template:
     from:
       uri: "kamelet:source"

--- a/library/camel-kamelets/src/main/resources/kamelets/aws-ddb-streams-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/aws-ddb-streams-source.kamelet.yaml
@@ -101,7 +101,6 @@ spec:
   - "camel:gson"
   - "camel:aws2-ddb"
   - "camel:kamelet"
-  - "mvn:software.amazon.awssdk:utils:2.17.223"
   template:
     from:
       uri: "aws2-ddbstream:{{table}}"

--- a/library/camel-kamelets/src/main/resources/kamelets/aws-ec2-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/aws-ec2-sink.kamelet.yaml
@@ -87,7 +87,6 @@ spec:
     - "camel:core"
     - "camel:aws2-ec2"
     - "camel:kamelet"
-    - "mvn:software.amazon.awssdk:utils:2.17.223"
   template:
     from:
       uri: kamelet:source

--- a/library/camel-kamelets/src/main/resources/kamelets/aws-eventbridge-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/aws-eventbridge-sink.kamelet.yaml
@@ -96,7 +96,6 @@ spec:
     - "camel:core"
     - "camel:aws2-eventbridge"
     - "camel:kamelet"
-    - "mvn:software.amazon.awssdk:utils:2.17.223"
   template:
     from:
       uri: "kamelet:source"

--- a/library/camel-kamelets/src/main/resources/kamelets/aws-kinesis-firehose-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/aws-kinesis-firehose-sink.kamelet.yaml
@@ -87,7 +87,6 @@ spec:
   dependencies:
     - "camel:aws2-kinesis"
     - "camel:kamelet"
-    - "mvn:software.amazon.awssdk:utils:2.17.223"
   template:
     from:
       uri: kamelet:source

--- a/library/camel-kamelets/src/main/resources/kamelets/aws-kinesis-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/aws-kinesis-sink.kamelet.yaml
@@ -98,7 +98,6 @@ spec:
     - "camel:core"
     - "camel:aws2-kinesis"
     - "camel:kamelet"
-    - "mvn:software.amazon.awssdk:utils:2.17.223"
   template:
     from:
       uri: kamelet:source

--- a/library/camel-kamelets/src/main/resources/kamelets/aws-kinesis-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/aws-kinesis-source.kamelet.yaml
@@ -96,7 +96,6 @@ spec:
     - "camel:aws2-kinesis"
     - "camel:kamelet"
     - "camel:core"
-    - "mvn:software.amazon.awssdk:utils:2.17.223"
   template:
     from:
       uri: aws2-kinesis:{{stream}}

--- a/library/camel-kamelets/src/main/resources/kamelets/aws-lambda-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/aws-lambda-sink.kamelet.yaml
@@ -76,7 +76,6 @@ spec:
   dependencies:
     - "camel:aws2-lambda"
     - "camel:kamelet"
-    - "mvn:software.amazon.awssdk:utils:2.17.223"
   template:
     from:
       uri: kamelet:source

--- a/library/camel-kamelets/src/main/resources/kamelets/aws-s3-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/aws-s3-sink.kamelet.yaml
@@ -103,7 +103,6 @@ spec:
     - "camel:core"
     - "camel:aws2-s3"
     - "camel:kamelet"
-    - "mvn:software.amazon.awssdk:utils:2.17.223"
   template:
     from:
       uri: "kamelet:source"

--- a/library/camel-kamelets/src/main/resources/kamelets/aws-s3-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/aws-s3-source.kamelet.yaml
@@ -108,7 +108,6 @@ spec:
   dependencies:
     - "camel:aws2-s3"
     - "camel:kamelet"
-    - "mvn:software.amazon.awssdk:utils:2.17.223"
   template:
     from:
       uri: "aws2-s3:{{bucketNameOrArn}}"

--- a/library/camel-kamelets/src/main/resources/kamelets/aws-s3-streaming-upload-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/aws-s3-streaming-upload-sink.kamelet.yaml
@@ -123,7 +123,6 @@ spec:
   dependencies:
     - "camel:aws2-s3"
     - "camel:kamelet"
-    - "mvn:software.amazon.awssdk:utils:2.17.223"
   template:
     from:
       uri: "kamelet:source"

--- a/library/camel-kamelets/src/main/resources/kamelets/aws-secrets-manager-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/aws-secrets-manager-sink.kamelet.yaml
@@ -78,7 +78,6 @@ spec:
     - "camel:core"
     - "camel:aws-secrets-manager"
     - "camel:kamelet"
-    - "mvn:software.amazon.awssdk:utils:2.17.223"
   template:
     from:
       uri: "kamelet:source"

--- a/library/camel-kamelets/src/main/resources/kamelets/aws-ses-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/aws-ses-sink.kamelet.yaml
@@ -87,7 +87,6 @@ spec:
     - "camel:core"
     - "camel:aws2-ses"
     - "camel:kamelet"
-    - "mvn:software.amazon.awssdk:utils:2.17.223"
   template:
     from:
       uri: "kamelet:source"

--- a/library/camel-kamelets/src/main/resources/kamelets/aws-sns-fifo-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/aws-sns-fifo-sink.kamelet.yaml
@@ -106,7 +106,6 @@ spec:
   - "camel:aws2-sns"
   - "camel:core"
   - "camel:kamelet"
-  - "mvn:software.amazon.awssdk:utils:2.17.223"
   template:
     from:
       uri: kamelet:source

--- a/library/camel-kamelets/src/main/resources/kamelets/aws-sns-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/aws-sns-sink.kamelet.yaml
@@ -97,7 +97,6 @@ spec:
     - "camel:core"
     - "camel:aws2-sns"
     - "camel:kamelet"
-    - "mvn:software.amazon.awssdk:utils:2.17.223"
   template:
     from:
       uri: kamelet:source

--- a/library/camel-kamelets/src/main/resources/kamelets/aws-sqs-batch-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/aws-sqs-batch-sink.kamelet.yaml
@@ -111,7 +111,6 @@ spec:
   dependencies:
     - "camel:aws2-sqs"
     - "camel:kamelet"
-    - "mvn:software.amazon.awssdk:utils:2.17.223"
   template:
     from:
       uri: kamelet:source

--- a/library/camel-kamelets/src/main/resources/kamelets/aws-sqs-fifo-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/aws-sqs-fifo-sink.kamelet.yaml
@@ -114,7 +114,6 @@ spec:
   - "camel:aws2-sqs"
   - "camel:core"
   - "camel:kamelet"
-  - "mvn:software.amazon.awssdk:utils:2.17.223"
   template:
     from:
       uri: kamelet:source

--- a/library/camel-kamelets/src/main/resources/kamelets/aws-sqs-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/aws-sqs-sink.kamelet.yaml
@@ -105,7 +105,6 @@ spec:
   dependencies:
     - "camel:aws2-sqs"
     - "camel:kamelet"
-    - "mvn:software.amazon.awssdk:utils:2.17.223"
   template:
     from:
       uri: kamelet:source

--- a/library/camel-kamelets/src/main/resources/kamelets/aws-sqs-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/aws-sqs-source.kamelet.yaml
@@ -132,7 +132,6 @@ spec:
   dependencies:
     - "camel:aws2-sqs"
     - "camel:kamelet"
-    - "mvn:software.amazon.awssdk:utils:2.17.223"
   template:
     from:
       uri: "aws2-sqs:{{queueNameOrArn}}"

--- a/library/camel-kamelets/src/main/resources/kamelets/aws-translate-action.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/aws-translate-action.kamelet.yaml
@@ -84,7 +84,6 @@ spec:
     - "camel:dns"
     - "camel:kamelet"
     - "camel:aws2-translate"
-    - "mvn:software.amazon.awssdk:utils:2.17.223"
   template:
     from:
       uri: "kamelet:source"


### PR DESCRIPTION
Fixes #1011 