### PR TITLE
chore: Run deploy GitHub workflow job on main repo only

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -69,8 +69,8 @@ jobs:
         path: maven-repo-${{ github.run_id }}-${{ github.run_number }}.tgz
   deploy:
     runs-on: ubuntu-latest
-    # Run only when pushing to the branches (either main or release), never on merge requests
-    if: ${{ github.event_name == 'push' }}
+    # Run only when pushing to the branches (either main or release), never on merge requests and forks
+    if: ${{ github.repository == 'apache/camel-kamelets' && github.event_name == 'push' }}
     env:
       NEXUS_DEPLOY_USERNAME: ${{ secrets.NEXUS_USER }}
       NEXUS_DEPLOY_PASSWORD: ${{ secrets.NEXUS_PW }}

--- a/.github/workflows/java-tests.yaml
+++ b/.github/workflows/java-tests.yaml
@@ -45,6 +45,6 @@ jobs:
           java-version: 17
           cache: 'maven'
       - name: Build catalog 1st Run
-        run: ./mvnw clean install -DskipTests
+        run: ./mvnw clean install -DskipTests -DskipITs
       - name: Build catalog 2nd Run
         run: ./mvnw clean install


### PR DESCRIPTION
Prevents deploy build job to fail on forked repositories