### PR TITLE
Azure Storage Blob Kamelets should specify which kind of credentials to use

### DIFF
--- a/kamelets/azure-storage-blob-sink.kamelet.yaml
+++ b/kamelets/azure-storage-blob-sink.kamelet.yaml
@@ -63,6 +63,11 @@ spec:
         description: The operation to perform.
         type: string
         default: uploadBlockBlob
+      credentialType:
+        title: Credential Type
+        description: Determines the credential strategy to adopt. Possible values are SHARED_ACCOUNT_KEY, SHARED_KEY_CREDENTIAL and AZURE_IDENTITY
+        type: string
+        default: SHARED_ACCOUNT_KEY
   dependencies:
     - "camel:core"
     - "camel:azure-storage-blob"
@@ -93,3 +98,4 @@ spec:
           parameters:
             accessKey: "{{accessKey}}"
             operation: "{{operation}}"
+            credentialType: "{{credentialType}}"

--- a/kamelets/azure-storage-blob-source.kamelet.yaml
+++ b/kamelets/azure-storage-blob-source.kamelet.yaml
@@ -62,6 +62,11 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
+      credentialType:
+        title: Credential Type
+        description: Determines the credential strategy to adopt. Possible values are SHARED_ACCOUNT_KEY, SHARED_KEY_CREDENTIAL and AZURE_IDENTITY
+        type: string
+        default: SHARED_ACCOUNT_KEY
   dependencies:
     - "camel:azure-storage-blob"
     - "camel:kamelet"
@@ -79,6 +84,7 @@ spec:
           parameters:
             operation: "listBlobs"
             accessKey: "{{accessKey}}"
+            credentialType: "{{credentialType}}"
       - split:
           jsonpath: "$.*"
           steps:

--- a/library/camel-kamelets/src/main/resources/kamelets/azure-storage-blob-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/azure-storage-blob-sink.kamelet.yaml
@@ -63,6 +63,11 @@ spec:
         description: The operation to perform.
         type: string
         default: uploadBlockBlob
+      credentialType:
+        title: Credential Type
+        description: Determines the credential strategy to adopt. Possible values are SHARED_ACCOUNT_KEY, SHARED_KEY_CREDENTIAL and AZURE_IDENTITY
+        type: string
+        default: SHARED_ACCOUNT_KEY
   dependencies:
     - "camel:core"
     - "camel:azure-storage-blob"
@@ -93,3 +98,4 @@ spec:
           parameters:
             accessKey: "{{accessKey}}"
             operation: "{{operation}}"
+            credentialType: "{{credentialType}}"

--- a/library/camel-kamelets/src/main/resources/kamelets/azure-storage-blob-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/azure-storage-blob-source.kamelet.yaml
@@ -62,6 +62,11 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
+      credentialType:
+        title: Credential Type
+        description: Determines the credential strategy to adopt. Possible values are SHARED_ACCOUNT_KEY, SHARED_KEY_CREDENTIAL and AZURE_IDENTITY
+        type: string
+        default: SHARED_ACCOUNT_KEY
   dependencies:
     - "camel:azure-storage-blob"
     - "camel:kamelet"
@@ -79,6 +84,7 @@ spec:
           parameters:
             operation: "listBlobs"
             accessKey: "{{accessKey}}"
+            credentialType: "{{credentialType}}"
       - split:
           jsonpath: "$.*"
           steps:


### PR DESCRIPTION
Fixes #1061 