### PR TITLE
Issue-981: Restore optional usage of chatId Configuration Option and correct narrative

### DIFF
--- a/kamelets/telegram-sink.kamelet.yaml
+++ b/kamelets/telegram-sink.kamelet.yaml
@@ -47,7 +47,6 @@ spec:
       - `chat-id` / `ce-chatid`: overrides the default chat where messages are sent to
     required:
       - authorizationToken
-      - chatId
     type: object
     properties:
       authorizationToken:
@@ -60,7 +59,10 @@ spec:
         - urn:camel:group:credentials
       chatId:
         title: Chat ID
-        description: The Chat ID to where you want to send messages by default. Optional if the `chat-id` / `ce-chatid` header is used.
+        description: |-
+          The Chat ID to where you want to send messages by default. 
+          
+          Whilst the Chat ID is not a required Configuration Option it must be provided for every message; either as a Configuration Option or a `chat-id` / `ce-chatid` header.
         type: string
   types:
     out:

--- a/library/camel-kamelets/src/main/resources/kamelets/telegram-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/telegram-sink.kamelet.yaml
@@ -47,7 +47,6 @@ spec:
       - `chat-id` / `ce-chatid`: overrides the default chat where messages are sent to
     required:
       - authorizationToken
-      - chatId
     type: object
     properties:
       authorizationToken:
@@ -60,7 +59,10 @@ spec:
         - urn:camel:group:credentials
       chatId:
         title: Chat ID
-        description: The Chat ID to where you want to send messages by default. Optional if the `chat-id` / `ce-chatid` header is used.
+        description: |-
+          The Chat ID to where you want to send messages by default. 
+          
+          Whilst the Chat ID is not a required Configuration Option it must be provided for every message; either as a Configuration Option or a `chat-id` / `ce-chatid` header.
         type: string
   types:
     out:


### PR DESCRIPTION
Following discussions with @valdar it was felt that including a default value and improving the documentation was the best approach. Keeping the parameter as `required` forces Users to explicitly consider how/where to set the value. Reverting optional behaviour can lead to implicit failures that can be more difficult to diagnose.

@valdar @oscerd WDYT?