### PR TITLE
Support personal token authentication to jira

### DIFF
--- a/kamelets/jira-add-comment-sink.kamelet.yaml
+++ b/kamelets/jira-add-comment-sink.kamelet.yaml
@@ -39,10 +39,10 @@ spec:
 
       The comment is set in the body of the message.
 
+      To authenticate a username/password or personal token must be defined. We recommend to use personal token as it is a safer way to get access to Jira.
+
     required:
       - jiraUrl
-      - username
-      - password
     type: object
     properties:
       jiraUrl:
@@ -58,11 +58,17 @@ spec:
         - urn:camel:group:credentials
       password:
         title: Password
-        description: The password or the API Token to access Jira
+        description: The password to access Jira
         type: string
         format: password
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:password
+        - urn:camel:group:credentials
+      personal-token:
+        title: Personal Token
+        description: Personal Token
+        type: string
+        x-descriptors:
         - urn:camel:group:credentials
   types:
     in:
@@ -88,5 +94,6 @@ spec:
           uri: "jira:AddComment"
           parameters:
             jiraUrl: "{{jiraUrl}}"
-            username: "{{username}}"
-            password: "{{password}}"
+            username: "{{?username}}"
+            password: "{{?password}}"
+            access-token: "{{?personal-token}}"

--- a/kamelets/jira-add-issue-sink.kamelet.yaml
+++ b/kamelets/jira-add-issue-sink.kamelet.yaml
@@ -51,10 +51,10 @@ spec:
 
       The issue description can be set from the body of the message or the `issueDescription`/`ce-issueDescription` in the header, however the body takes precedence.
 
+      To authenticate a username/password or personal token must be defined. We recommend to use personal token as it is a safer way to get access to Jira.
+
     required:
       - jiraUrl
-      - username
-      - password
     type: object
     properties:
       jiraUrl:
@@ -70,11 +70,17 @@ spec:
         - urn:camel:group:credentials
       password:
         title: Password
-        description: The password or the API Token to access Jira
+        description: The password to access Jira
         type: string
         format: password
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:password
+        - urn:camel:group:credentials
+      personal-token:
+        title: Personal Token
+        description: Personal Token
+        type: string
+        x-descriptors:
         - urn:camel:group:credentials
   types:
     in:
@@ -142,5 +148,6 @@ spec:
           uri: "jira:AddIssue"
           parameters:
             jiraUrl: "{{jiraUrl}}"
-            username: "{{username}}"
-            password: "{{password}}"
+            username: "{{?username}}"
+            password: "{{?password}}"
+            access-token: "{{?personal-token}}"

--- a/kamelets/jira-source.kamelet.yaml
+++ b/kamelets/jira-source.kamelet.yaml
@@ -32,10 +32,11 @@ spec:
     title: "Jira Source"
     description: |-
       Receive notifications about new issues from Jira.
+
+      To authenticate a username/password or personal token must be defined. We recommend to use personal token as it is a safer way to get access to Jira.
+
     required:
       - jiraUrl
-      - username
-      - password
     type: object
     properties:
       jiraUrl:
@@ -51,11 +52,17 @@ spec:
         - urn:camel:group:credentials
       password:
         title: Password
-        description: The password or the API Token to access Jira.
+        description: The password to access Jira.
         type: string
         format: password
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:password
+        - urn:camel:group:credentials
+      personal-token:
+        title: Personal Token
+        description: Personal Token
+        type: string
+        x-descriptors:
         - urn:camel:group:credentials
       jql:
         title: JQL
@@ -76,8 +83,9 @@ spec:
       uri: "jira:newIssues"
       parameters:
         jiraUrl: "{{jiraUrl}}"
-        username: "{{username}}"
-        password: "{{password}}"
+        username: "{{?username}}"
+        password: "{{?password}}"
+        accessToken: "{{?personal-token}}"
         jql: "{{jql}}"
       steps:
       - marshal:

--- a/kamelets/jira-transition-issue-sink.kamelet.yaml
+++ b/kamelets/jira-transition-issue-sink.kamelet.yaml
@@ -41,10 +41,10 @@ spec:
 
       The comment of the transition is set in the body of the message.
 
+      To authenticate a username/password or personal token must be defined. We recommend to use personal token as it is a safer way to get access to Jira.
+
     required:
       - jiraUrl
-      - username
-      - password
     type: object
     properties:
       jiraUrl:
@@ -60,11 +60,17 @@ spec:
         - urn:camel:group:credentials
       password:
         title: Password
-        description: The password or the API Token to access Jira
+        description: The password to access Jira
         type: string
         format: password
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:password
+        - urn:camel:group:credentials
+      personal-token:
+        title: Personal Token
+        description: Personal Token
+        type: string
+        x-descriptors:
         - urn:camel:group:credentials
   types:
     in:
@@ -97,5 +103,6 @@ spec:
           uri: "jira:transitionIssue"
           parameters:
             jiraUrl: "{{jiraUrl}}"
-            username: "{{username}}"
-            password: "{{password}}"
+            username: "{{?username}}"
+            password: "{{?password}}"
+            access-token: "{{?personal-token}}"

--- a/kamelets/jira-update-issue-sink.kamelet.yaml
+++ b/kamelets/jira-update-issue-sink.kamelet.yaml
@@ -51,10 +51,10 @@ spec:
 
       The issue description can be set from the body of the message or the `issueDescription`/`ce-issueDescription` in the header, however the body takes precedence.
 
+      To authenticate a username/password or personal token must be defined. We recommend to use personal token as it is a safer way to get access to Jira.
+
     required:
       - jiraUrl
-      - username
-      - password
     type: object
     properties:
       jiraUrl:
@@ -70,11 +70,17 @@ spec:
         - urn:camel:group:credentials
       password:
         title: Password
-        description: The password or the API Token to access Jira
+        description: The password to access Jira
         type: string
         format: password
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:password
+        - urn:camel:group:credentials
+      personal-token:
+        title: Personal Token
+        description: Personal Token
+        type: string
+        x-descriptors:
         - urn:camel:group:credentials
   types:
     in:
@@ -142,5 +148,6 @@ spec:
           uri: "jira:UpdateIssue"
           parameters:
             jiraUrl: "{{jiraUrl}}"
-            username: "{{username}}"
-            password: "{{password}}"
+            username: "{{?username}}"
+            password: "{{?password}}"
+            access-token: "{{?personal-token}}"

--- a/library/camel-kamelets/src/main/resources/kamelets/jira-add-comment-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/jira-add-comment-sink.kamelet.yaml
@@ -39,10 +39,10 @@ spec:
 
       The comment is set in the body of the message.
 
+      To authenticate a username/password or personal token must be defined. We recommend to use personal token as it is a safer way to get access to Jira.
+
     required:
       - jiraUrl
-      - username
-      - password
     type: object
     properties:
       jiraUrl:
@@ -58,11 +58,17 @@ spec:
         - urn:camel:group:credentials
       password:
         title: Password
-        description: The password or the API Token to access Jira
+        description: The password to access Jira
         type: string
         format: password
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:password
+        - urn:camel:group:credentials
+      personal-token:
+        title: Personal Token
+        description: Personal Token
+        type: string
+        x-descriptors:
         - urn:camel:group:credentials
   types:
     in:
@@ -88,5 +94,6 @@ spec:
           uri: "jira:AddComment"
           parameters:
             jiraUrl: "{{jiraUrl}}"
-            username: "{{username}}"
-            password: "{{password}}"
+            username: "{{?username}}"
+            password: "{{?password}}"
+            access-token: "{{?personal-token}}"

--- a/library/camel-kamelets/src/main/resources/kamelets/jira-add-issue-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/jira-add-issue-sink.kamelet.yaml
@@ -51,10 +51,10 @@ spec:
 
       The issue description can be set from the body of the message or the `issueDescription`/`ce-issueDescription` in the header, however the body takes precedence.
 
+      To authenticate a username/password or personal token must be defined. We recommend to use personal token as it is a safer way to get access to Jira.
+
     required:
       - jiraUrl
-      - username
-      - password
     type: object
     properties:
       jiraUrl:
@@ -70,11 +70,17 @@ spec:
         - urn:camel:group:credentials
       password:
         title: Password
-        description: The password or the API Token to access Jira
+        description: The password to access Jira
         type: string
         format: password
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:password
+        - urn:camel:group:credentials
+      personal-token:
+        title: Personal Token
+        description: Personal Token
+        type: string
+        x-descriptors:
         - urn:camel:group:credentials
   types:
     in:
@@ -142,5 +148,6 @@ spec:
           uri: "jira:AddIssue"
           parameters:
             jiraUrl: "{{jiraUrl}}"
-            username: "{{username}}"
-            password: "{{password}}"
+            username: "{{?username}}"
+            password: "{{?password}}"
+            access-token: "{{?personal-token}}"

--- a/library/camel-kamelets/src/main/resources/kamelets/jira-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/jira-source.kamelet.yaml
@@ -32,10 +32,11 @@ spec:
     title: "Jira Source"
     description: |-
       Receive notifications about new issues from Jira.
+
+      To authenticate a username/password or personal token must be defined. We recommend to use personal token as it is a safer way to get access to Jira.
+
     required:
       - jiraUrl
-      - username
-      - password
     type: object
     properties:
       jiraUrl:
@@ -51,11 +52,17 @@ spec:
         - urn:camel:group:credentials
       password:
         title: Password
-        description: The password or the API Token to access Jira.
+        description: The password to access Jira.
         type: string
         format: password
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:password
+        - urn:camel:group:credentials
+      personal-token:
+        title: Personal Token
+        description: Personal Token
+        type: string
+        x-descriptors:
         - urn:camel:group:credentials
       jql:
         title: JQL
@@ -76,8 +83,9 @@ spec:
       uri: "jira:newIssues"
       parameters:
         jiraUrl: "{{jiraUrl}}"
-        username: "{{username}}"
-        password: "{{password}}"
+        username: "{{?username}}"
+        password: "{{?password}}"
+        accessToken: "{{?personal-token}}"
         jql: "{{jql}}"
       steps:
       - marshal:

--- a/library/camel-kamelets/src/main/resources/kamelets/jira-transition-issue-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/jira-transition-issue-sink.kamelet.yaml
@@ -41,10 +41,10 @@ spec:
 
       The comment of the transition is set in the body of the message.
 
+      To authenticate a username/password or personal token must be defined. We recommend to use personal token as it is a safer way to get access to Jira.
+
     required:
       - jiraUrl
-      - username
-      - password
     type: object
     properties:
       jiraUrl:
@@ -60,11 +60,17 @@ spec:
         - urn:camel:group:credentials
       password:
         title: Password
-        description: The password or the API Token to access Jira
+        description: The password to access Jira
         type: string
         format: password
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:password
+        - urn:camel:group:credentials
+      personal-token:
+        title: Personal Token
+        description: Personal Token
+        type: string
+        x-descriptors:
         - urn:camel:group:credentials
   types:
     in:
@@ -97,5 +103,6 @@ spec:
           uri: "jira:transitionIssue"
           parameters:
             jiraUrl: "{{jiraUrl}}"
-            username: "{{username}}"
-            password: "{{password}}"
+            username: "{{?username}}"
+            password: "{{?password}}"
+            access-token: "{{?personal-token}}"

--- a/library/camel-kamelets/src/main/resources/kamelets/jira-update-issue-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/jira-update-issue-sink.kamelet.yaml
@@ -51,10 +51,10 @@ spec:
 
       The issue description can be set from the body of the message or the `issueDescription`/`ce-issueDescription` in the header, however the body takes precedence.
 
+      To authenticate a username/password or personal token must be defined. We recommend to use personal token as it is a safer way to get access to Jira.
+
     required:
       - jiraUrl
-      - username
-      - password
     type: object
     properties:
       jiraUrl:
@@ -70,11 +70,17 @@ spec:
         - urn:camel:group:credentials
       password:
         title: Password
-        description: The password or the API Token to access Jira
+        description: The password to access Jira
         type: string
         format: password
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:password
+        - urn:camel:group:credentials
+      personal-token:
+        title: Personal Token
+        description: Personal Token
+        type: string
+        x-descriptors:
         - urn:camel:group:credentials
   types:
     in:
@@ -142,5 +148,6 @@ spec:
           uri: "jira:UpdateIssue"
           parameters:
             jiraUrl: "{{jiraUrl}}"
-            username: "{{username}}"
-            password: "{{password}}"
+            username: "{{?username}}"
+            password: "{{?password}}"
+            access-token: "{{?personal-token}}"

--- a/library/kamelets-maven-plugin/src/main/java/org/apache/camel/kamelets/maven/plugin/ValidateKameletsMojo.java
+++ b/library/kamelets-maven-plugin/src/main/java/org/apache/camel/kamelets/maven/plugin/ValidateKameletsMojo.java
@@ -17,10 +17,11 @@
 package org.apache.camel.kamelets.maven.plugin;
 
 import java.io.File;
-import java.util.*;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
-
 import org.apache.camel.catalog.DefaultCamelCatalog;
 import org.apache.camel.kamelets.catalog.KameletsCatalog;
 import org.apache.camel.tooling.model.ComponentModel;
@@ -63,8 +64,7 @@ public class ValidateKameletsMojo extends AbstractMojo {
         KameletsCatalog catalog = new KameletsCatalog();
         DefaultCamelCatalog cc = new DefaultCamelCatalog();
         List<String> names = catalog.getKameletsName();
-        for (String name:
-                names) {
+        for (String name: names) {
             Map<String, Object> kd = catalog.getKameletTemplate(name);
             Map<String,Object> f = (Map) kd.get("from");
             Map<String,Object> p = (Map) f.get("parameters");
@@ -100,7 +100,10 @@ public class ValidateKameletsMojo extends AbstractMojo {
                         List<String> ceInternal =
                                 ce.stream()
                                         .map(ComponentModel.EndpointOptionModel::getName)
+                                        .sorted()
                                         .collect(Collectors.toList());
+                        StringBuilder availableParams = new StringBuilder();
+                        ceInternal.forEach(_param -> availableParams.append(_param).append(" "));
                         for (Map.Entry<String, Object> entry : p.entrySet()) {
                             if (!entry.getKey().equals("period") && (!name.equals("set-kafka-key-action") && !name.equals("sftp-source") && !name.equals("kafka-ssl-source") && !name.equals("timer-source") && !name.equals("cron-source") && !name.equals("fhir-source") && !name.equals("beer-source") && !name.equals("cassandra-source") && !name.equals("cassandra-sink"))) {
                                 if (!ceInternal.contains(entry.getKey())) {
@@ -108,6 +111,7 @@ public class ValidateKameletsMojo extends AbstractMojo {
                                     getLog().error("Scheme Name: " + cleanName);
                                     getLog().error("Parameter: " + entry.getKey());
                                     getLog().error("The parameter " + entry.getKey() + " doesn't exist in the endpoint options of " + cleanName + " component");
+                                    getLog().error("Available endpoint options: " + availableParams);
                                     if (failOnError) {
                                         throw new MojoExecutionException("The Kamelets Validation failed. See logs for more information." + "\n");
                                     }


### PR DESCRIPTION
- Fix https://github.com/apache/camel-kamelets/issues/1529
- In case the maven plugin fails to a unknown parameter, list all available endpoint parameters