### PR TITLE
Bean: Use properties instead of property with key and value - AWS DDB Sink

### DIFF
--- a/kamelets/aws-ddb-sink.kamelet.yaml
+++ b/kamelets/aws-ddb-sink.kamelet.yaml
@@ -119,13 +119,10 @@ spec:
         type: "#class:org.apache.camel.kamelets.utils.format.DefaultDataTypeRegistry"
       - name: dataTypeProcessor
         type: "#class:org.apache.camel.kamelets.utils.format.DataTypeProcessor"
-        property:
-          - key: scheme
-            value: 'aws2-ddb'
-          - key: format
-            value: 'json'
-          - key: registry
-            value: '#bean:{{dataTypeRegistry}}'
+        properties:
+          scheme: 'aws2-ddb'
+          format: 'json'
+          registry: '#bean:{{dataTypeRegistry}}'
     from:
       uri: "kamelet:source"
       steps:

--- a/library/camel-kamelets/src/main/resources/kamelets/aws-ddb-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/aws-ddb-sink.kamelet.yaml
@@ -119,13 +119,10 @@ spec:
         type: "#class:org.apache.camel.kamelets.utils.format.DefaultDataTypeRegistry"
       - name: dataTypeProcessor
         type: "#class:org.apache.camel.kamelets.utils.format.DataTypeProcessor"
-        property:
-          - key: scheme
-            value: 'aws2-ddb'
-          - key: format
-            value: 'json'
-          - key: registry
-            value: '#bean:{{dataTypeRegistry}}'
+        properties:
+          scheme: 'aws2-ddb'
+          format: 'json'
+          registry: '#bean:{{dataTypeRegistry}}'
     from:
       uri: "kamelet:source"
       steps:


### PR DESCRIPTION
Related to #1475 