### PR TITLE
Added a Catalog Method showing the supported headers (specific for consumer, producer and common) for a Kamelet - Azure

### DIFF
--- a/library/camel-kamelets-catalog/src/main/java/org/apache/camel/kamelets/catalog/model/KameletPrefixSchemeEnum.java
+++ b/library/camel-kamelets-catalog/src/main/java/org/apache/camel/kamelets/catalog/model/KameletPrefixSchemeEnum.java
@@ -36,7 +36,8 @@ public enum KameletPrefixSchemeEnum {
     azure_functions("azure-functions","vertx-http"),
     azure_servicebus("azure-servicebus","azure-servicebus"),
     azure_storage_blob("azure-storage-blob","azure-storage-blob"),
-    azure_storage_blob_changefeed("azure-storage-blob-changefeed","azure-storage-blob");
+    azure_storage_blob_changefeed("azure-storage-blob-changefeed","azure-storage-blob"),
+    azure_storage_queue("azure-storage-queue","azure-storage-queue");
 
     public final String label;
     public final String prefix;

--- a/library/camel-kamelets-catalog/src/main/java/org/apache/camel/kamelets/catalog/model/KameletPrefixSchemeEnum.java
+++ b/library/camel-kamelets-catalog/src/main/java/org/apache/camel/kamelets/catalog/model/KameletPrefixSchemeEnum.java
@@ -35,7 +35,8 @@ public enum KameletPrefixSchemeEnum {
     azure_eventhubs("azure-eventhubs","azure-eventhubs"),
     azure_functions("azure-functions","vertx-http"),
     azure_servicebus("azure-servicebus","azure-servicebus"),
-    azure_storage_blob("azure-storage-blob","azure-storage-blob");
+    azure_storage_blob("azure-storage-blob","azure-storage-blob"),
+    azure_storage_blob_changefeed("azure-storage-blob-changefeed","azure-storage-blob");
 
     public final String label;
     public final String prefix;

--- a/library/camel-kamelets-catalog/src/main/java/org/apache/camel/kamelets/catalog/model/KameletPrefixSchemeEnum.java
+++ b/library/camel-kamelets-catalog/src/main/java/org/apache/camel/kamelets/catalog/model/KameletPrefixSchemeEnum.java
@@ -33,7 +33,8 @@ public enum KameletPrefixSchemeEnum {
     aws_sqs_batch("aws-sqs-batch","aws2-sqs"),
     aws_sqs_fifo("aws-sqs-fifo","aws2-sqs"),
     azure_eventhubs("azure-eventhubs","azure-eventhubs"),
-    azure_functions("azure-functions","vertx-http");
+    azure_functions("azure-functions","vertx-http"),
+    azure_servicebus("azure-servicebus","azure-servicebus");
 
     public final String label;
     public final String prefix;

--- a/library/camel-kamelets-catalog/src/main/java/org/apache/camel/kamelets/catalog/model/KameletPrefixSchemeEnum.java
+++ b/library/camel-kamelets-catalog/src/main/java/org/apache/camel/kamelets/catalog/model/KameletPrefixSchemeEnum.java
@@ -34,7 +34,8 @@ public enum KameletPrefixSchemeEnum {
     aws_sqs_fifo("aws-sqs-fifo","aws2-sqs"),
     azure_eventhubs("azure-eventhubs","azure-eventhubs"),
     azure_functions("azure-functions","vertx-http"),
-    azure_servicebus("azure-servicebus","azure-servicebus");
+    azure_servicebus("azure-servicebus","azure-servicebus"),
+    azure_storage_blob("azure-storage-blob","azure-storage-blob");
 
     public final String label;
     public final String prefix;

--- a/library/camel-kamelets-catalog/src/test/java/org/apache/camel/kamelets/catalog/KameletsCatalogTest.java
+++ b/library/camel-kamelets-catalog/src/test/java/org/apache/camel/kamelets/catalog/KameletsCatalogTest.java
@@ -138,5 +138,7 @@ public class KameletsCatalogTest {
         assertEquals(2, headersAzureSink.size());
         List<ComponentModel.EndpointHeaderModel> headersAzureFunctionsSink = catalog.getKameletSupportedHeaders("azure-functions-sink");
         assertEquals(8, headersAzureFunctionsSink.size());
+        List<ComponentModel.EndpointHeaderModel> headersAzureServicebusSource = catalog.getKameletSupportedHeaders("azure-servicebus-source");
+        assertEquals(22, headersAzureServicebusSource.size());
     }
 }

--- a/library/camel-kamelets-catalog/src/test/java/org/apache/camel/kamelets/catalog/KameletsCatalogTest.java
+++ b/library/camel-kamelets-catalog/src/test/java/org/apache/camel/kamelets/catalog/KameletsCatalogTest.java
@@ -140,5 +140,9 @@ public class KameletsCatalogTest {
         assertEquals(8, headersAzureFunctionsSink.size());
         List<ComponentModel.EndpointHeaderModel> headersAzureServicebusSource = catalog.getKameletSupportedHeaders("azure-servicebus-source");
         assertEquals(22, headersAzureServicebusSource.size());
+        List<ComponentModel.EndpointHeaderModel> headersAzureStorageBlobSource = catalog.getKameletSupportedHeaders("azure-storage-blob-source");
+        assertEquals(34, headersAzureStorageBlobSource.size());
+        List<ComponentModel.EndpointHeaderModel> headersAzureStorageBlobSink = catalog.getKameletSupportedHeaders("azure-storage-blob-sink");
+        assertEquals(32, headersAzureStorageBlobSink.size());
     }
 }

--- a/library/camel-kamelets-catalog/src/test/java/org/apache/camel/kamelets/catalog/KameletsCatalogTest.java
+++ b/library/camel-kamelets-catalog/src/test/java/org/apache/camel/kamelets/catalog/KameletsCatalogTest.java
@@ -144,5 +144,7 @@ public class KameletsCatalogTest {
         assertEquals(34, headersAzureStorageBlobSource.size());
         List<ComponentModel.EndpointHeaderModel> headersAzureStorageBlobSink = catalog.getKameletSupportedHeaders("azure-storage-blob-sink");
         assertEquals(32, headersAzureStorageBlobSink.size());
+        List<ComponentModel.EndpointHeaderModel> headersAzureStorageBlobChangeefeedSource = catalog.getKameletSupportedHeaders("azure-storage-blob-changefeed-source");
+        assertEquals(34, headersAzureStorageBlobChangeefeedSource.size());
     }
 }

--- a/library/camel-kamelets-catalog/src/test/java/org/apache/camel/kamelets/catalog/KameletsCatalogTest.java
+++ b/library/camel-kamelets-catalog/src/test/java/org/apache/camel/kamelets/catalog/KameletsCatalogTest.java
@@ -146,5 +146,9 @@ public class KameletsCatalogTest {
         assertEquals(32, headersAzureStorageBlobSink.size());
         List<ComponentModel.EndpointHeaderModel> headersAzureStorageBlobChangeefeedSource = catalog.getKameletSupportedHeaders("azure-storage-blob-changefeed-source");
         assertEquals(34, headersAzureStorageBlobChangeefeedSource.size());
+        List<ComponentModel.EndpointHeaderModel> headersAzureStorageQueueSource = catalog.getKameletSupportedHeaders("azure-storage-queue-source");
+        assertEquals(6, headersAzureStorageQueueSource.size());
+        List<ComponentModel.EndpointHeaderModel> headersAzureStorageQueueSink = catalog.getKameletSupportedHeaders("azure-storage-queue-sink");
+        assertEquals(16, headersAzureStorageQueueSink.size());
     }
 }


### PR DESCRIPTION
Part of #929 