### PR TITLE
Issue-981: Improve narrative for chatId.

### DIFF
--- a/kamelets/telegram-sink.kamelet.yaml
+++ b/kamelets/telegram-sink.kamelet.yaml
@@ -47,6 +47,7 @@ spec:
       - `chat-id` / `ce-chatid`: overrides the default chat where messages are sent to
     required:
       - authorizationToken
+      - chatId
     type: object
     properties:
       authorizationToken:
@@ -59,7 +60,7 @@ spec:
         - urn:camel:group:credentials
       chatId:
         title: Chat ID
-        description: The Chat ID to where you want to send messages by default.
+        description: The Chat ID to where you want to send messages by default. Optional if the `chat-id` / `ce-chatid` header is used.
         type: string
   types:
     out:


### PR DESCRIPTION
See https://github.com/apache/camel-kamelets/issues/981

The consensus was that the documentation wasn't entirely clear as to whether `chatId` was mandatory or not.

It _is_ mandatory but not necessarily as a [Configuration Option](https://camel.apache.org/camel-kamelets/3.20.x/telegram-sink.html#_configuration_options) if provided in the header.