### PR TITLE
Azure Storage Blob Kamelets: Use just the SHARED_ACCOUNT_KEY credentials as default

### DIFF
--- a/kamelets/azure-storage-blob-changefeed-source.kamelet.yaml
+++ b/kamelets/azure-storage-blob-changefeed-source.kamelet.yaml
@@ -57,11 +57,6 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
-      credentialType:
-        title: Credential Type
-        description: Determines the credential strategy to adopt. Possible values are SHARED_ACCOUNT_KEY, SHARED_KEY_CREDENTIAL and AZURE_IDENTITY
-        type: string
-        default: SHARED_ACCOUNT_KEY
   dependencies:
     - "camel:azure-storage-blob"
     - "camel:kamelet"
@@ -79,5 +74,5 @@ spec:
           parameters:
             operation: "getChangeFeed"
             accessKey: "{{accessKey}}"
-            credentialType: "{{credentialType}}"
+            credentialType: "SHARED_ACCOUNT_KEY"
       - to: "kamelet:sink"

--- a/kamelets/azure-storage-blob-sink.kamelet.yaml
+++ b/kamelets/azure-storage-blob-sink.kamelet.yaml
@@ -63,11 +63,6 @@ spec:
         description: The operation to perform.
         type: string
         default: uploadBlockBlob
-      credentialType:
-        title: Credential Type
-        description: Determines the credential strategy to adopt. Possible values are SHARED_ACCOUNT_KEY, SHARED_KEY_CREDENTIAL and AZURE_IDENTITY
-        type: string
-        default: SHARED_ACCOUNT_KEY
   dependencies:
     - "camel:core"
     - "camel:azure-storage-blob"
@@ -98,4 +93,4 @@ spec:
           parameters:
             accessKey: "{{accessKey}}"
             operation: "{{operation}}"
-            credentialType: "{{credentialType}}"
+            credentialType: "SHARED_ACCOUNT_KEY"

--- a/kamelets/azure-storage-blob-source.kamelet.yaml
+++ b/kamelets/azure-storage-blob-source.kamelet.yaml
@@ -56,11 +56,6 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
-      credentialType:
-        title: Credential Type
-        description: Determines the credential strategy to adopt. Possible values are SHARED_ACCOUNT_KEY, SHARED_KEY_CREDENTIAL and AZURE_IDENTITY
-        type: string
-        default: SHARED_ACCOUNT_KEY
       delay:
         title: Delay
         description: The number of milliseconds before the next poll of the selected blob.
@@ -98,5 +93,5 @@ spec:
                       parameters:
                         operation: "deleteBlob"
                         accessKey: "{{accessKey}}"
-                        credentialType: "{{credentialType}}"
+                        credentialType: "SHARED_ACCOUNT_KEY"
 

--- a/library/camel-kamelets/src/main/resources/kamelets/azure-storage-blob-changefeed-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/azure-storage-blob-changefeed-source.kamelet.yaml
@@ -57,11 +57,6 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
-      credentialType:
-        title: Credential Type
-        description: Determines the credential strategy to adopt. Possible values are SHARED_ACCOUNT_KEY, SHARED_KEY_CREDENTIAL and AZURE_IDENTITY
-        type: string
-        default: SHARED_ACCOUNT_KEY
   dependencies:
     - "camel:azure-storage-blob"
     - "camel:kamelet"
@@ -79,5 +74,5 @@ spec:
           parameters:
             operation: "getChangeFeed"
             accessKey: "{{accessKey}}"
-            credentialType: "{{credentialType}}"
+            credentialType: "SHARED_ACCOUNT_KEY"
       - to: "kamelet:sink"

--- a/library/camel-kamelets/src/main/resources/kamelets/azure-storage-blob-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/azure-storage-blob-sink.kamelet.yaml
@@ -63,11 +63,6 @@ spec:
         description: The operation to perform.
         type: string
         default: uploadBlockBlob
-      credentialType:
-        title: Credential Type
-        description: Determines the credential strategy to adopt. Possible values are SHARED_ACCOUNT_KEY, SHARED_KEY_CREDENTIAL and AZURE_IDENTITY
-        type: string
-        default: SHARED_ACCOUNT_KEY
   dependencies:
     - "camel:core"
     - "camel:azure-storage-blob"
@@ -98,4 +93,4 @@ spec:
           parameters:
             accessKey: "{{accessKey}}"
             operation: "{{operation}}"
-            credentialType: "{{credentialType}}"
+            credentialType: "SHARED_ACCOUNT_KEY"

--- a/library/camel-kamelets/src/main/resources/kamelets/azure-storage-blob-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/azure-storage-blob-source.kamelet.yaml
@@ -56,11 +56,6 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
-      credentialType:
-        title: Credential Type
-        description: Determines the credential strategy to adopt. Possible values are SHARED_ACCOUNT_KEY, SHARED_KEY_CREDENTIAL and AZURE_IDENTITY
-        type: string
-        default: SHARED_ACCOUNT_KEY
       delay:
         title: Delay
         description: The number of milliseconds before the next poll of the selected blob.
@@ -98,5 +93,5 @@ spec:
                       parameters:
                         operation: "deleteBlob"
                         accessKey: "{{accessKey}}"
-                        credentialType: "{{credentialType}}"
+                        credentialType: "SHARED_ACCOUNT_KEY"
 


### PR DESCRIPTION
Related to #1400 