### PR TITLE
Cassandra Kamelets: Consistency Level in source should list only available consistency level for reading

### DIFF
--- a/kamelets/cassandra-source.kamelet.yaml
+++ b/kamelets/cassandra-source.kamelet.yaml
@@ -74,7 +74,7 @@ spec:
         default: ALL
       consistencyLevel:
         title: Consistency Level
-        description: The consistency level to use. Possible values are ANY, ONE, TWO, THREE, QUORUM, ALL, LOCAL_QUORUM, EACH_QUORUM, SERIAL, LOCAL_SERIAL, or LOCAL_ONE.
+        description: The consistency level to use. Possible values are ONE, TWO, THREE, QUORUM, ALL, LOCAL_QUORUM, EACH_QUORUM, SERIAL, LOCAL_SERIAL, or LOCAL_ONE.
         type: string
         default: QUORUM
       query:

--- a/library/camel-kamelets/src/main/resources/kamelets/cassandra-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/cassandra-source.kamelet.yaml
@@ -74,7 +74,7 @@ spec:
         default: ALL
       consistencyLevel:
         title: Consistency Level
-        description: The consistency level to use. Possible values are ANY, ONE, TWO, THREE, QUORUM, ALL, LOCAL_QUORUM, EACH_QUORUM, SERIAL, LOCAL_SERIAL, or LOCAL_ONE.
+        description: The consistency level to use. Possible values are ONE, TWO, THREE, QUORUM, ALL, LOCAL_QUORUM, EACH_QUORUM, SERIAL, LOCAL_SERIAL, or LOCAL_ONE.
         type: string
         default: QUORUM
       query:


### PR DESCRIPTION
Related to #1410 