### PR TITLE
Remove no more needed GitHub actions/cache

### DIFF
--- a/.github/workflows/main-push-regen.yaml
+++ b/.github/workflows/main-push-regen.yaml
@@ -44,12 +44,6 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: 1.16.x
-      - name: Cache Maven Repository
-        uses: actions/cache@v1
-        with:
-          path: ~/.m2
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2
       - name: Build catalog 1st Run
         run: ./mvnw clean install -DskipTests
       - name: Build catalog 2nd Run


### PR DESCRIPTION
the cache for Maven is now built-in with actions/setup-java@v3

it will also avoid warning: `The following actions uses node12 which is
deprecated and will be forced to run on node16: actions/cache@v1 For
more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/`