### PR TITLE
Fix mail-sink Kamelet

### DIFF
--- a/kamelets/mail-sink.kamelet.yaml
+++ b/kamelets/mail-sink.kamelet.yaml
@@ -36,11 +36,6 @@ spec:
       - password
     type: object
     properties:
-      protocol:
-        description: The mail protocol to use
-        default: smtp
-        title: Protocol
-        type: string
       connectionHost:
         description: The mail server host
         example: smtp.gmail.com
@@ -115,4 +110,12 @@ spec:
                     simple: "${header[ce-cc]}"
         - remove-headers:
             pattern: "ce-*"
-        - to: '{{protocol}}://{{connectionHost}}:{{connectionPort}}?subject={{subject}}&from={{from}}&to={{to}}&username={{username}}&password={{password}}'
+        - to:
+            uri: "smtp:{{connectionHost}}:{{connectionPort}}"
+            parameters:
+              subject: "{{subject}}"
+              from: "{{from}}"
+              to: "{{to}}"
+              username: "{{username}}"
+              password: "{{password}}"
+

--- a/library/camel-kamelets/src/main/resources/kamelets/mail-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/mail-sink.kamelet.yaml
@@ -36,11 +36,6 @@ spec:
       - password
     type: object
     properties:
-      protocol:
-        description: The mail protocol to use
-        default: smtp
-        title: Protocol
-        type: string
       connectionHost:
         description: The mail server host
         example: smtp.gmail.com
@@ -115,4 +110,12 @@ spec:
                     simple: "${header[ce-cc]}"
         - remove-headers:
             pattern: "ce-*"
-        - to: '{{protocol}}://{{connectionHost}}:{{connectionPort}}?subject={{subject}}&from={{from}}&to={{to}}&username={{username}}&password={{password}}'
+        - to:
+            uri: "smtp:{{connectionHost}}:{{connectionPort}}"
+            parameters:
+              subject: "{{subject}}"
+              from: "{{from}}"
+              to: "{{to}}"
+              username: "{{username}}"
+              password: "{{password}}"
+

--- a/test/mail-sink/mail-sink.feature
+++ b/test/mail-sink/mail-sink.feature
@@ -28,15 +28,16 @@ Feature: Mail Sink
       | message   | Camel K rocks |
 
   Scenario: Create mail server
-    Given load endpoint mail-server.groovy
+    Given HTTP server "mail-server"
+    Given HTTP server listening on port 22222
     Given create Kubernetes service mail-server with port mapping 25:22222
+    And stop HTTP server
+    Given load endpoint mail-server.groovy
 
   Scenario: Create Camel K resources
     Given Camel K resource polling configuration
       | maxAttempts          | 200   |
       | delayBetweenAttempts | 2000  |
-    Given Kamelet mail-sink is available
-    Given Kamelet timer-source is available
     Given load KameletBinding timer-to-mail.yaml
     And Camel K integration timer-to-mail should be running
     And Camel K integration timer-to-mail should print Routes startup


### PR DESCRIPTION
- In fact mail-sink only supports smtp protocol. Others like pop3 and imap do not make sense for sending mails
- SMTPS protocol is also not supported because SSL context is missing
- to:{{protocol}} stopped working with latest versions so remove protocol property and always use "smtp"
- Also fix YAKS test