### PR TITLE
Added a Catalog Method showing the supported headers (specific for consumer, producer and common) for a Kamelet

### DIFF
--- a/library/camel-kamelets-catalog/pom.xml
+++ b/library/camel-kamelets-catalog/pom.xml
@@ -115,13 +115,13 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-tooling-model</artifactId>
-            <version>3.19.0</version>
+            <version>${camel.version}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-catalog</artifactId>
-            <version>3.19.0</version>
+            <version>${camel.version}</version>
             <scope>compile</scope>
         </dependency>
 

--- a/library/camel-kamelets-catalog/pom.xml
+++ b/library/camel-kamelets-catalog/pom.xml
@@ -112,6 +112,18 @@
             <scope>test</scope>
             <version>${junit.jupiter.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-tooling-model</artifactId>
+            <version>3.19.0</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-catalog</artifactId>
+            <version>3.19.0</version>
+            <scope>compile</scope>
+        </dependency>
 
     </dependencies>
 </project>

--- a/library/camel-kamelets-catalog/src/main/java/org/apache/camel/kamelets/catalog/KameletsCatalog.java
+++ b/library/camel-kamelets-catalog/src/main/java/org/apache/camel/kamelets/catalog/KameletsCatalog.java
@@ -18,12 +18,7 @@ package org.apache.camel.kamelets.catalog;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.TreeMap;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
@@ -34,8 +29,13 @@ import io.fabric8.camelk.v1alpha1.JSONSchemaProps;
 import io.github.classgraph.ClassGraph;
 import io.github.classgraph.Resource;
 import io.github.classgraph.ScanResult;
+import org.apache.camel.catalog.DefaultCamelCatalog;
 import org.apache.camel.kamelets.catalog.model.KameletAnnotationsNames;
 import org.apache.camel.kamelets.catalog.model.KameletLabelNames;
+import org.apache.camel.kamelets.catalog.model.KameletPrefixSchemeEnum;
+import org.apache.camel.kamelets.catalog.model.KameletTypeEnum;
+import org.apache.camel.tooling.model.ComponentModel;
+import org.apache.camel.util.ObjectHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -48,6 +48,7 @@ public class KameletsCatalog {
 
     private final Map<String, Kamelet> kameletModels;
     private final List<String> kameletNames;
+    private final DefaultCamelCatalog cc = new DefaultCamelCatalog();
 
     public KameletsCatalog() {
         kameletModels = initCatalog();
@@ -65,9 +66,9 @@ public class KameletsCatalog {
                     Kamelet kamelet = MAPPER.readValue(is, Kamelet.class);
 
                     LOG.debug("Loading kamelet from: {}, path: {}, name: {}",
-                        resource.getClasspathElementFile(),
-                        resource.getPath(),
-                        name);
+                            resource.getClasspathElementFile(),
+                            resource.getPath(),
+                            name);
 
                     kameletModels.put(name, kamelet);
                 } catch (IOException e) {
@@ -123,7 +124,7 @@ public class KameletsCatalog {
     public JSONSchemaProps getKameletDefinition(String name) {
         Kamelet kamelet = kameletModels.get(name);
         if (kamelet != null) {
-                return kamelet.getSpec().getDefinition();
+            return kamelet.getSpec().getDefinition();
         } else {
             return null;
         }
@@ -161,9 +162,9 @@ public class KameletsCatalog {
 
     public void getAllKameletDependencies() {
         Map<String, Kamelet> treeMap = new TreeMap<>(kameletModels);
-        for (Map.Entry<String, Kamelet> entry: treeMap.entrySet()) {
+        for (Map.Entry<String, Kamelet> entry : treeMap.entrySet()) {
             StringBuilder builder = new StringBuilder();
-            for (String dep: entry.getValue().getSpec().getDependencies()) {
+            for (String dep : entry.getValue().getSpec().getDependencies()) {
                 builder.append(dep + System.lineSeparator());
             }
             System.out.println(entry.getKey());
@@ -180,5 +181,44 @@ public class KameletsCatalog {
         } else {
             return null;
         }
+    }
+
+    public List<ComponentModel.EndpointHeaderModel> getKameletSupportedHeaders(String name) {
+        List<ComponentModel.EndpointHeaderModel> resultingHeaders = new ArrayList<>();
+        Kamelet local = kameletModels.get(name);
+        if (ObjectHelper.isNotEmpty(local)) {
+            String camelType = determineCamelType(local);
+            String kameletName = local.getMetadata().getName();
+            int lastIndex = kameletName.lastIndexOf("-");
+            String prefixName = local.getMetadata().getName().substring(0, lastIndex);
+            String schemeName = enumValue(prefixName);
+            if (schemeName != null) {
+                List<ComponentModel.EndpointHeaderModel> headers = cc.componentModel(schemeName).getEndpointHeaders();
+                for (ComponentModel.EndpointHeaderModel e : headers) {
+                    if (ObjectHelper.isEmpty(e.getLabel()) || e.getLabel().equalsIgnoreCase(camelType)) {
+                        resultingHeaders.add(e);
+                    }
+                }
+            }
+        }
+        return resultingHeaders;
+    }
+
+    private String enumValue(String prefix) {
+        for (KameletPrefixSchemeEnum c : KameletPrefixSchemeEnum.values()) {
+            if (c.prefix.equals(prefix)) return c.label;
+        }
+        return null;
+    }
+
+    private String determineCamelType(Kamelet local) {
+        String camelType;
+        String kameletType = local.getMetadata().getLabels().get(KameletLabelNames.KAMELET_LABEL_TYPE);
+        if (kameletType.equalsIgnoreCase(KameletTypeEnum.SINK.type())) {
+            camelType = "producer";
+        } else {
+            camelType = "consumer";
+        }
+        return camelType;
     }
 }

--- a/library/camel-kamelets-catalog/src/main/java/org/apache/camel/kamelets/catalog/model/KameletPrefixSchemeEnum.java
+++ b/library/camel-kamelets-catalog/src/main/java/org/apache/camel/kamelets/catalog/model/KameletPrefixSchemeEnum.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.kamelets.catalog.model;
+
+public enum KameletPrefixSchemeEnum {
+    aws_cloudwatch("aws-cloudwatch","aws2-cw"),
+    aws_ddb("aws-ddb","aws2-ddb"),
+    aws_ddb_streams("aws-ddb","aws2-ddbstream"),
+    aws_ec2("aws-ec2","aws2-ec2"),
+    aws_eventbridge("aws-eventbridge","aws2-eventbridge"),
+    aws_lambda("aws-lambda","aws2-lambda"),
+    aws_redshift("aws-redshift","sql"),
+    aws_s3("aws-s3","aws2-s3"),
+    aws_secrets_manager("aws-secrets-manager","aws-secrets-manager"),
+    aws_ses("aws-ses","aws2-ses"),
+    aws_sns("aws-sns","aws2-sns"),
+    aws_sns_fifo("aws-sns-fifo","aws2-sns"),
+    aws_sqs("aws-sqs","aws2-sqs"),
+    aws_sqs_batch("aws-sqs-batch","aws2-sqs"),
+    aws_sqs_fifo("aws-sqs-fifo","aws2-sqs"),
+    azure_eventhubs("azure-eventhubs","azure-eventhubs");
+
+    public final String label;
+    public final String prefix;
+
+    private KameletPrefixSchemeEnum(String prefix, String label) {
+        this.prefix = prefix;
+        this.label = label;
+    }
+}

--- a/library/camel-kamelets-catalog/src/test/java/org/apache/camel/kamelets/catalog/KameletsCatalogTest.java
+++ b/library/camel-kamelets-catalog/src/test/java/org/apache/camel/kamelets/catalog/KameletsCatalogTest.java
@@ -20,6 +20,7 @@ import io.fabric8.camelk.v1alpha1.Kamelet;
 import io.fabric8.camelk.v1alpha1.JSONSchemaProps;
 import io.github.classgraph.ClassGraph;
 import org.apache.camel.kamelets.catalog.model.KameletTypeEnum;
+import org.apache.camel.tooling.model.ComponentModel;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -123,5 +124,17 @@ public class KameletsCatalogTest {
     @Test
     void testAllKameletDependencies() throws Exception {
         catalog.getAllKameletDependencies();
+    }
+
+    @Test
+    void testSupportedHeaders() throws Exception {
+        List<ComponentModel.EndpointHeaderModel> headersSource = catalog.getKameletSupportedHeaders("aws-s3-source");
+        assertEquals(18, headersSource.size());
+        List<ComponentModel.EndpointHeaderModel> headersSink = catalog.getKameletSupportedHeaders("aws-s3-sink");
+        assertEquals(25, headersSink.size());
+        List<ComponentModel.EndpointHeaderModel> headerNotExistent = catalog.getKameletSupportedHeaders("aws-not-exists");
+        assertEquals(0, headerNotExistent.size());
+        List<ComponentModel.EndpointHeaderModel> headersAzureSink = catalog.getKameletSupportedHeaders("azure-eventhubs-sink");
+        assertEquals(2, headersAzureSink.size());
     }
 }


### PR DESCRIPTION
I still need to map all the Kamelets prefix to scheme, but this is just a beginning.

Part of #929 