### PR TITLE
chore: Fix Log4j2 to SLF4J2 binding

### DIFF
--- a/library/camel-kamelets-catalog/pom.xml
+++ b/library/camel-kamelets-catalog/pom.xml
@@ -95,7 +95,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
+            <artifactId>log4j-slf4j2-impl</artifactId>
             <version>${log4j.version}</version>
             <scope>test</scope>
         </dependency>

--- a/library/camel-kamelets-utils/pom.xml
+++ b/library/camel-kamelets-utils/pom.xml
@@ -120,7 +120,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
+            <artifactId>log4j-slf4j2-impl</artifactId>
             <version>${log4j.version}</version>
             <scope>test</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -61,8 +61,8 @@
 	<cyclonedx-maven-plugin-version>2.7.5</cyclonedx-maven-plugin-version>
 
         <camel.version>4.0.0-M1</camel.version>
-        <slf4j.version>1.7.36</slf4j.version>
-        <log4j.version>2.19.0</log4j.version>
+        <slf4j.version>2.0.6</slf4j.version>
+        <log4j.version>2.20.0</log4j.version>
         <jackson.version>2.14.1</jackson.version>
         <camel.k.extension.version>6.1.1</camel.k.extension.version>
         <commons.io.version>2.11.0</commons.io.version>


### PR DESCRIPTION
Use proper Log4j2 binding to support SLF4J 2.x API

The Maven project had both SLF4J API 1.7.x and 2.x in the classpath due to transitive dependencies. Use only SLF4J 2.x API and use proper Log4j2 binding to support 2.x API