### PR TITLE
Improve KAFKA SSL source

### DIFF
--- a/kamelets/kafka-ssl-source.kamelet.yaml
+++ b/kamelets/kafka-ssl-source.kamelet.yaml
@@ -34,8 +34,6 @@ spec:
     required:
       - topic
       - bootstrapServers
-      - sslKeystoreLocation
-      - sslKeystorePassword
       - sslTruststoreLocation
       - sslKeyPassword
     type: object
@@ -124,7 +122,6 @@ spec:
           - urn:alm:descriptor:com.tectonic.ui:password
           - urn:camel:group:credentials
           - urn:keda:authentication:password
-          - urn:keda:required
       sslProtocol:
         description: The SSL protocol used to generate the SSLContext. Default setting is TLS, which is fine for most cases. Allowed values in recent JVMs are TLS, TLSv1.1 and TLSv1.2. SSL, SSLv2 and SSLv3 may be supported in older JVMs, but their usage is discouraged due to known security vulnerabilities.
         title: SSL Protocol
@@ -159,11 +156,11 @@ spec:
           - key: securityProtocol
             value: '{{securityProtocol}}'
           - key: sslKeystoreLocation
-            value: '{{sslKeystoreLocation}}'
+            value: '{{?sslKeystoreLocation}}'
           - key: sslKeyPassword
             value: '{{sslKeyPassword}}'
           - key: sslKeystorePassword
-            value: '{{sslKeystorePassword}}'
+            value: '{{?sslKeystorePassword}}'
           - key: sslTruststoreLocation
             value: '{{sslTruststoreLocation}}'
           - key: sslProtocol

--- a/kamelets/kafka-ssl-source.kamelet.yaml
+++ b/kamelets/kafka-ssl-source.kamelet.yaml
@@ -140,6 +140,10 @@ spec:
         title: SSL Enabled Protocols
         type: string
         default: TLSv1.2,TLSv1.1,TLSv1
+      saslJaasConfig:
+        description: Java Authentication and Authorization Service (JAAS) for Simple Authentication and Security Layer (SASL) configuration.
+        title: JAAS Configuration
+        type: string
   dependencies:
     - "github:apache.camel-kamelets:camel-kamelets-utils:main-SNAPSHOT"
     - "camel:core"
@@ -179,6 +183,8 @@ spec:
             value: '{{allowManualCommit}}'
           - key: autoCommitEnable
             value: '{{autoCommitEnable}}'
+          - key: saslJaasConfig
+            value: '{{?saslJaasConfig}}'
         type: '#class:org.apache.camel.component.kafka.KafkaConfiguration'
       - name: kafkaHeaderDeserializer
         type: "#class:org.apache.camel.kamelets.utils.serialization.kafka.KafkaHeaderDeserializer"

--- a/library/camel-kamelets/src/main/resources/kamelets/kafka-ssl-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/kafka-ssl-source.kamelet.yaml
@@ -34,8 +34,6 @@ spec:
     required:
       - topic
       - bootstrapServers
-      - sslKeystoreLocation
-      - sslKeystorePassword
       - sslTruststoreLocation
       - sslKeyPassword
     type: object
@@ -124,7 +122,6 @@ spec:
           - urn:alm:descriptor:com.tectonic.ui:password
           - urn:camel:group:credentials
           - urn:keda:authentication:password
-          - urn:keda:required
       sslProtocol:
         description: The SSL protocol used to generate the SSLContext. Default setting is TLS, which is fine for most cases. Allowed values in recent JVMs are TLS, TLSv1.1 and TLSv1.2. SSL, SSLv2 and SSLv3 may be supported in older JVMs, but their usage is discouraged due to known security vulnerabilities.
         title: SSL Protocol
@@ -159,11 +156,11 @@ spec:
           - key: securityProtocol
             value: '{{securityProtocol}}'
           - key: sslKeystoreLocation
-            value: '{{sslKeystoreLocation}}'
+            value: '{{?sslKeystoreLocation}}'
           - key: sslKeyPassword
             value: '{{sslKeyPassword}}'
           - key: sslKeystorePassword
-            value: '{{sslKeystorePassword}}'
+            value: '{{?sslKeystorePassword}}'
           - key: sslTruststoreLocation
             value: '{{sslTruststoreLocation}}'
           - key: sslProtocol

--- a/library/camel-kamelets/src/main/resources/kamelets/kafka-ssl-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/kafka-ssl-source.kamelet.yaml
@@ -140,6 +140,10 @@ spec:
         title: SSL Enabled Protocols
         type: string
         default: TLSv1.2,TLSv1.1,TLSv1
+      saslJaasConfig:
+        description: Java Authentication and Authorization Service (JAAS) for Simple Authentication and Security Layer (SASL) configuration.
+        title: JAAS Configuration
+        type: string
   dependencies:
     - "github:apache.camel-kamelets:camel-kamelets-utils:main-SNAPSHOT"
     - "camel:core"
@@ -179,6 +183,8 @@ spec:
             value: '{{allowManualCommit}}'
           - key: autoCommitEnable
             value: '{{autoCommitEnable}}'
+          - key: saslJaasConfig
+            value: '{{?saslJaasConfig}}'
         type: '#class:org.apache.camel.component.kafka.KafkaConfiguration'
       - name: kafkaHeaderDeserializer
         type: "#class:org.apache.camel.kamelets.utils.serialization.kafka.KafkaHeaderDeserializer"


### PR DESCRIPTION
Make two-way authentication optional.
Add JAAS config as optional.

Fixes https://github.com/apache/camel-kamelets/issues/1085.