### PR TITLE
Slack Sink: iconEmoji, iconUrl, username are deprecated in camel

### DIFF
--- a/kamelets/slack-sink.kamelet.yaml
+++ b/kamelets/slack-sink.kamelet.yaml
@@ -54,14 +54,17 @@ spec:
         title: Icon Emoji
         description: Use a Slack emoji as an avatar.
         type: string
+        deprecated: true
       iconUrl:
         title: Icon URL
         description: The avatar to use when sending a message to a channel or user.
         type: string
+        deprecated: true
       username:
         title: Username
         description: The username for the bot when it sends messages to a channel or user.
         type: string
+        deprecated: true
   types:
     out:
       mediaType: application/json

--- a/library/camel-kamelets/src/main/resources/kamelets/slack-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/slack-sink.kamelet.yaml
@@ -54,14 +54,17 @@ spec:
         title: Icon Emoji
         description: Use a Slack emoji as an avatar.
         type: string
+        deprecated: true
       iconUrl:
         title: Icon URL
         description: The avatar to use when sending a message to a channel or user.
         type: string
+        deprecated: true
       username:
         title: Username
         description: The username for the bot when it sends messages to a channel or user.
         type: string
+        deprecated: true
   types:
     out:
       mediaType: application/json


### PR DESCRIPTION
Please advise if you require Camel issues lodged for PRs vs third party tracking references.

The underlying Slack Component has deprecated a few [parameters](https://camel.apache.org/components/3.20.x/slack-component.html#_path_parameters_1_parameters), namely `iconEmoji`, `iconUrl` and `username`.

This PR attempts to reflect the same in the corresponding Kamelet definition.

I'm uncertain if Kamelets even support the definition of deprecated parameters. [Documentation](https://camel.apache.org/camel-k/1.11.x/kamelets/kamelets-dev.html#_step_6_describe_the_parameters) isn't clear.

I'm even less clear, to be honest, whether the `parameters` in a Kamelet map to "Components Options" or "Query parameters" or both due to some clever name-based mapping in Camel. The three affected Kamelet parameters appear as `parameters` in the Kamelet but as "Query parameters" in the Component. The Kamelet parameter `webhookUrl` relates to a [Component Option](https://camel.apache.org/components/3.20.x/slack-component.html#_component_option_webhookUrl) and [Query parameter](https://camel.apache.org/components/3.20.x/slack-component.html#_endpoint_query_option_webhookUrl).

I suspect they only map to Component Options and hence the three "Query" parameters can be removed entirely and not just deprecated.

Advice welcome.
