### PR TITLE
Remove mention to SVN in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ export CAMEL_KAMELET_VERSION=x.y.z
 ./mvnw clean install -DreleaseVersion=$CAMEL_KAMELET_VERSION
 ```
 
-Stage the commits in SVN:
+Stage the commits in the Source Version Control:
 
 ```
 git commit -am "Update Kamelets for release $CAMEL_KAMELET_VERSION"


### PR DESCRIPTION
it is now git and no more svn, using the generic terminology Source Version Control to limit need to update it in the future