### PR TITLE
chore: Fix flaky AWS DDB sink YAKS tests

### DIFF
--- a/test/aws-ddb-sink/aws-ddb-sink-deleteItem.feature
+++ b/test/aws-ddb-sink/aws-ddb-sink-deleteItem.feature
@@ -43,20 +43,21 @@ Feature: AWS DDB Sink - DeleteItem
   Scenario: Create item on AWS-DDB
     Given run script putItem.groovy
     Given variables
+      | maxRetryAttempts  | 20 |
       | aws.ddb.items     | [{year=AttributeValue(N=${aws.ddb.item.year}), id=AttributeValue(N=${aws.ddb.item.id}), title=AttributeValue(S=${aws.ddb.item.title})}] |
-    Then run script verifyItems.groovy
+    Then apply actions verifyItems.groovy
 
   Scenario: Create AWS-DDB Kamelet sink binding
     When load KameletBinding aws-ddb-sink-binding.yaml
     And KameletBinding aws-ddb-sink-binding is available
     And Camel K integration aws-ddb-sink-binding is running
     And Camel K integration aws-ddb-sink-binding should print Routes startup
-    Then sleep 10sec
 
   Scenario: Verify Kamelet sink
     Given variables
+      | maxRetryAttempts  | 20 |
       | aws.ddb.items     | [] |
-    Then run script verifyItems.groovy
+    Then apply actions verifyItems.groovy
 
   Scenario: Remove Camel K resources
     Given delete KameletBinding aws-ddb-sink-binding

--- a/test/aws-ddb-sink/aws-ddb-sink-putItem.feature
+++ b/test/aws-ddb-sink/aws-ddb-sink-putItem.feature
@@ -30,7 +30,6 @@ Feature: AWS DDB Sink - PutItem
       | aws.ddb.item.year    | 1977 |
       | aws.ddb.item.title   | Star Wars IV |
       | aws.ddb.json.data    | { "id":${aws.ddb.item.id}, "year":${aws.ddb.item.year}, "title":"${aws.ddb.item.title}" } |
-      | aws.ddb.items        | [{year=AttributeValue(N=${aws.ddb.item.year}), id=AttributeValue(N=${aws.ddb.item.id}), title=AttributeValue(S=${aws.ddb.item.title})}] |
 
   Scenario: Start LocalStack container
     Given Enable service DYNAMODB
@@ -46,10 +45,12 @@ Feature: AWS DDB Sink - PutItem
     And KameletBinding aws-ddb-sink-binding is available
     And Camel K integration aws-ddb-sink-binding is running
     And Camel K integration aws-ddb-sink-binding should print Routes startup
-    Then sleep 10sec
 
   Scenario: Verify Kamelet sink
-    Then run script verifyItems.groovy
+    Given variables
+      | maxRetryAttempts  | 20 |
+      | aws.ddb.items     | [{year=AttributeValue(N=${aws.ddb.item.year}), id=AttributeValue(N=${aws.ddb.item.id}), title=AttributeValue(S=${aws.ddb.item.title})}] |
+    Then apply actions verifyItems.groovy
 
   Scenario: Remove Camel K resources
     Given delete KameletBinding aws-ddb-sink-binding

--- a/test/aws-ddb-sink/aws-ddb-sink-updateItem.feature
+++ b/test/aws-ddb-sink/aws-ddb-sink-updateItem.feature
@@ -45,21 +45,22 @@ Feature: AWS DDB Sink - UpdateItem
   Scenario: Create item on AWS-DDB
     Given run script putItem.groovy
     Given variables
+      | maxRetryAttempts  | 20 |
       | aws.ddb.items | [{year=AttributeValue(N=${aws.ddb.item.year}), id=AttributeValue(N=${aws.ddb.item.id}), title=AttributeValue(S=${aws.ddb.item.title})}] |
-    Then run script verifyItems.groovy
+    Then apply actions verifyItems.groovy
 
   Scenario: Create AWS-DDB Kamelet sink binding
     When load KameletBinding aws-ddb-sink-binding.yaml
     And KameletBinding aws-ddb-sink-binding is available
     And Camel K integration aws-ddb-sink-binding is running
     And Camel K integration aws-ddb-sink-binding should print Routes startup
-    Then sleep 10sec
 
   Scenario: Verify Kamelet sink
     Given variables
+      | maxRetryAttempts  | 200 |
       | aws.ddb.item.directors | [Ernest B. Schoedsack, Merian C. Cooper] |
       | aws.ddb.items | [{year=AttributeValue(N=${aws.ddb.item.year}), directors=AttributeValue(SS=${aws.ddb.item.directors}), id=AttributeValue(N=${aws.ddb.item.id}), title=AttributeValue(S=${aws.ddb.item.title.new})}] |
-    Then run script verifyItems.groovy
+    Then apply actions verifyItems.groovy
 
   Scenario: Remove Camel K resources
     Given delete KameletBinding aws-ddb-sink-binding

--- a/test/aws-ddb-sink/verifyItems.groovy
+++ b/test/aws-ddb-sink/verifyItems.groovy
@@ -15,4 +15,19 @@
  * limitations under the License.
  */
 
-assert "${aws.ddb.items}".equals(amazonDDBClient.scan(b -> b.tableName("${aws.ddb.tableName}"))?.items()?.toString())
+$actions {
+    $(repeatOnError()
+        .until('i > ${maxRetryAttempts}')
+        .actions(new com.consol.citrus.TestAction() {
+            @Override
+            void execute(com.consol.citrus.context.TestContext context) {
+                try {
+                    assert context.getVariable('aws.ddb.items')
+                            .equals(amazonDDBClient.scan(b -> b.tableName(context.getVariable('aws.ddb.tableName')))?.items()?.toString())
+                } catch (AssertionError e) {
+                    throw new com.consol.citrus.exceptions.CitrusRuntimeException("AWS DDB item verification failed", e)
+                }
+            }
+        })
+    )
+}

--- a/test/experimental/aws-ddb-sink-exp/aws-ddb-sink-deleteItem.feature
+++ b/test/experimental/aws-ddb-sink-exp/aws-ddb-sink-deleteItem.feature
@@ -43,20 +43,21 @@ Feature: AWS DDB Sink - DeleteItem
   Scenario: Create item on AWS-DDB
     Given run script putItem.groovy
     Given variables
+      | maxRetryAttempts  | 20 |
       | aws.ddb.items     | [{year=AttributeValue(N=${aws.ddb.item.year}), id=AttributeValue(N=${aws.ddb.item.id}), title=AttributeValue(S=${aws.ddb.item.title})}] |
-    Then run script verifyItems.groovy
+    Then apply actions verifyItems.groovy
 
   Scenario: Create AWS-DDB Kamelet sink binding
     When load KameletBinding aws-ddb-sink-binding.yaml
     And KameletBinding aws-ddb-experimental-sink-binding is available
     And Camel K integration aws-ddb-experimental-sink-binding is running
     And Camel K integration aws-ddb-experimental-sink-binding should print Routes startup
-    Then sleep 10sec
 
   Scenario: Verify Kamelet sink
     Given variables
+      | maxRetryAttempts  | 20 |
       | aws.ddb.items     | [] |
-    Then run script verifyItems.groovy
+    Then apply actions verifyItems.groovy
 
   Scenario: Remove Camel K resources
     Given delete KameletBinding aws-ddb-experimental-sink-binding

--- a/test/experimental/aws-ddb-sink-exp/aws-ddb-sink-putItem.feature
+++ b/test/experimental/aws-ddb-sink-exp/aws-ddb-sink-putItem.feature
@@ -30,7 +30,6 @@ Feature: AWS DDB Sink - PutItem
       | aws.ddb.item.year    | 1977 |
       | aws.ddb.item.title   | Star Wars IV |
       | aws.ddb.json.data    | { "id":${aws.ddb.item.id}, "year":${aws.ddb.item.year}, "title":"${aws.ddb.item.title}" } |
-      | aws.ddb.items        | [{year=AttributeValue(N=${aws.ddb.item.year}), id=AttributeValue(N=${aws.ddb.item.id}), title=AttributeValue(S=${aws.ddb.item.title})}] |
 
   Scenario: Start LocalStack container
     Given Enable service DYNAMODB
@@ -46,10 +45,12 @@ Feature: AWS DDB Sink - PutItem
     And KameletBinding aws-ddb-experimental-sink-binding is available
     And Camel K integration aws-ddb-experimental-sink-binding is running
     And Camel K integration aws-ddb-experimental-sink-binding should print Routes startup
-    Then sleep 10sec
 
   Scenario: Verify Kamelet sink
-    Then run script verifyItems.groovy
+    Given variables
+      | maxRetryAttempts  | 20 |
+      | aws.ddb.items     | [{year=AttributeValue(N=${aws.ddb.item.year}), id=AttributeValue(N=${aws.ddb.item.id}), title=AttributeValue(S=${aws.ddb.item.title})}] |
+    Then apply actions verifyItems.groovy
 
   Scenario: Remove Camel K resources
     Given delete KameletBinding aws-ddb-experimental-sink-binding

--- a/test/experimental/aws-ddb-sink-exp/aws-ddb-sink-updateItem.feature
+++ b/test/experimental/aws-ddb-sink-exp/aws-ddb-sink-updateItem.feature
@@ -45,21 +45,22 @@ Feature: AWS DDB Sink - UpdateItem
   Scenario: Create item on AWS-DDB
     Given run script putItem.groovy
     Given variables
+      | maxRetryAttempts  | 20 |
       | aws.ddb.items | [{year=AttributeValue(N=${aws.ddb.item.year}), id=AttributeValue(N=${aws.ddb.item.id}), title=AttributeValue(S=${aws.ddb.item.title})}] |
-    Then run script verifyItems.groovy
+    Then apply actions verifyItems.groovy
 
   Scenario: Create AWS-DDB Kamelet sink binding
     When load KameletBinding aws-ddb-sink-binding.yaml
     And KameletBinding aws-ddb-experimental-sink-binding is available
     And Camel K integration aws-ddb-experimental-sink-binding is running
     And Camel K integration aws-ddb-experimental-sink-binding should print Routes startup
-    Then sleep 10sec
 
   Scenario: Verify Kamelet sink
     Given variables
+      | maxRetryAttempts  | 200 |
       | aws.ddb.item.directors | [Ernest B. Schoedsack, Merian C. Cooper] |
       | aws.ddb.items | [{year=AttributeValue(N=${aws.ddb.item.year}), directors=AttributeValue(SS=${aws.ddb.item.directors}), id=AttributeValue(N=${aws.ddb.item.id}), title=AttributeValue(S=${aws.ddb.item.title.new})}] |
-    Then run script verifyItems.groovy
+    Then apply actions verifyItems.groovy
 
   Scenario: Remove Camel K resources
     Given delete KameletBinding aws-ddb-experimental-sink-binding

--- a/test/experimental/aws-ddb-sink-exp/verifyItems.groovy
+++ b/test/experimental/aws-ddb-sink-exp/verifyItems.groovy
@@ -15,4 +15,19 @@
  * limitations under the License.
  */
 
-assert "${aws.ddb.items}".equals(amazonDDBClient.scan(b -> b.tableName("${aws.ddb.tableName}"))?.items()?.toString())
+$actions {
+    $(repeatOnError()
+        .until('i > ${maxRetryAttempts}')
+        .actions(new com.consol.citrus.TestAction() {
+            @Override
+            void execute(com.consol.citrus.context.TestContext context) {
+                try {
+                    assert context.getVariable('aws.ddb.items')
+                            .equals(amazonDDBClient.scan(b -> b.tableName(context.getVariable('aws.ddb.tableName')))?.items()?.toString())
+                } catch (AssertionError e) {
+                    throw new com.consol.citrus.exceptions.CitrusRuntimeException("AWS DDB item verification failed", e)
+                }
+            }
+        })
+    )
+}


### PR DESCRIPTION
- Use repeatOnError with maxRetryAttempts instead of static sleep 10sec
- Should give GitHub CI job more time to verify AWS DDB items without increasing the total test execution time