### PR TITLE
chore(docs): attempt to fix website failure

### DIFF
--- a/library/camel-kamelets/src/main/resources/kamelets/simple-filter-action.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/simple-filter-action.kamelet.yaml
@@ -38,7 +38,7 @@ spec:
         title: Simple Expression
         description: A simple expression to apply on the exchange to filter out some exchange
         type: string
-        example: "${body} contains 'John'"
+        example: "$\{body} contains 'John'"
     type: object
   dependencies:
   - "camel:core"


### PR DESCRIPTION
Ref error https://github.com/apache/camel-website/actions/runs/6073382492
```
➤ YN0000: [build:antora  ] [build:antora-perf] [12:56:31.445] WARN (asciidoctor): skipping reference to missing attribute: body
➤ YN0000: [build:antora  ] [build:antora-perf]     file: modules/ROOT/examples/yaml/simple-filter-action.kamelet.yaml
```
This is not a final patch, as I think the library is regenerated automatically. However, it's an attempt to verify if the changes applied would fix the problem. If this solution works, we need eventually to include a replacements for all variables we find, probably in this place https://github.com/apache/camel-kamelets/blob/aaaa88092ba36d6d121e91d7c6ffb1f076c7b67c/docs/modules/ROOT/examples/template/kamelet-options.adoc?plain=1#L87