### PR TITLE
Azure Storage Blob Kamelets: Use just the SHARED_ACCOUNT_KEY credentials as default

### DIFF
--- a/kamelets/azure-storage-blob-changefeed-source.kamelet.yaml
+++ b/kamelets/azure-storage-blob-changefeed-source.kamelet.yaml
@@ -58,12 +58,6 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
-      credentialType:
-        title: Credential Type
-        description: Determines the credential strategy to adopt. 
-        type: string
-        default: SHARED_ACCOUNT_KEY
-        enum: ["SHARED_ACCOUNT_KEY", "SHARED_KEY_CREDENTIAL", "AZURE_IDENTITY"]
   dependencies:
     - "camel:azure-storage-blob"
     - "camel:kamelet"
@@ -84,7 +78,7 @@ spec:
             parameters:
               operation: "getChangeFeed"
               accessKey: "{{accessKey}}"
-              credentialType: "{{credentialType}}"
+              credentialType: "SHARED_ACCOUNT_KEY"
         - split:
             expression:
               simple: "${body}"

--- a/kamelets/azure-storage-blob-sink.kamelet.yaml
+++ b/kamelets/azure-storage-blob-sink.kamelet.yaml
@@ -64,12 +64,6 @@ spec:
         description: The operation to perform.
         type: string
         default: uploadBlockBlob
-      credentialType:
-        title: Credential Type
-        description: Determines the credential strategy to adopt. 
-        type: string
-        default: SHARED_ACCOUNT_KEY
-        enum: ["SHARED_ACCOUNT_KEY", "SHARED_KEY_CREDENTIAL", "AZURE_IDENTITY"]
   dependencies:
     - "camel:core"
     - "camel:azure-storage-blob"
@@ -100,4 +94,4 @@ spec:
           parameters:
             accessKey: "{{accessKey}}"
             operation: "{{operation}}"
-            credentialType: "{{credentialType}}"
+            credentialType: "SHARED_ACCOUNT_KEY"

--- a/kamelets/azure-storage-blob-source.kamelet.yaml
+++ b/kamelets/azure-storage-blob-source.kamelet.yaml
@@ -59,12 +59,6 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
-      credentialType:
-        title: Credential Type
-        description: Determines the credential strategy to adopt.
-        type: string
-        default: SHARED_ACCOUNT_KEY
-        enum: ["SHARED_ACCOUNT_KEY", "SHARED_KEY_CREDENTIAL", "AZURE_IDENTITY"]
       delay:
         title: Delay
         description: The number of milliseconds before the next poll of the selected blob.
@@ -117,5 +111,5 @@ spec:
                       parameters:
                         operation: "deleteBlob"
                         accessKey: "{{accessKey}}"
-                        credentialType: "{{credentialType}}"
+                        credentialType: "SHARED_ACCOUNT_KEY"
 

--- a/library/camel-kamelets/src/main/resources/kamelets/azure-storage-blob-changefeed-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/azure-storage-blob-changefeed-source.kamelet.yaml
@@ -58,12 +58,6 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
-      credentialType:
-        title: Credential Type
-        description: Determines the credential strategy to adopt. 
-        type: string
-        default: SHARED_ACCOUNT_KEY
-        enum: ["SHARED_ACCOUNT_KEY", "SHARED_KEY_CREDENTIAL", "AZURE_IDENTITY"]
   dependencies:
     - "camel:azure-storage-blob"
     - "camel:kamelet"
@@ -84,7 +78,7 @@ spec:
             parameters:
               operation: "getChangeFeed"
               accessKey: "{{accessKey}}"
-              credentialType: "{{credentialType}}"
+              credentialType: "SHARED_ACCOUNT_KEY"
         - split:
             expression:
               simple: "${body}"

--- a/library/camel-kamelets/src/main/resources/kamelets/azure-storage-blob-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/azure-storage-blob-sink.kamelet.yaml
@@ -64,12 +64,6 @@ spec:
         description: The operation to perform.
         type: string
         default: uploadBlockBlob
-      credentialType:
-        title: Credential Type
-        description: Determines the credential strategy to adopt. 
-        type: string
-        default: SHARED_ACCOUNT_KEY
-        enum: ["SHARED_ACCOUNT_KEY", "SHARED_KEY_CREDENTIAL", "AZURE_IDENTITY"]
   dependencies:
     - "camel:core"
     - "camel:azure-storage-blob"
@@ -100,4 +94,4 @@ spec:
           parameters:
             accessKey: "{{accessKey}}"
             operation: "{{operation}}"
-            credentialType: "{{credentialType}}"
+            credentialType: "SHARED_ACCOUNT_KEY"

--- a/library/camel-kamelets/src/main/resources/kamelets/azure-storage-blob-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/azure-storage-blob-source.kamelet.yaml
@@ -59,12 +59,6 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
-      credentialType:
-        title: Credential Type
-        description: Determines the credential strategy to adopt.
-        type: string
-        default: SHARED_ACCOUNT_KEY
-        enum: ["SHARED_ACCOUNT_KEY", "SHARED_KEY_CREDENTIAL", "AZURE_IDENTITY"]
       delay:
         title: Delay
         description: The number of milliseconds before the next poll of the selected blob.
@@ -117,5 +111,5 @@ spec:
                       parameters:
                         operation: "deleteBlob"
                         accessKey: "{{accessKey}}"
-                        credentialType: "{{credentialType}}"
+                        credentialType: "SHARED_ACCOUNT_KEY"
 


### PR DESCRIPTION
Related to #1400 