### PR TITLE
chore: Remove Jitpack

### DIFF
--- a/.github/workflows/yaks-tests.yaml
+++ b/.github/workflows/yaks-tests.yaml
@@ -58,18 +58,6 @@ jobs:
         distribution: 'temurin'
         java-version: 17
         cache: 'maven'
-    - name: Set JitPack coordinates for pull requests
-      if: github.event_name == 'pull_request'
-      env:
-        HEAD_REF: ${{ github.head_ref }}
-        HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
-      run: |
-        echo "Set JitPack dependency coordinates to ${HEAD_REPO/\//.}:camel-kamelets-utils:${HEAD_REF//\//'~'}-SNAPSHOT"
-
-        export PROJECT_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
-        
-        # Overwrite JitPack coordinates in the local Kamelets so the tests can use the utility classes in this PR
-        find kamelets -maxdepth 1 -name '*.kamelet.yaml' -exec sed -i "s/github:apache.camel-kamelets:camel-kamelets-utils:${PROJECT_VERSION}/github:${HEAD_REPO/\//.}:camel-kamelets-utils:${HEAD_REF//\//'~'}-SNAPSHOT/g" {} +
     - name: Get YAKS CLI
       run: |
         curl --fail -L --silent https://github.com/citrusframework/yaks/releases/download/v${YAKS_VERSION}/yaks-${YAKS_VERSION}-linux-64bit.tar.gz -o yaks.tar.gz

--- a/kamelets/avro-deserialize-action.kamelet.yaml
+++ b/kamelets/avro-deserialize-action.kamelet.yaml
@@ -49,7 +49,7 @@ spec:
         x-descriptors:
         - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
   dependencies:
-  - "github:apache.camel-kamelets:camel-kamelets-utils:4.0.0-SNAPSHOT"
+  - "mvn:org.apache.camel.kamelets:camel-kamelets-utils:4.0.0-SNAPSHOT"
   - "camel:kamelet"
   - "camel:core"
   - "camel:jackson-avro"

--- a/kamelets/avro-serialize-action.kamelet.yaml
+++ b/kamelets/avro-serialize-action.kamelet.yaml
@@ -49,7 +49,7 @@ spec:
         x-descriptors:
         - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
   dependencies:
-  - "github:apache.camel-kamelets:camel-kamelets-utils:4.0.0-SNAPSHOT"
+  - "mvn:org.apache.camel.kamelets:camel-kamelets-utils:4.0.0-SNAPSHOT"
   - "camel:kamelet"
   - "camel:core"
   - "camel:jackson-avro"

--- a/kamelets/aws-ddb-experimental-sink.kamelet.yaml
+++ b/kamelets/aws-ddb-experimental-sink.kamelet.yaml
@@ -110,7 +110,7 @@ spec:
     in:
       mediaType: application/json
   dependencies:
-  - github:apache.camel-kamelets:camel-kamelets-utils:4.0.0-SNAPSHOT
+  - mvn:org.apache.camel.kamelets:camel-kamelets-utils:4.0.0-SNAPSHOT
   - "camel:core"
   - "camel:jackson"
   - "camel:aws2-ddb"

--- a/kamelets/aws-ddb-sink.kamelet.yaml
+++ b/kamelets/aws-ddb-sink.kamelet.yaml
@@ -102,7 +102,7 @@ spec:
     in:
       mediaType: application/json
   dependencies:
-  - github:apache.camel-kamelets:camel-kamelets-utils:4.0.0-SNAPSHOT
+  - mvn:org.apache.camel.kamelets:camel-kamelets-utils:4.0.0-SNAPSHOT
   - "camel:core"
   - "camel:jackson"
   - "camel:aws2-ddb"

--- a/kamelets/aws-kinesis-source.kamelet.yaml
+++ b/kamelets/aws-kinesis-source.kamelet.yaml
@@ -99,7 +99,7 @@ spec:
     - "camel:aws2-kinesis"
     - "camel:kamelet"
     - "camel:core"
-    - "github:apache.camel-kamelets:camel-kamelets-utils:4.0.0-SNAPSHOT"
+    - "mvn:org.apache.camel.kamelets:camel-kamelets-utils:4.0.0-SNAPSHOT"
   template:
     beans:
       - name: duplicateHeaders

--- a/kamelets/aws-s3-experimental-source.kamelet.yaml
+++ b/kamelets/aws-s3-experimental-source.kamelet.yaml
@@ -119,7 +119,7 @@ spec:
   dependencies:
     - "camel:core"
     - "camel:aws2-s3"
-    - "github:apache.camel-kamelets:camel-kamelets-utils:4.0.0-SNAPSHOT"
+    - "mvn:org.apache.camel.kamelets:camel-kamelets-utils:4.0.0-SNAPSHOT"
     - "camel:kamelet"
   template:
     beans:

--- a/kamelets/aws-s3-source.kamelet.yaml
+++ b/kamelets/aws-s3-source.kamelet.yaml
@@ -111,7 +111,7 @@ spec:
   dependencies:
     - "camel:core"
     - "camel:aws2-s3"
-    - "github:apache.camel-kamelets:camel-kamelets-utils:4.0.0-SNAPSHOT"
+    - "mvn:org.apache.camel.kamelets:camel-kamelets-utils:4.0.0-SNAPSHOT"
     - "camel:kamelet"
   template:
     beans:

--- a/kamelets/aws-sqs-source.kamelet.yaml
+++ b/kamelets/aws-sqs-source.kamelet.yaml
@@ -142,7 +142,7 @@ spec:
   dependencies:
     - "camel:core"
     - "camel:aws2-sqs"
-    - "github:apache.camel-kamelets:camel-kamelets-utils:4.0.0-SNAPSHOT"
+    - "mvn:org.apache.camel.kamelets:camel-kamelets-utils:4.0.0-SNAPSHOT"
     - "camel:kamelet"
   template:
     beans:

--- a/kamelets/azure-storage-blob-source.kamelet.yaml
+++ b/kamelets/azure-storage-blob-source.kamelet.yaml
@@ -83,7 +83,7 @@ spec:
     - "camel:core"
     - "camel:jsonpath"
     - "camel:timer"
-    - "github:apache.camel-kamelets:camel-kamelets-utils:4.0.0-SNAPSHOT"
+    - "mvn:org.apache.camel.kamelets:camel-kamelets-utils:4.0.0-SNAPSHOT"
   template:
     beans:
       - name: duplicateHeaders

--- a/kamelets/azure-storage-queue-source.kamelet.yaml
+++ b/kamelets/azure-storage-queue-source.kamelet.yaml
@@ -67,7 +67,7 @@ spec:
   dependencies:
     - "camel:azure-storage-queue"
     - "camel:kamelet"
-    - "github:apache.camel-kamelets:camel-kamelets-utils:4.0.0-SNAPSHOT"
+    - "mvn:org.apache.camel.kamelets:camel-kamelets-utils:4.0.0-SNAPSHOT"
     - "camel:core"
   template:
     beans:

--- a/kamelets/extract-field-action.kamelet.yaml
+++ b/kamelets/extract-field-action.kamelet.yaml
@@ -73,7 +73,7 @@ spec:
         - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
     type: object
   dependencies:
-  - "github:apache.camel-kamelets:camel-kamelets-utils:4.0.0-SNAPSHOT"
+  - "mvn:org.apache.camel.kamelets:camel-kamelets-utils:4.0.0-SNAPSHOT"
   - "camel:kamelet"
   - "camel:core"
   - "camel:jackson"

--- a/kamelets/hoist-field-action.kamelet.yaml
+++ b/kamelets/hoist-field-action.kamelet.yaml
@@ -40,7 +40,7 @@ spec:
         type: string
     type: object
   dependencies:
-  - github:apache.camel-kamelets:camel-kamelets-utils:4.0.0-SNAPSHOT
+  - mvn:org.apache.camel.kamelets:camel-kamelets-utils:4.0.0-SNAPSHOT
   - "camel:core"
   - "camel:jackson"
   - "camel:kamelet"

--- a/kamelets/insert-field-action.kamelet.yaml
+++ b/kamelets/insert-field-action.kamelet.yaml
@@ -50,7 +50,7 @@ spec:
         type: string
     type: object
   dependencies:
-  - "github:apache.camel-kamelets:camel-kamelets-utils:4.0.0-SNAPSHOT"
+  - "mvn:org.apache.camel.kamelets:camel-kamelets-utils:4.0.0-SNAPSHOT"
   - "camel:core"
   - "camel:jackson"
   - "camel:kamelet"

--- a/kamelets/json-deserialize-action.kamelet.yaml
+++ b/kamelets/json-deserialize-action.kamelet.yaml
@@ -33,7 +33,7 @@ spec:
     description: "Deserialize payload to JSON"
     type: object
   dependencies:
-  - "github:apache.camel-kamelets:camel-kamelets-utils:4.0.0-SNAPSHOT"
+  - "mvn:org.apache.camel.kamelets:camel-kamelets-utils:4.0.0-SNAPSHOT"
   - "camel:kamelet"
   - "camel:core"
   - "camel:jackson"

--- a/kamelets/json-serialize-action.kamelet.yaml
+++ b/kamelets/json-serialize-action.kamelet.yaml
@@ -33,7 +33,7 @@ spec:
     description: "Serialize payload to JSON"
     type: object
   dependencies:
-  - "github:apache.camel-kamelets:camel-kamelets-utils:4.0.0-SNAPSHOT"
+  - "mvn:org.apache.camel.kamelets:camel-kamelets-utils:4.0.0-SNAPSHOT"
   - "camel:kamelet"
   - "camel:core"
   - "camel:jackson"

--- a/kamelets/kafka-manual-commit-action.kamelet.yaml
+++ b/kamelets/kafka-manual-commit-action.kamelet.yaml
@@ -33,7 +33,7 @@ spec:
     description: "Manually commit Kafka Offset"
     type: object
   dependencies:
-  - "github:apache.camel-kamelets:camel-kamelets-utils:4.0.0-SNAPSHOT"
+  - "mvn:org.apache.camel.kamelets:camel-kamelets-utils:4.0.0-SNAPSHOT"
   - "camel:kamelet"
   template:
     from:

--- a/kamelets/kafka-not-secured-sink.kamelet.yaml
+++ b/kamelets/kafka-not-secured-sink.kamelet.yaml
@@ -58,7 +58,7 @@ spec:
   dependencies:
     - "camel:core"
     - "camel:kafka"
-    - "github:apache.camel-kamelets:camel-kamelets-utils:4.0.0-SNAPSHOT"
+    - "mvn:org.apache.camel.kamelets:camel-kamelets-utils:4.0.0-SNAPSHOT"
     - "camel:kamelet"
   template:
     beans:

--- a/kamelets/kafka-not-secured-source.kamelet.yaml
+++ b/kamelets/kafka-not-secured-source.kamelet.yaml
@@ -94,7 +94,7 @@ spec:
           - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
   dependencies:
-    - "github:apache.camel-kamelets:camel-kamelets-utils:4.0.0-SNAPSHOT"
+    - "mvn:org.apache.camel.kamelets:camel-kamelets-utils:4.0.0-SNAPSHOT"
     - "camel:kafka"
     - "camel:core"
     - "camel:kamelet"

--- a/kamelets/kafka-scram-source.kamelet.yaml
+++ b/kamelets/kafka-scram-source.kamelet.yaml
@@ -126,7 +126,7 @@ spec:
           - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
   dependencies:
-    - "github:apache.camel-kamelets:camel-kamelets-utils:4.0.0-SNAPSHOT"
+    - "mvn:org.apache.camel.kamelets:camel-kamelets-utils:4.0.0-SNAPSHOT"
     - "camel:core"
     - "camel:kafka"
     - "camel:kamelet"

--- a/kamelets/kafka-source.kamelet.yaml
+++ b/kamelets/kafka-source.kamelet.yaml
@@ -126,7 +126,7 @@ spec:
           - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
   dependencies:
-    - "github:apache.camel-kamelets:camel-kamelets-utils:4.0.0-SNAPSHOT"
+    - "mvn:org.apache.camel.kamelets:camel-kamelets-utils:4.0.0-SNAPSHOT"
     - "camel:core"
     - "camel:kafka"
     - "camel:kamelet"

--- a/kamelets/kafka-ssl-source.kamelet.yaml
+++ b/kamelets/kafka-ssl-source.kamelet.yaml
@@ -146,7 +146,7 @@ spec:
         title: JAAS Configuration
         type: string
   dependencies:
-    - "github:apache.camel-kamelets:camel-kamelets-utils:4.0.0-SNAPSHOT"
+    - "mvn:org.apache.camel.kamelets:camel-kamelets-utils:4.0.0-SNAPSHOT"
     - "camel:core"
     - "camel:kafka"
     - "camel:kamelet"

--- a/kamelets/mask-field-action.kamelet.yaml
+++ b/kamelets/mask-field-action.kamelet.yaml
@@ -45,7 +45,7 @@ spec:
         type: string
     type: object
   dependencies:
-  - "github:apache.camel-kamelets:camel-kamelets-utils:4.0.0-SNAPSHOT"
+  - "mvn:org.apache.camel.kamelets:camel-kamelets-utils:4.0.0-SNAPSHOT"
   - "camel:jackson"
   - "camel:kamelet"
   - "camel:core"

--- a/kamelets/message-timestamp-router-action.kamelet.yaml
+++ b/kamelets/message-timestamp-router-action.kamelet.yaml
@@ -55,7 +55,7 @@ spec:
         default: "timestamp"
     type: object
   dependencies:
-  - "github:apache.camel-kamelets:camel-kamelets-utils:4.0.0-SNAPSHOT"
+  - "mvn:org.apache.camel.kamelets:camel-kamelets-utils:4.0.0-SNAPSHOT"
   - "camel:jackson"
   - "camel:kamelet"
   - "camel:core"

--- a/kamelets/openai-classification-action.kamelet.yaml
+++ b/kamelets/openai-classification-action.kamelet.yaml
@@ -75,7 +75,7 @@ spec:
     out:
       mediaType: text/plain
   dependencies:
-  - "github:apache.camel-kamelets:camel-kamelets-utils:4.0.0-SNAPSHOT"
+  - "mvn:org.apache.camel.kamelets:camel-kamelets-utils:4.0.0-SNAPSHOT"
   - "camel:jackson"
   - "camel:jsonpath"
   - "camel:core"

--- a/kamelets/protobuf-deserialize-action.kamelet.yaml
+++ b/kamelets/protobuf-deserialize-action.kamelet.yaml
@@ -41,7 +41,7 @@ spec:
         type: string
         example: 'message Person { required string first = 1; required string last = 2; }'
   dependencies:
-  - "github:apache.camel-kamelets:camel-kamelets-utils:4.0.0-SNAPSHOT"
+  - "mvn:org.apache.camel.kamelets:camel-kamelets-utils:4.0.0-SNAPSHOT"
   - "camel:kamelet"
   - "camel:core"
   - "camel:jackson-protobuf"

--- a/kamelets/protobuf-serialize-action.kamelet.yaml
+++ b/kamelets/protobuf-serialize-action.kamelet.yaml
@@ -41,7 +41,7 @@ spec:
         type: string
         example: 'message Person { required string first = 1; required string last = 2; }'
   dependencies:
-  - "github:apache.camel-kamelets:camel-kamelets-utils:4.0.0-SNAPSHOT"
+  - "mvn:org.apache.camel.kamelets:camel-kamelets-utils:4.0.0-SNAPSHOT"
   - "camel:kamelet"
   - "camel:core"
   - "camel:jackson-protobuf"

--- a/kamelets/regex-router-action.kamelet.yaml
+++ b/kamelets/regex-router-action.kamelet.yaml
@@ -45,7 +45,7 @@ spec:
         type: string
     type: object
   dependencies:
-  - "github:apache.camel-kamelets:camel-kamelets-utils:4.0.0-SNAPSHOT"
+  - "mvn:org.apache.camel.kamelets:camel-kamelets-utils:4.0.0-SNAPSHOT"
   - "camel:kamelet"
   - "camel:core"
   template:

--- a/kamelets/replace-field-action.kamelet.yaml
+++ b/kamelets/replace-field-action.kamelet.yaml
@@ -65,7 +65,7 @@ spec:
     in:
       mediaType: application/json
   dependencies:
-  - "github:apache.camel-kamelets:camel-kamelets-utils:4.0.0-SNAPSHOT"
+  - "mvn:org.apache.camel.kamelets:camel-kamelets-utils:4.0.0-SNAPSHOT"
   - "camel:core"
   - "camel:jackson"
   - "camel:kamelet"

--- a/kamelets/timestamp-router-action.kamelet.yaml
+++ b/kamelets/timestamp-router-action.kamelet.yaml
@@ -49,7 +49,7 @@ spec:
         default: "kafka.TIMESTAMP"
     type: object
   dependencies:
-  - "github:apache.camel-kamelets:camel-kamelets-utils:4.0.0-SNAPSHOT"
+  - "mvn:org.apache.camel.kamelets:camel-kamelets-utils:4.0.0-SNAPSHOT"
   - "camel:kamelet"
   - "camel:core"
   template:

--- a/kamelets/value-to-key-action.kamelet.yaml
+++ b/kamelets/value-to-key-action.kamelet.yaml
@@ -40,7 +40,7 @@ spec:
         type: string
     type: object
   dependencies:
-  - "github:apache.camel-kamelets:camel-kamelets-utils:4.0.0-SNAPSHOT"
+  - "mvn:org.apache.camel.kamelets:camel-kamelets-utils:4.0.0-SNAPSHOT"
   - "camel:core"
   - "camel:jackson"
   - "camel:kamelet"

--- a/library/camel-kamelets/src/main/resources/kamelets/avro-deserialize-action.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/avro-deserialize-action.kamelet.yaml
@@ -49,7 +49,7 @@ spec:
         x-descriptors:
         - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
   dependencies:
-  - "github:apache.camel-kamelets:camel-kamelets-utils:4.0.0-SNAPSHOT"
+  - "mvn:org.apache.camel.kamelets:camel-kamelets-utils:4.0.0-SNAPSHOT"
   - "camel:kamelet"
   - "camel:core"
   - "camel:jackson-avro"

--- a/library/camel-kamelets/src/main/resources/kamelets/avro-serialize-action.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/avro-serialize-action.kamelet.yaml
@@ -49,7 +49,7 @@ spec:
         x-descriptors:
         - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
   dependencies:
-  - "github:apache.camel-kamelets:camel-kamelets-utils:4.0.0-SNAPSHOT"
+  - "mvn:org.apache.camel.kamelets:camel-kamelets-utils:4.0.0-SNAPSHOT"
   - "camel:kamelet"
   - "camel:core"
   - "camel:jackson-avro"

--- a/library/camel-kamelets/src/main/resources/kamelets/aws-ddb-experimental-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/aws-ddb-experimental-sink.kamelet.yaml
@@ -110,7 +110,7 @@ spec:
     in:
       mediaType: application/json
   dependencies:
-  - github:apache.camel-kamelets:camel-kamelets-utils:4.0.0-SNAPSHOT
+  - mvn:org.apache.camel.kamelets:camel-kamelets-utils:4.0.0-SNAPSHOT
   - "camel:core"
   - "camel:jackson"
   - "camel:aws2-ddb"

--- a/library/camel-kamelets/src/main/resources/kamelets/aws-ddb-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/aws-ddb-sink.kamelet.yaml
@@ -102,7 +102,7 @@ spec:
     in:
       mediaType: application/json
   dependencies:
-  - github:apache.camel-kamelets:camel-kamelets-utils:4.0.0-SNAPSHOT
+  - mvn:org.apache.camel.kamelets:camel-kamelets-utils:4.0.0-SNAPSHOT
   - "camel:core"
   - "camel:jackson"
   - "camel:aws2-ddb"

--- a/library/camel-kamelets/src/main/resources/kamelets/aws-kinesis-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/aws-kinesis-source.kamelet.yaml
@@ -99,7 +99,7 @@ spec:
     - "camel:aws2-kinesis"
     - "camel:kamelet"
     - "camel:core"
-    - "github:apache.camel-kamelets:camel-kamelets-utils:4.0.0-SNAPSHOT"
+    - "mvn:org.apache.camel.kamelets:camel-kamelets-utils:4.0.0-SNAPSHOT"
   template:
     beans:
       - name: duplicateHeaders

--- a/library/camel-kamelets/src/main/resources/kamelets/aws-s3-experimental-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/aws-s3-experimental-source.kamelet.yaml
@@ -119,7 +119,7 @@ spec:
   dependencies:
     - "camel:core"
     - "camel:aws2-s3"
-    - "github:apache.camel-kamelets:camel-kamelets-utils:4.0.0-SNAPSHOT"
+    - "mvn:org.apache.camel.kamelets:camel-kamelets-utils:4.0.0-SNAPSHOT"
     - "camel:kamelet"
   template:
     beans:

--- a/library/camel-kamelets/src/main/resources/kamelets/aws-s3-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/aws-s3-source.kamelet.yaml
@@ -111,7 +111,7 @@ spec:
   dependencies:
     - "camel:core"
     - "camel:aws2-s3"
-    - "github:apache.camel-kamelets:camel-kamelets-utils:4.0.0-SNAPSHOT"
+    - "mvn:org.apache.camel.kamelets:camel-kamelets-utils:4.0.0-SNAPSHOT"
     - "camel:kamelet"
   template:
     beans:

--- a/library/camel-kamelets/src/main/resources/kamelets/aws-sqs-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/aws-sqs-source.kamelet.yaml
@@ -142,7 +142,7 @@ spec:
   dependencies:
     - "camel:core"
     - "camel:aws2-sqs"
-    - "github:apache.camel-kamelets:camel-kamelets-utils:4.0.0-SNAPSHOT"
+    - "mvn:org.apache.camel.kamelets:camel-kamelets-utils:4.0.0-SNAPSHOT"
     - "camel:kamelet"
   template:
     beans:

--- a/library/camel-kamelets/src/main/resources/kamelets/azure-storage-blob-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/azure-storage-blob-source.kamelet.yaml
@@ -83,7 +83,7 @@ spec:
     - "camel:core"
     - "camel:jsonpath"
     - "camel:timer"
-    - "github:apache.camel-kamelets:camel-kamelets-utils:4.0.0-SNAPSHOT"
+    - "mvn:org.apache.camel.kamelets:camel-kamelets-utils:4.0.0-SNAPSHOT"
   template:
     beans:
       - name: duplicateHeaders

--- a/library/camel-kamelets/src/main/resources/kamelets/azure-storage-queue-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/azure-storage-queue-source.kamelet.yaml
@@ -67,7 +67,7 @@ spec:
   dependencies:
     - "camel:azure-storage-queue"
     - "camel:kamelet"
-    - "github:apache.camel-kamelets:camel-kamelets-utils:4.0.0-SNAPSHOT"
+    - "mvn:org.apache.camel.kamelets:camel-kamelets-utils:4.0.0-SNAPSHOT"
     - "camel:core"
   template:
     beans:

--- a/library/camel-kamelets/src/main/resources/kamelets/extract-field-action.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/extract-field-action.kamelet.yaml
@@ -73,7 +73,7 @@ spec:
         - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
     type: object
   dependencies:
-  - "github:apache.camel-kamelets:camel-kamelets-utils:4.0.0-SNAPSHOT"
+  - "mvn:org.apache.camel.kamelets:camel-kamelets-utils:4.0.0-SNAPSHOT"
   - "camel:kamelet"
   - "camel:core"
   - "camel:jackson"

--- a/library/camel-kamelets/src/main/resources/kamelets/hoist-field-action.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/hoist-field-action.kamelet.yaml
@@ -40,7 +40,7 @@ spec:
         type: string
     type: object
   dependencies:
-  - github:apache.camel-kamelets:camel-kamelets-utils:4.0.0-SNAPSHOT
+  - mvn:org.apache.camel.kamelets:camel-kamelets-utils:4.0.0-SNAPSHOT
   - "camel:core"
   - "camel:jackson"
   - "camel:kamelet"

--- a/library/camel-kamelets/src/main/resources/kamelets/insert-field-action.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/insert-field-action.kamelet.yaml
@@ -50,7 +50,7 @@ spec:
         type: string
     type: object
   dependencies:
-  - "github:apache.camel-kamelets:camel-kamelets-utils:4.0.0-SNAPSHOT"
+  - "mvn:org.apache.camel.kamelets:camel-kamelets-utils:4.0.0-SNAPSHOT"
   - "camel:core"
   - "camel:jackson"
   - "camel:kamelet"

--- a/library/camel-kamelets/src/main/resources/kamelets/json-deserialize-action.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/json-deserialize-action.kamelet.yaml
@@ -33,7 +33,7 @@ spec:
     description: "Deserialize payload to JSON"
     type: object
   dependencies:
-  - "github:apache.camel-kamelets:camel-kamelets-utils:4.0.0-SNAPSHOT"
+  - "mvn:org.apache.camel.kamelets:camel-kamelets-utils:4.0.0-SNAPSHOT"
   - "camel:kamelet"
   - "camel:core"
   - "camel:jackson"

--- a/library/camel-kamelets/src/main/resources/kamelets/json-serialize-action.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/json-serialize-action.kamelet.yaml
@@ -33,7 +33,7 @@ spec:
     description: "Serialize payload to JSON"
     type: object
   dependencies:
-  - "github:apache.camel-kamelets:camel-kamelets-utils:4.0.0-SNAPSHOT"
+  - "mvn:org.apache.camel.kamelets:camel-kamelets-utils:4.0.0-SNAPSHOT"
   - "camel:kamelet"
   - "camel:core"
   - "camel:jackson"

--- a/library/camel-kamelets/src/main/resources/kamelets/kafka-manual-commit-action.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/kafka-manual-commit-action.kamelet.yaml
@@ -33,7 +33,7 @@ spec:
     description: "Manually commit Kafka Offset"
     type: object
   dependencies:
-  - "github:apache.camel-kamelets:camel-kamelets-utils:4.0.0-SNAPSHOT"
+  - "mvn:org.apache.camel.kamelets:camel-kamelets-utils:4.0.0-SNAPSHOT"
   - "camel:kamelet"
   template:
     from:

--- a/library/camel-kamelets/src/main/resources/kamelets/kafka-not-secured-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/kafka-not-secured-sink.kamelet.yaml
@@ -58,7 +58,7 @@ spec:
   dependencies:
     - "camel:core"
     - "camel:kafka"
-    - "github:apache.camel-kamelets:camel-kamelets-utils:4.0.0-SNAPSHOT"
+    - "mvn:org.apache.camel.kamelets:camel-kamelets-utils:4.0.0-SNAPSHOT"
     - "camel:kamelet"
   template:
     beans:

--- a/library/camel-kamelets/src/main/resources/kamelets/kafka-not-secured-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/kafka-not-secured-source.kamelet.yaml
@@ -94,7 +94,7 @@ spec:
           - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
   dependencies:
-    - "github:apache.camel-kamelets:camel-kamelets-utils:4.0.0-SNAPSHOT"
+    - "mvn:org.apache.camel.kamelets:camel-kamelets-utils:4.0.0-SNAPSHOT"
     - "camel:kafka"
     - "camel:core"
     - "camel:kamelet"

--- a/library/camel-kamelets/src/main/resources/kamelets/kafka-scram-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/kafka-scram-source.kamelet.yaml
@@ -126,7 +126,7 @@ spec:
           - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
   dependencies:
-    - "github:apache.camel-kamelets:camel-kamelets-utils:4.0.0-SNAPSHOT"
+    - "mvn:org.apache.camel.kamelets:camel-kamelets-utils:4.0.0-SNAPSHOT"
     - "camel:core"
     - "camel:kafka"
     - "camel:kamelet"

--- a/library/camel-kamelets/src/main/resources/kamelets/kafka-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/kafka-source.kamelet.yaml
@@ -126,7 +126,7 @@ spec:
           - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
   dependencies:
-    - "github:apache.camel-kamelets:camel-kamelets-utils:4.0.0-SNAPSHOT"
+    - "mvn:org.apache.camel.kamelets:camel-kamelets-utils:4.0.0-SNAPSHOT"
     - "camel:core"
     - "camel:kafka"
     - "camel:kamelet"

--- a/library/camel-kamelets/src/main/resources/kamelets/kafka-ssl-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/kafka-ssl-source.kamelet.yaml
@@ -146,7 +146,7 @@ spec:
         title: JAAS Configuration
         type: string
   dependencies:
-    - "github:apache.camel-kamelets:camel-kamelets-utils:4.0.0-SNAPSHOT"
+    - "mvn:org.apache.camel.kamelets:camel-kamelets-utils:4.0.0-SNAPSHOT"
     - "camel:core"
     - "camel:kafka"
     - "camel:kamelet"

--- a/library/camel-kamelets/src/main/resources/kamelets/mask-field-action.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/mask-field-action.kamelet.yaml
@@ -45,7 +45,7 @@ spec:
         type: string
     type: object
   dependencies:
-  - "github:apache.camel-kamelets:camel-kamelets-utils:4.0.0-SNAPSHOT"
+  - "mvn:org.apache.camel.kamelets:camel-kamelets-utils:4.0.0-SNAPSHOT"
   - "camel:jackson"
   - "camel:kamelet"
   - "camel:core"

--- a/library/camel-kamelets/src/main/resources/kamelets/message-timestamp-router-action.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/message-timestamp-router-action.kamelet.yaml
@@ -55,7 +55,7 @@ spec:
         default: "timestamp"
     type: object
   dependencies:
-  - "github:apache.camel-kamelets:camel-kamelets-utils:4.0.0-SNAPSHOT"
+  - "mvn:org.apache.camel.kamelets:camel-kamelets-utils:4.0.0-SNAPSHOT"
   - "camel:jackson"
   - "camel:kamelet"
   - "camel:core"

--- a/library/camel-kamelets/src/main/resources/kamelets/openai-classification-action.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/openai-classification-action.kamelet.yaml
@@ -75,7 +75,7 @@ spec:
     out:
       mediaType: text/plain
   dependencies:
-  - "github:apache.camel-kamelets:camel-kamelets-utils:4.0.0-SNAPSHOT"
+  - "mvn:org.apache.camel.kamelets:camel-kamelets-utils:4.0.0-SNAPSHOT"
   - "camel:jackson"
   - "camel:jsonpath"
   - "camel:core"

--- a/library/camel-kamelets/src/main/resources/kamelets/protobuf-deserialize-action.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/protobuf-deserialize-action.kamelet.yaml
@@ -41,7 +41,7 @@ spec:
         type: string
         example: 'message Person { required string first = 1; required string last = 2; }'
   dependencies:
-  - "github:apache.camel-kamelets:camel-kamelets-utils:4.0.0-SNAPSHOT"
+  - "mvn:org.apache.camel.kamelets:camel-kamelets-utils:4.0.0-SNAPSHOT"
   - "camel:kamelet"
   - "camel:core"
   - "camel:jackson-protobuf"

--- a/library/camel-kamelets/src/main/resources/kamelets/protobuf-serialize-action.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/protobuf-serialize-action.kamelet.yaml
@@ -41,7 +41,7 @@ spec:
         type: string
         example: 'message Person { required string first = 1; required string last = 2; }'
   dependencies:
-  - "github:apache.camel-kamelets:camel-kamelets-utils:4.0.0-SNAPSHOT"
+  - "mvn:org.apache.camel.kamelets:camel-kamelets-utils:4.0.0-SNAPSHOT"
   - "camel:kamelet"
   - "camel:core"
   - "camel:jackson-protobuf"

--- a/library/camel-kamelets/src/main/resources/kamelets/regex-router-action.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/regex-router-action.kamelet.yaml
@@ -45,7 +45,7 @@ spec:
         type: string
     type: object
   dependencies:
-  - "github:apache.camel-kamelets:camel-kamelets-utils:4.0.0-SNAPSHOT"
+  - "mvn:org.apache.camel.kamelets:camel-kamelets-utils:4.0.0-SNAPSHOT"
   - "camel:kamelet"
   - "camel:core"
   template:

--- a/library/camel-kamelets/src/main/resources/kamelets/replace-field-action.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/replace-field-action.kamelet.yaml
@@ -65,7 +65,7 @@ spec:
     in:
       mediaType: application/json
   dependencies:
-  - "github:apache.camel-kamelets:camel-kamelets-utils:4.0.0-SNAPSHOT"
+  - "mvn:org.apache.camel.kamelets:camel-kamelets-utils:4.0.0-SNAPSHOT"
   - "camel:core"
   - "camel:jackson"
   - "camel:kamelet"

--- a/library/camel-kamelets/src/main/resources/kamelets/timestamp-router-action.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/timestamp-router-action.kamelet.yaml
@@ -49,7 +49,7 @@ spec:
         default: "kafka.TIMESTAMP"
     type: object
   dependencies:
-  - "github:apache.camel-kamelets:camel-kamelets-utils:4.0.0-SNAPSHOT"
+  - "mvn:org.apache.camel.kamelets:camel-kamelets-utils:4.0.0-SNAPSHOT"
   - "camel:kamelet"
   - "camel:core"
   template:

--- a/library/camel-kamelets/src/main/resources/kamelets/value-to-key-action.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/value-to-key-action.kamelet.yaml
@@ -40,7 +40,7 @@ spec:
         type: string
     type: object
   dependencies:
-  - "github:apache.camel-kamelets:camel-kamelets-utils:4.0.0-SNAPSHOT"
+  - "mvn:org.apache.camel.kamelets:camel-kamelets-utils:4.0.0-SNAPSHOT"
   - "camel:core"
   - "camel:jackson"
   - "camel:kamelet"

--- a/library/kamelets-maven-plugin/src/main/java/org/apache/camel/kamelets/maven/plugin/ValidateKameletsMojo.java
+++ b/library/kamelets-maven-plugin/src/main/java/org/apache/camel/kamelets/maven/plugin/ValidateKameletsMojo.java
@@ -58,7 +58,7 @@ public class ValidateKameletsMojo extends AbstractMojo {
 
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
-        String[] bannedDeps = {"mvn:", "camel:gson", "camel:core", "camel:kamelet", "github:apache.camel-kamelets:camel-kamelets-utils:3.20.1-SNAPSHOT"};
+        String[] bannedDeps = {"mvn:", "camel:gson", "camel:core", "camel:kamelet"};
         List<String> bannedDepsList = Arrays.asList(bannedDeps);
         KameletsCatalog catalog = new KameletsCatalog();
         DefaultCamelCatalog cc = new DefaultCamelCatalog();
@@ -69,7 +69,8 @@ public class ValidateKameletsMojo extends AbstractMojo {
             Map<String,Object> f = (Map) kd.get("from");
             Map<String,Object> p = (Map) f.get("parameters");
             List<String> deps = catalog.getKameletDependencies(name).stream()
-                    .filter(Predicate.not(bannedDepsList::contains)).collect(Collectors.toList());
+                    .filter(Predicate.not(bannedDepsList::contains))
+                    .collect(Collectors.toList());
             String cleanName;
             if (!deps.isEmpty()) {
                 if (deps.get(0).equals("camel:jackson") && deps.size() > 1) {

--- a/update-kamelets.xml
+++ b/update-kamelets.xml
@@ -1,36 +1,24 @@
 <project name="camel-kamelets" basedir=".">
-    
+
     <property name="releaseVersion" value="${project.version}" />
 
     <target name="context">
         <echo message="Project version: ${project.version}, release version: ${releaseVersion}"/>
     </target>
 
-    <target name="check.snapshot" depends="context">
-        <condition property="is.snapshot">
-            <contains string="${releaseVersion}" substring="SNAPSHOT" />
-        </condition>
-    </target>
-    <target name="replace.release" depends="check.snapshot">
+    <target name="replace.release" depends="context">
         <replaceregexp match="camel.apache.org/catalog.version:.*$" replace="camel.apache.org/catalog.version: &quot;${releaseVersion}&quot;" byline="true">
             <fileset dir="kamelets/">
                 <include name="*.kamelet.yaml"/>
             </fileset>
         </replaceregexp>
-        <replaceregexp match="github:apache.camel-kamelets:camel-kamelets-utils:[A-Za-z0-9-.]+" replace="mvn:org.apache.camel.kamelets:camel-kamelets-utils:${releaseVersion}" byline="true">
-            <fileset dir="kamelets/">
-                <include name="*.kamelet.yaml"/>
-            </fileset>
-        </replaceregexp>
-    </target>
-    <target name="replace.snapshot" depends="replace.release" if="is.snapshot">
-        <replaceregexp match="mvn:org.apache.camel.kamelets:camel-kamelets-utils:[A-Za-z0-9-.]+" replace="github:apache.camel-kamelets:camel-kamelets-utils:${releaseVersion}" byline="true">
+        <replaceregexp match="mvn:org.apache.camel.kamelets:camel-kamelets-utils:[A-Za-z0-9-.]+" replace="mvn:org.apache.camel.kamelets:camel-kamelets-utils:${releaseVersion}" byline="true">
             <fileset dir="kamelets/">
                 <include name="*.kamelet.yaml"/>
             </fileset>
         </replaceregexp>
     </target>
 
-    <target name="update.kamelets" depends="replace.snapshot" />
+    <target name="update.kamelets" depends="replace.release" />
 
 </project>


### PR DESCRIPTION
Always use plain mvn dependency for camel-kamelets-utils library. Avoid dependency resolution via Jitpack in Kamelets as it causes high branch maintenance effort and easily becomes complex when dealing with PRs and multiple release branches.

We do not have to maintain branches for different versions resolved via Jitpack. Just use the camel-kamelet-utils that has been built locally with `-SNAPSHOT` instead.

Also simplifies the `update-kamelets.xml` release tooling as this only sets the right release version for camel-kamelets-utils library.