### PR TITLE
added sslCipherSuite property so TLS can be enabled

### DIFF
--- a/kamelets/jms-ibm-mq-sink.kamelet.yaml
+++ b/kamelets/jms-ibm-mq-sink.kamelet.yaml
@@ -90,6 +90,10 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
+      sslCipherSuite:
+        title: "CipherSuite"
+        description: "CipherSuite to use for enabling TLS"
+        type: string
   dependencies:
   - "camel:jms"
   - "camel:kamelet"
@@ -114,6 +118,8 @@ spec:
             value: '{{password}}'
           - key: XMSC_CLIENT_ID
             value: '{{?clientId}}'
+          - key: XMSC_WMQ_SSL_CIPHER_SUITE
+            value: '{{?sslCipherSuite}}'
     from:
       uri: "kamelet:source"
       steps:

--- a/kamelets/jms-ibm-mq-source.kamelet.yaml
+++ b/kamelets/jms-ibm-mq-source.kamelet.yaml
@@ -90,6 +90,10 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
+      sslCipherSuite:
+        title: "CipherSuite"
+        description: "CipherSuite to use for enabling TLS"
+        type: string
   dependencies:
   - "camel:jms"
   - "camel:kamelet"
@@ -114,6 +118,8 @@ spec:
             value: '{{password}}'
           - key: XMSC_CLIENT_ID
             value: '{{?clientId}}'
+          - key: XMSC_WMQ_SSL_CIPHER_SUITE
+            value: '{{?sslCipherSuite}}'
     from:
       uri: "jms:{{destinationType}}:{{destinationName}}"
       parameters:

--- a/library/camel-kamelets/src/main/resources/kamelets/jms-ibm-mq-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/jms-ibm-mq-sink.kamelet.yaml
@@ -90,6 +90,10 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
+      sslCipherSuite:
+        title: "CipherSuite"
+        description: "CipherSuite to use for enabling TLS"
+        type: string
   dependencies:
   - "camel:jms"
   - "camel:kamelet"
@@ -114,6 +118,8 @@ spec:
             value: '{{password}}'
           - key: XMSC_CLIENT_ID
             value: '{{?clientId}}'
+          - key: XMSC_WMQ_SSL_CIPHER_SUITE
+            value: '{{?sslCipherSuite}}'
     from:
       uri: "kamelet:source"
       steps:

--- a/library/camel-kamelets/src/main/resources/kamelets/jms-ibm-mq-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/jms-ibm-mq-source.kamelet.yaml
@@ -90,6 +90,10 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
+      sslCipherSuite:
+        title: "CipherSuite"
+        description: "CipherSuite to use for enabling TLS"
+        type: string
   dependencies:
   - "camel:jms"
   - "camel:kamelet"
@@ -114,6 +118,8 @@ spec:
             value: '{{password}}'
           - key: XMSC_CLIENT_ID
             value: '{{?clientId}}'
+          - key: XMSC_WMQ_SSL_CIPHER_SUITE
+            value: '{{?sslCipherSuite}}'
     from:
       uri: "jms:{{destinationType}}:{{destinationName}}"
       parameters:


### PR DESCRIPTION
This PR adds a sslCipherSuite property to the jms-ibm-mq sink and source kamelets that enables using TLS with IBM MQ.
