### PR TITLE
Kafka Secured Kamelets: use double quote around user and password

### DIFF
--- a/kamelets/kafka-scram-sink.kamelet.yaml
+++ b/kamelets/kafka-scram-sink.kamelet.yaml
@@ -117,4 +117,4 @@ spec:
             brokers: "{{bootstrapServers}}"
             securityProtocol: "{{securityProtocol}}"
             saslMechanism: "{{saslMechanism}}"
-            saslJaasConfig: "org.apache.kafka.common.security.scram.ScramLoginModule required username='{{user}}' password='{{password}}';"
+            saslJaasConfig: 'org.apache.kafka.common.security.scram.ScramLoginModule required username="{{user}}" password="{{password}}";'

--- a/kamelets/kafka-scram-source.kamelet.yaml
+++ b/kamelets/kafka-scram-source.kamelet.yaml
@@ -143,7 +143,7 @@ spec:
         brokers: "{{?bootstrapServers}}"
         securityProtocol: "{{securityProtocol}}"
         saslMechanism: "{{saslMechanism}}"
-        saslJaasConfig: "org.apache.kafka.common.security.scram.ScramLoginModule required username='{{user}}' password='{{password}}';"
+        saslJaasConfig: 'org.apache.kafka.common.security.scram.ScramLoginModule required username="{{user}}" password="{{password}}";'
         autoCommitEnable: "{{autoCommitEnable}}"
         allowManualCommit: "{{allowManualCommit}}"
         pollOnError: "{{pollOnError}}"

--- a/kamelets/kafka-sink.kamelet.yaml
+++ b/kamelets/kafka-sink.kamelet.yaml
@@ -117,4 +117,4 @@ spec:
             brokers: "{{bootstrapServers}}"
             securityProtocol: "{{securityProtocol}}"
             saslMechanism: "{{saslMechanism}}"
-            saslJaasConfig: "org.apache.kafka.common.security.plain.PlainLoginModule required username='{{user}}' password='{{password}}';"
+            saslJaasConfig: 'org.apache.kafka.common.security.plain.PlainLoginModule required username="{{user}}" password="{{password}}";'

--- a/kamelets/kafka-source.kamelet.yaml
+++ b/kamelets/kafka-source.kamelet.yaml
@@ -143,7 +143,7 @@ spec:
         brokers: "{{?bootstrapServers}}"
         securityProtocol: "{{securityProtocol}}"
         saslMechanism: "{{saslMechanism}}"
-        saslJaasConfig: "org.apache.kafka.common.security.plain.PlainLoginModule required username='{{user}}' password='{{password}}';"
+        saslJaasConfig: 'org.apache.kafka.common.security.plain.PlainLoginModule required username="{{user}}" password="{{password}}";'
         autoCommitEnable: "{{autoCommitEnable}}"
         allowManualCommit: "{{allowManualCommit}}"
         pollOnError: "{{pollOnError}}"

--- a/library/camel-kamelets/src/main/resources/kamelets/kafka-scram-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/kafka-scram-sink.kamelet.yaml
@@ -117,4 +117,4 @@ spec:
             brokers: "{{bootstrapServers}}"
             securityProtocol: "{{securityProtocol}}"
             saslMechanism: "{{saslMechanism}}"
-            saslJaasConfig: "org.apache.kafka.common.security.scram.ScramLoginModule required username='{{user}}' password='{{password}}';"
+            saslJaasConfig: 'org.apache.kafka.common.security.scram.ScramLoginModule required username="{{user}}" password="{{password}}";'

--- a/library/camel-kamelets/src/main/resources/kamelets/kafka-scram-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/kafka-scram-source.kamelet.yaml
@@ -143,7 +143,7 @@ spec:
         brokers: "{{?bootstrapServers}}"
         securityProtocol: "{{securityProtocol}}"
         saslMechanism: "{{saslMechanism}}"
-        saslJaasConfig: "org.apache.kafka.common.security.scram.ScramLoginModule required username='{{user}}' password='{{password}}';"
+        saslJaasConfig: 'org.apache.kafka.common.security.scram.ScramLoginModule required username="{{user}}" password="{{password}}";'
         autoCommitEnable: "{{autoCommitEnable}}"
         allowManualCommit: "{{allowManualCommit}}"
         pollOnError: "{{pollOnError}}"

--- a/library/camel-kamelets/src/main/resources/kamelets/kafka-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/kafka-sink.kamelet.yaml
@@ -117,4 +117,4 @@ spec:
             brokers: "{{bootstrapServers}}"
             securityProtocol: "{{securityProtocol}}"
             saslMechanism: "{{saslMechanism}}"
-            saslJaasConfig: "org.apache.kafka.common.security.plain.PlainLoginModule required username='{{user}}' password='{{password}}';"
+            saslJaasConfig: 'org.apache.kafka.common.security.plain.PlainLoginModule required username="{{user}}" password="{{password}}";'

--- a/library/camel-kamelets/src/main/resources/kamelets/kafka-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/kafka-source.kamelet.yaml
@@ -143,7 +143,7 @@ spec:
         brokers: "{{?bootstrapServers}}"
         securityProtocol: "{{securityProtocol}}"
         saslMechanism: "{{saslMechanism}}"
-        saslJaasConfig: "org.apache.kafka.common.security.plain.PlainLoginModule required username='{{user}}' password='{{password}}';"
+        saslJaasConfig: 'org.apache.kafka.common.security.plain.PlainLoginModule required username="{{user}}" password="{{password}}";'
         autoCommitEnable: "{{autoCommitEnable}}"
         allowManualCommit: "{{allowManualCommit}}"
         pollOnError: "{{pollOnError}}"


### PR DESCRIPTION
Fixes #1476