### PR TITLE
Added a Catalog Method showing the supported headers (specific for consumer, producer and common) for a Kamelet

### DIFF
--- a/library/camel-kamelets-catalog/src/main/java/org/apache/camel/kamelets/catalog/model/KameletPrefixSchemeEnum.java
+++ b/library/camel-kamelets-catalog/src/main/java/org/apache/camel/kamelets/catalog/model/KameletPrefixSchemeEnum.java
@@ -86,7 +86,9 @@ public enum KameletPrefixSchemeEnum {
     log("log", "log"),
     mail("mail", "imaps"),
     mariadb("mariadb", "sql"),
-    minio("minio", "minio");
+    minio("minio", "minio"),
+    mongodb_changes_stream("mongodb-changes-stream", "mongodb"),
+    mongodb("mongodb", "mongodb");
 
     public final String name;
     public final String scheme;

--- a/library/camel-kamelets-catalog/src/main/java/org/apache/camel/kamelets/catalog/model/KameletPrefixSchemeEnum.java
+++ b/library/camel-kamelets-catalog/src/main/java/org/apache/camel/kamelets/catalog/model/KameletPrefixSchemeEnum.java
@@ -85,7 +85,8 @@ public enum KameletPrefixSchemeEnum {
     kubernetes_pods("kubernetes-pods", "kubernetes-pods"),
     log("log", "log"),
     mail("mail", "imaps"),
-    mariadb("mariadb", "sql");
+    mariadb("mariadb", "sql"),
+    minio("minio", "minio");
 
     public final String name;
     public final String scheme;

--- a/library/camel-kamelets-catalog/src/test/java/org/apache/camel/kamelets/catalog/KameletsCatalogTest.java
+++ b/library/camel-kamelets-catalog/src/test/java/org/apache/camel/kamelets/catalog/KameletsCatalogTest.java
@@ -274,5 +274,11 @@ public class KameletsCatalogTest {
         assertEquals(14, headersMinioSource.size());
         List<ComponentModel.EndpointHeaderModel> headersMinioSink= catalog.getKameletSupportedHeaders("minio-sink");
         assertEquals(21, headersMinioSink.size());
+        List<ComponentModel.EndpointHeaderModel> headersMongodbChangesStreamSource= catalog.getKameletSupportedHeaders("mongodb-changes-stream-source");
+        assertEquals(3, headersMongodbChangesStreamSource.size());
+        List<ComponentModel.EndpointHeaderModel> headersMongoDbSink= catalog.getKameletSupportedHeaders("mongodb-sink");
+        assertEquals(12, headersMongoDbSink.size());
+        List<ComponentModel.EndpointHeaderModel> headersMongoDbSource= catalog.getKameletSupportedHeaders("mongodb-source");
+        assertEquals(3, headersMongoDbSource.size());
     }
 }

--- a/library/camel-kamelets-catalog/src/test/java/org/apache/camel/kamelets/catalog/KameletsCatalogTest.java
+++ b/library/camel-kamelets-catalog/src/test/java/org/apache/camel/kamelets/catalog/KameletsCatalogTest.java
@@ -270,5 +270,9 @@ public class KameletsCatalogTest {
         assertEquals(0, headersMariaDBSource.size());
         List<ComponentModel.EndpointHeaderModel> headersMariaDBSink= catalog.getKameletSupportedHeaders("mariadb-sink");
         assertEquals(8, headersMariaDBSink.size());
+        List<ComponentModel.EndpointHeaderModel> headersMinioSource= catalog.getKameletSupportedHeaders("minio-source");
+        assertEquals(14, headersMinioSource.size());
+        List<ComponentModel.EndpointHeaderModel> headersMinioSink= catalog.getKameletSupportedHeaders("minio-sink");
+        assertEquals(21, headersMinioSink.size());
     }
 }


### PR DESCRIPTION
Part of #929 