### PR TITLE
Azure Storage Blob Sink: Remove operation parameter, since the kamelet has been developed just for uploadBlockBlob operation

### DIFF
--- a/kamelets/azure-storage-blob-sink.kamelet.yaml
+++ b/kamelets/azure-storage-blob-sink.kamelet.yaml
@@ -59,11 +59,6 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
-      operation:
-        title: Operation name
-        description: The operation to perform.
-        type: string
-        default: uploadBlockBlob
   dependencies:
     - "camel:core"
     - "camel:azure-storage-blob"
@@ -93,5 +88,5 @@ spec:
           uri: "azure-storage-blob://{{accountName}}/{{containerName}}"
           parameters:
             accessKey: "{{accessKey}}"
-            operation: "{{operation}}"
+            operation: "uploadBlockBlob"
             credentialType: "SHARED_ACCOUNT_KEY"

--- a/library/camel-kamelets/src/main/resources/kamelets/azure-storage-blob-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/azure-storage-blob-sink.kamelet.yaml
@@ -59,11 +59,6 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
-      operation:
-        title: Operation name
-        description: The operation to perform.
-        type: string
-        default: uploadBlockBlob
   dependencies:
     - "camel:core"
     - "camel:azure-storage-blob"
@@ -93,5 +88,5 @@ spec:
           uri: "azure-storage-blob://{{accountName}}/{{containerName}}"
           parameters:
             accessKey: "{{accessKey}}"
-            operation: "{{operation}}"
+            operation: "uploadBlockBlob"
             credentialType: "SHARED_ACCOUNT_KEY"


### PR DESCRIPTION
Related to #1405 