### PR TITLE
Kafka Source Kamelets: Enable deserializeHeaders by default

### DIFF
--- a/kamelets/kafka-not-secured-source.kamelet.yaml
+++ b/kamelets/kafka-not-secured-source.kamelet.yaml
@@ -92,7 +92,7 @@ spec:
         type: boolean
         x-descriptors:
           - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
-        default: false
+        default: true
   dependencies:
     - "github:apache.camel-kamelets:camel-kamelets-utils:3.20.3-SNAPSHOT"
     - "camel:kafka"

--- a/kamelets/kafka-source.kamelet.yaml
+++ b/kamelets/kafka-source.kamelet.yaml
@@ -124,7 +124,7 @@ spec:
         type: boolean
         x-descriptors:
           - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
-        default: false
+        default: true
   dependencies:
     - "github:apache.camel-kamelets:camel-kamelets-utils:3.20.3-SNAPSHOT"
     - "camel:core"

--- a/kamelets/kafka-ssl-source.kamelet.yaml
+++ b/kamelets/kafka-ssl-source.kamelet.yaml
@@ -103,7 +103,7 @@ spec:
         type: boolean
         x-descriptors:
           - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
-        default: false
+        default: true
       sslKeyPassword:
         description: The password of the private key in the key store file.
         title: SSL Key Password

--- a/library/camel-kamelets/src/main/resources/kamelets/kafka-not-secured-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/kafka-not-secured-source.kamelet.yaml
@@ -92,7 +92,7 @@ spec:
         type: boolean
         x-descriptors:
           - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
-        default: false
+        default: true
   dependencies:
     - "github:apache.camel-kamelets:camel-kamelets-utils:3.20.3-SNAPSHOT"
     - "camel:kafka"

--- a/library/camel-kamelets/src/main/resources/kamelets/kafka-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/kafka-source.kamelet.yaml
@@ -124,7 +124,7 @@ spec:
         type: boolean
         x-descriptors:
           - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
-        default: false
+        default: true
   dependencies:
     - "github:apache.camel-kamelets:camel-kamelets-utils:3.20.3-SNAPSHOT"
     - "camel:core"

--- a/library/camel-kamelets/src/main/resources/kamelets/kafka-ssl-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/kafka-ssl-source.kamelet.yaml
@@ -103,7 +103,7 @@ spec:
         type: boolean
         x-descriptors:
           - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
-        default: false
+        default: true
       sslKeyPassword:
         description: The password of the private key in the key store file.
         title: SSL Key Password


### PR DESCRIPTION
Related to #1382 