### PR TITLE
Enhance application-x-struct data type

### DIFF
--- a/library/camel-kamelets-utils/src/main/java/org/apache/camel/kamelets/utils/format/converter/json/JsonStructDataType.java
+++ b/library/camel-kamelets-utils/src/main/java/org/apache/camel/kamelets/utils/format/converter/json/JsonStructDataType.java
@@ -20,6 +20,7 @@ package org.apache.camel.kamelets.utils.format.converter.json;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import org.apache.camel.CamelExecutionException;
@@ -50,6 +51,10 @@ public class JsonStructDataType extends Transformer {
     }
 
     private InputStream getBodyAsStream(Message message) throws InvalidPayloadException {
+        if (message.getBody() == null) {
+            return new ByteArrayInputStream("{}".getBytes(StandardCharsets.UTF_8));
+        }
+
         InputStream bodyStream = message.getBody(InputStream.class);
 
         if (bodyStream == null) {


### PR DESCRIPTION
- Support empty message body value and initialize the application-x-struct data type with empty JsonNode {} value
- Allows follow-up action Kamelets such as insert-field-action to add more fields to the empty JsonNode body

Example:

1. webhook-source creates empty message body
2. application-x-struct data-type used as output data type initializes empty JsonNode
3. insert-field action Kamelet uses header fields to set fields on the JsonNode
4. Json struct gets serialized to String value as outcome