### PR TITLE
FTP / SFTP connectors missing setting for binary mode transfers 

### DIFF
--- a/kamelets/ftp-sink.kamelet.yaml
+++ b/kamelets/ftp-sink.kamelet.yaml
@@ -82,6 +82,13 @@ spec:
         description: How to behave in case of file already existent. There are 4 enums. Possible values are Override, Append, Fail, or Ignore.
         type: string
         default: Override
+      binary:
+        title: Binary
+        description: Specifies the file transfer mode, BINARY or ASCII. Default is ASCII (false).
+        type: boolean
+        default: false
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
   dependencies:
     - "camel:ftp"
     - "camel:core"
@@ -108,3 +115,4 @@ spec:
             password: "{{password}}"
             passiveMode: "{{passiveMode}}"
             fileExist: "{{fileExist}}"
+            binary: "{{binary}}"

--- a/kamelets/ftp-source.kamelet.yaml
+++ b/kamelets/ftp-source.kamelet.yaml
@@ -87,6 +87,13 @@ spec:
         default: true
         x-descriptors:
         - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+      binary:
+        title: Binary
+        description: Specifies the file transfer mode, BINARY or ASCII. Default is ASCII (false).
+        type: boolean
+        default: false
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
   dependencies:
     - "camel:ftp"
     - "camel:core"
@@ -99,6 +106,7 @@ spec:
         passiveMode: "{{passiveMode}}"
         recursive: "{{recursive}}"
         idempotent: "{{idempotent}}"
+        binary: "{{binary}}"
       steps:
       - set-header:
           name: file

--- a/kamelets/ftps-sink.kamelet.yaml
+++ b/kamelets/ftps-sink.kamelet.yaml
@@ -82,6 +82,13 @@ spec:
         description: "Specifies how the Kamelet behaves if the file already exists. Possible values are Override, Append, Fail, or Ignore."
         type: string
         default: Override
+      binary:
+        title: Binary
+        description: Specifies the file transfer mode, BINARY or ASCII. Default is ASCII (false).
+        type: boolean
+        default: false
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
   dependencies:
     - "camel:ftp"
     - "camel:core"
@@ -108,3 +115,4 @@ spec:
             password: "{{password}}"
             passiveMode: "{{passiveMode}}"
             fileExist: "{{fileExist}}"
+            binary: "{{binary}}"

--- a/kamelets/ftps-source.kamelet.yaml
+++ b/kamelets/ftps-source.kamelet.yaml
@@ -87,6 +87,13 @@ spec:
         default: true
         x-descriptors:
         - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+      binary:
+        title: Binary
+        description: Specifies the file transfer mode, BINARY or ASCII. Default is ASCII (false).
+        type: boolean
+        default: false
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
   dependencies:
     - "camel:ftp"
     - "camel:core"
@@ -99,6 +106,7 @@ spec:
         passiveMode: "{{passiveMode}}"
         recursive: "{{recursive}}"
         idempotent: "{{idempotent}}"
+        binary: "{{binary}}"
       steps:
       - set-header:
           name: file

--- a/kamelets/sftp-sink.kamelet.yaml
+++ b/kamelets/sftp-sink.kamelet.yaml
@@ -82,6 +82,13 @@ spec:
         description: How to behave in case of file already existent. There are 4 enums. Possible values are Override, Append, Fail, or Ignore.
         type: string
         default: Override
+      binary:
+        title: Binary
+        description: Specifies the file transfer mode, BINARY or ASCII. Default is ASCII (false).
+        type: boolean
+        default: false
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
   dependencies:
     - "camel:ftp"
     - "camel:core"
@@ -108,3 +115,4 @@ spec:
             password: "{{password}}"
             passiveMode: "{{passiveMode}}"
             fileExist: "{{fileExist}}"
+            binary: "{{binary}}"

--- a/kamelets/sftp-source.kamelet.yaml
+++ b/kamelets/sftp-source.kamelet.yaml
@@ -94,6 +94,13 @@ spec:
         default: false
         x-descriptors:
         - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+      binary:
+        title: Binary
+        description: Specifies the file transfer mode, BINARY or ASCII. Default is ASCII (false).
+        type: boolean
+        default: false
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
   dependencies:
     - "camel:ftp"
     - "camel:core"
@@ -107,6 +114,7 @@ spec:
         recursive: "{{recursive}}"
         idempotent: "{{idempotent}}"
         ignoreFileNotFoundOrPermissionError: "{{ignoreFileNotFoundOrPermissionError}}"
+        binary: "{{binary}}"
       steps:
       - set-header:
           name: file

--- a/library/camel-kamelets/src/main/resources/kamelets/ftp-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/ftp-sink.kamelet.yaml
@@ -82,6 +82,13 @@ spec:
         description: How to behave in case of file already existent. There are 4 enums. Possible values are Override, Append, Fail, or Ignore.
         type: string
         default: Override
+      binary:
+        title: Binary
+        description: Specifies the file transfer mode, BINARY or ASCII. Default is ASCII (false).
+        type: boolean
+        default: false
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
   dependencies:
     - "camel:ftp"
     - "camel:core"
@@ -108,3 +115,4 @@ spec:
             password: "{{password}}"
             passiveMode: "{{passiveMode}}"
             fileExist: "{{fileExist}}"
+            binary: "{{binary}}"

--- a/library/camel-kamelets/src/main/resources/kamelets/ftp-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/ftp-source.kamelet.yaml
@@ -87,6 +87,13 @@ spec:
         default: true
         x-descriptors:
         - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+      binary:
+        title: Binary
+        description: Specifies the file transfer mode, BINARY or ASCII. Default is ASCII (false).
+        type: boolean
+        default: false
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
   dependencies:
     - "camel:ftp"
     - "camel:core"
@@ -99,6 +106,7 @@ spec:
         passiveMode: "{{passiveMode}}"
         recursive: "{{recursive}}"
         idempotent: "{{idempotent}}"
+        binary: "{{binary}}"
       steps:
       - set-header:
           name: file

--- a/library/camel-kamelets/src/main/resources/kamelets/ftps-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/ftps-sink.kamelet.yaml
@@ -82,6 +82,13 @@ spec:
         description: "Specifies how the Kamelet behaves if the file already exists. Possible values are Override, Append, Fail, or Ignore."
         type: string
         default: Override
+      binary:
+        title: Binary
+        description: Specifies the file transfer mode, BINARY or ASCII. Default is ASCII (false).
+        type: boolean
+        default: false
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
   dependencies:
     - "camel:ftp"
     - "camel:core"
@@ -108,3 +115,4 @@ spec:
             password: "{{password}}"
             passiveMode: "{{passiveMode}}"
             fileExist: "{{fileExist}}"
+            binary: "{{binary}}"

--- a/library/camel-kamelets/src/main/resources/kamelets/ftps-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/ftps-source.kamelet.yaml
@@ -87,6 +87,13 @@ spec:
         default: true
         x-descriptors:
         - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+      binary:
+        title: Binary
+        description: Specifies the file transfer mode, BINARY or ASCII. Default is ASCII (false).
+        type: boolean
+        default: false
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
   dependencies:
     - "camel:ftp"
     - "camel:core"
@@ -99,6 +106,7 @@ spec:
         passiveMode: "{{passiveMode}}"
         recursive: "{{recursive}}"
         idempotent: "{{idempotent}}"
+        binary: "{{binary}}"
       steps:
       - set-header:
           name: file

--- a/library/camel-kamelets/src/main/resources/kamelets/sftp-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/sftp-sink.kamelet.yaml
@@ -82,6 +82,13 @@ spec:
         description: How to behave in case of file already existent. There are 4 enums. Possible values are Override, Append, Fail, or Ignore.
         type: string
         default: Override
+      binary:
+        title: Binary
+        description: Specifies the file transfer mode, BINARY or ASCII. Default is ASCII (false).
+        type: boolean
+        default: false
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
   dependencies:
     - "camel:ftp"
     - "camel:core"
@@ -108,3 +115,4 @@ spec:
             password: "{{password}}"
             passiveMode: "{{passiveMode}}"
             fileExist: "{{fileExist}}"
+            binary: "{{binary}}"

--- a/library/camel-kamelets/src/main/resources/kamelets/sftp-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/sftp-source.kamelet.yaml
@@ -94,6 +94,13 @@ spec:
         default: false
         x-descriptors:
         - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+      binary:
+        title: Binary
+        description: Specifies the file transfer mode, BINARY or ASCII. Default is ASCII (false).
+        type: boolean
+        default: false
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
   dependencies:
     - "camel:ftp"
     - "camel:core"
@@ -107,6 +114,7 @@ spec:
         recursive: "{{recursive}}"
         idempotent: "{{idempotent}}"
         ignoreFileNotFoundOrPermissionError: "{{ignoreFileNotFoundOrPermissionError}}"
+        binary: "{{binary}}"
       steps:
       - set-header:
           name: file


### PR DESCRIPTION
Fixes #1156 for 0.9.x

FTP/FTPS and SFTP