### PR TITLE
Azure Storage Blob Kamelets: Use just the SHARED_ACCOUNT_KEY credentials as default

### DIFF
--- a/kamelets/azure-storage-blob-source.kamelet.yaml
+++ b/kamelets/azure-storage-blob-source.kamelet.yaml
@@ -95,7 +95,7 @@ spec:
       uri: "azure-storage-blob:{{accountName}}/{{containerName}}"
       parameters:
         accessKey: "{{accessKey}}"
-        credentialType: "{{credentialType}}"
+        credentialType: "SHARED_ACCOUNT_KEY"
         delay: "{{delay}}"
       steps:
         - process:

--- a/library/camel-kamelets/src/main/resources/kamelets/azure-storage-blob-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/azure-storage-blob-source.kamelet.yaml
@@ -95,7 +95,7 @@ spec:
       uri: "azure-storage-blob:{{accountName}}/{{containerName}}"
       parameters:
         accessKey: "{{accessKey}}"
-        credentialType: "{{credentialType}}"
+        credentialType: "SHARED_ACCOUNT_KEY"
         delay: "{{delay}}"
       steps:
         - process:


### PR DESCRIPTION
Related to #1405 