### PR TITLE
 fixed Oracle connection URL

### DIFF
--- a/kamelets/oracle-database-sink.kamelet.yaml
+++ b/kamelets/oracle-database-sink.kamelet.yaml
@@ -103,7 +103,7 @@ spec:
           - key: password
             value: '{{password}}'
           - key: url
-            value: 'jdbc:oracle:thin://{{serverName}}:{{serverPort}}/{{databaseName}}'
+            value: 'jdbc:oracle:thin:@{{serverName}}:{{serverPort}}/{{databaseName}}'
           - key: driverClassName
             value: 'oracle.jdbc.driver.OracleDriver'
     from:

--- a/kamelets/oracle-database-source.kamelet.yaml
+++ b/kamelets/oracle-database-source.kamelet.yaml
@@ -100,7 +100,7 @@ spec:
           - key: password
             value: '{{password}}'
           - key: url
-            value: 'jdbc:oracle:thin://{{serverName}}:{{serverPort}}/{{databaseName}}'
+            value: 'jdbc:oracle:thin:@{{serverName}}:{{serverPort}}/{{databaseName}}'
           - key: driverClassName
             value: 'oracle.jdbc.driver.OracleDriver'
     from:


### PR DESCRIPTION
Correct format of URL is given below so replaced // with @
```
url="jdbc:oracle:thin:@(DESCRIPTION=
  (LOAD_BALANCE=on)
(ADDRESS_LIST=
  (ADDRESS=(PROTOCOL=TCP)(HOST=host1) (PORT=5221))
 (ADDRESS=(PROTOCOL=TCP)(HOST=host2)(PORT=5221)))
 (CONNECT_DATA=(SERVICE_NAME=orcl)))"
```