### PR TITLE
fix(ci): remove example breaking site

### DIFF
--- a/kamelets/simple-filter-action.kamelet.yaml
+++ b/kamelets/simple-filter-action.kamelet.yaml
@@ -38,7 +38,6 @@ spec:
         title: Simple Expression
         description: A simple expression to apply on the exchange to filter out some exchange
         type: string
-        example: "${body} contains 'John'"
     type: object
   dependencies:
   - "camel:core"


### PR DESCRIPTION
We need to find a way to include  ${} chars which is giving a warning in the website generation.