### PR TITLE
Use https instead of http for maven metadata information of the

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,11 +75,11 @@
         <developer>
             <name>The Apache Camel Team</name>
             <email>dev@camel.apache.org</email>
-            <url>http://camel.apache.org</url>
+            <url>https://camel.apache.org</url>
             <organization>Apache Software Foundation</organization>
-            <organizationUrl>http://apache.org/</organizationUrl>
+            <organizationUrl>https://apache.org/</organizationUrl>
             <properties>
-                <picUrl>http://camel.apache.org/banner.data/apache-camel-7.png</picUrl>
+                <picUrl>https://camel.apache.org/banner.data/apache-camel-7.png</picUrl>
             </properties>
         </developer>
     </developers>


### PR DESCRIPTION
developers