### PR TITLE
chore: Improve YAKS tests

### DIFF
--- a/test/earthquake-source/earthquake-source.feature
+++ b/test/earthquake-source/earthquake-source.feature
@@ -25,10 +25,10 @@ Feature: Kamelet earthquake-source
     Given create Kubernetes service test-service with target port 8080
 
   Scenario: Create Kamelet binding
-    When bind Kamelet earthquake-source to uri yaks:resolveURL('test-service')/test
-    And create KameletBinding earthquake-source-uri
-    Then KameletBinding earthquake-source-uri should be available
-    Then Camel K integration earthquake-source-uri should be running
+    Given load KameletBinding earthquake-to-http.yaml
+    Then KameletBinding earthquake-to-http should be available
+    Then Camel K integration earthquake-to-http should be running
+    And Camel K integration earthquake-to-http should print Routes startup
 
   Scenario: Verify binding
     Given expect HTTP request header: Content-Type="application/json;charset=UTF-8"
@@ -36,5 +36,5 @@ Feature: Kamelet earthquake-source
     Then send HTTP 200 OK
 
   Scenario: Remove Camel K resources
-    Given delete KameletBinding earthquake-source-uri
+    Given delete KameletBinding earthquake-to-http
     And delete Kubernetes service test-service

--- a/test/earthquake-source/earthquake-to-http.yaml
+++ b/test/earthquake-source/earthquake-to-http.yaml
@@ -15,28 +15,15 @@
 # limitations under the License.
 # ---------------------------------------------------------------------------
 
-Feature: Timer Source Kamelet
-
-  Background:
-    Given HTTP server timeout is 150000 ms
-    Given HTTP server "test-service"
-
-  Scenario: Create Http server
-    Given create Kubernetes service test-service with target port 8080
-
-  Scenario: Create Kamelet binding
-    And variables
-      | message  | Hello World |
-    Given load KameletBinding timer-to-http.yaml
-    Then KameletBinding timer-to-http should be available
-    Then Camel K integration timer-to-http should be running
-    And Camel K integration timer-to-http should print Routes startup
-
-  Scenario: Verify binding
-    Given expect HTTP request body: Hello World
-    When receive POST /events
-    Then send HTTP 200 OK
-
-  Scenario: Remove Camel K resources
-    Given delete KameletBinding timer-to-http
-    And delete Kubernetes service test-service
+apiVersion: camel.apache.org/v1alpha1
+kind: KameletBinding
+metadata:
+  name: earthquake-to-http
+spec:
+  source:
+    ref:
+      kind: Kamelet
+      apiVersion: camel.apache.org/v1alpha1
+      name: earthquake-source
+  sink:
+    uri: yaks:resolveURL('test-service')/test

--- a/test/earthquake-source/yaks-config.yaml
+++ b/test/earthquake-source/yaks-config.yaml
@@ -32,6 +32,8 @@ config:
           level: INFO
         - name: INTEGRATION_LOGS
           level: INFO
+    resources:
+      - earthquake-to-http.yaml
   dump:
     enabled: true
     failedOnly: true

--- a/test/timer-source/timer-to-http.yaml
+++ b/test/timer-source/timer-to-http.yaml
@@ -15,28 +15,17 @@
 # limitations under the License.
 # ---------------------------------------------------------------------------
 
-Feature: Timer Source Kamelet
-
-  Background:
-    Given HTTP server timeout is 150000 ms
-    Given HTTP server "test-service"
-
-  Scenario: Create Http server
-    Given create Kubernetes service test-service with target port 8080
-
-  Scenario: Create Kamelet binding
-    And variables
-      | message  | Hello World |
-    Given load KameletBinding timer-to-http.yaml
-    Then KameletBinding timer-to-http should be available
-    Then Camel K integration timer-to-http should be running
-    And Camel K integration timer-to-http should print Routes startup
-
-  Scenario: Verify binding
-    Given expect HTTP request body: Hello World
-    When receive POST /events
-    Then send HTTP 200 OK
-
-  Scenario: Remove Camel K resources
-    Given delete KameletBinding timer-to-http
-    And delete Kubernetes service test-service
+apiVersion: camel.apache.org/v1alpha1
+kind: KameletBinding
+metadata:
+  name: timer-to-http
+spec:
+  source:
+    ref:
+      kind: Kamelet
+      apiVersion: camel.apache.org/v1alpha1
+      name: timer-source
+    properties:
+      message: "${message}"
+  sink:
+    uri: yaks:resolveURL('test-service')/events

--- a/test/timer-source/yaks-config.yaml
+++ b/test/timer-source/yaks-config.yaml
@@ -32,6 +32,8 @@ config:
           level: INFO
         - name: INTEGRATION_LOGS
           level: INFO
+    resources:
+      - timer-to-http.yaml
   dump:
     enabled: true
     failedOnly: true


### PR DESCRIPTION
- Use KameletBinding yaml file resource instead of YAKS bind step