### PR TITLE
Update GitHub Action version

### DIFF
--- a/.github/workflows/automatic-changelog-update.yml
+++ b/.github/workflows/automatic-changelog-update.yml
@@ -30,7 +30,7 @@ jobs:
     name: Generate changelog for main branch
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           persist-credentials: false
           submodules: recursive

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -28,7 +28,7 @@ jobs:
     name: Backport
     steps:
       - name: "Checkout Camel Kamelets"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           persist-credentials: false
           submodules: recursive

--- a/.github/workflows/java-tests.yaml
+++ b/.github/workflows/java-tests.yaml
@@ -35,7 +35,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           persist-credentials: false
       - name: Set up JDK

--- a/.github/workflows/main-push-regen.yaml
+++ b/.github/workflows/main-push-regen.yaml
@@ -31,7 +31,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           persist-credentials: false
       - name: Set up JDK
@@ -41,7 +41,7 @@ jobs:
           java-version: 17
           cache: 'maven'
       - name: Install Go
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v4
         with:
           go-version: 1.16.x
       - name: Cache Maven Repository

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -45,9 +45,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Install Go
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v4
       with:
         go-version: 1.16.x
     - name: Run Validator


### PR DESCRIPTION
it will avoid this kind of warnings:

The following actions uses node12 which is deprecated and will be forced to run on node16: actions/checkout@v2, actions/setup-go@v1. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/