### PR TITLE
chore(docs): escape variable to prevent site failure

### DIFF
--- a/kamelets/simple-filter-action.kamelet.yaml
+++ b/kamelets/simple-filter-action.kamelet.yaml
@@ -38,7 +38,7 @@ spec:
         title: Simple Expression
         description: A simple expression to apply on the exchange to filter out some exchange
         type: string
-        example: "${body} contains 'John'"
+        example: "$\{body} contains 'John'"
     type: object
   dependencies:
   - "camel:core"


### PR DESCRIPTION
The problem is described in #1609. Likely this one solves, but we need to verify if the added character will render in the visualization as well. In such case, we need to change the template with a replacement as suggested in #1609.