### PR TITLE
chore: Fix JitPack build for main branch

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,2 +1,2 @@
 jdk:
-  - openjdk11
+  - openjdk17


### PR DESCRIPTION
- Use JDK17 for JitPack builds
- Should fix main-SNAPSHOT builds for JitPack