### PR TITLE
Google BigQuery Sink Kamelet: Use ServiceAccountKey parameter instead of forming a connectionFactoryBean

### DIFF
--- a/kamelets/google-bigquery-sink.kamelet.yaml
+++ b/kamelets/google-bigquery-sink.kamelet.yaml
@@ -52,12 +52,12 @@ spec:
         title: Big Query Table Id
         description: The Big Query Table ID.
         type: string
-      credentialsFileLocation:
-        title: Google Cloud Platform Credential File
-        description: The credential for accessing Google Cloud Platform API services. This value must be a path to a service account key file.
-        type: string
+      serviceAccountKey:
+        title: Service Account Key
+        description: The service account key to use as credentials for the BigQuery Service. You must encode this value in base64.
+        type: binary
         x-descriptors:
-          - urn:camel:group:credentials
+        - urn:camel:group:credentials
   types:
     in:
       mediaType: application/json
@@ -67,12 +67,6 @@ spec:
     - "camel:google-bigquery"
     - "camel:jackson"
   template:
-    beans:
-      - name: connectionFactoryBean
-        type: "#class:org.apache.camel.component.google.bigquery.GoogleBigQueryConnectionFactory"
-        property:
-          - key: credentialsFileLocation
-            value: '{{credentialsFileLocation}}'
     from:
       uri: "kamelet:source"
       steps:
@@ -82,4 +76,4 @@ spec:
       - to:
           uri: "google-bigquery:{{projectId}}:{{dataset}}:{{table}}"
           parameters:
-            connectionFactory: "#bean:{{connectionFactoryBean}}"
+            serviceAccountKey: "base64:{{serviceAccountKey}}"

--- a/kamelets/google-bigquery-sink.kamelet.yaml
+++ b/kamelets/google-bigquery-sink.kamelet.yaml
@@ -37,7 +37,7 @@ spec:
       - projectId
       - dataset
       - table
-      - credentialsFileLocation
+      - serviceAccountKey
     type: object
     properties:
       projectId:

--- a/library/camel-kamelets/src/main/resources/kamelets/google-bigquery-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/google-bigquery-sink.kamelet.yaml
@@ -52,12 +52,12 @@ spec:
         title: Big Query Table Id
         description: The Big Query Table ID.
         type: string
-      credentialsFileLocation:
-        title: Google Cloud Platform Credential File
-        description: The credential for accessing Google Cloud Platform API services. This value must be a path to a service account key file.
-        type: string
+      serviceAccountKey:
+        title: Service Account Key
+        description: The service account key to use as credentials for the BigQuery Service. You must encode this value in base64.
+        type: binary
         x-descriptors:
-          - urn:camel:group:credentials
+        - urn:camel:group:credentials
   types:
     in:
       mediaType: application/json
@@ -67,12 +67,6 @@ spec:
     - "camel:google-bigquery"
     - "camel:jackson"
   template:
-    beans:
-      - name: connectionFactoryBean
-        type: "#class:org.apache.camel.component.google.bigquery.GoogleBigQueryConnectionFactory"
-        property:
-          - key: credentialsFileLocation
-            value: '{{credentialsFileLocation}}'
     from:
       uri: "kamelet:source"
       steps:
@@ -82,4 +76,4 @@ spec:
       - to:
           uri: "google-bigquery:{{projectId}}:{{dataset}}:{{table}}"
           parameters:
-            connectionFactory: "#bean:{{connectionFactoryBean}}"
+            serviceAccountKey: "base64:{{serviceAccountKey}}"

--- a/library/camel-kamelets/src/main/resources/kamelets/google-bigquery-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/google-bigquery-sink.kamelet.yaml
@@ -37,7 +37,7 @@ spec:
       - projectId
       - dataset
       - table
-      - credentialsFileLocation
+      - serviceAccountKey
     type: object
     properties:
       projectId:


### PR DESCRIPTION
Fixes #1037 