### PR TITLE
chore: Fix YAKS tests for 4.2.0-SNAPSHOT

### DIFF
--- a/.github/workflows/yaks-tests.yaml
+++ b/.github/workflows/yaks-tests.yaml
@@ -41,7 +41,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  YAKS_VERSION: 0.16.0
+  YAKS_VERSION: 0.17.0
 
 jobs:
   test:

--- a/kamelets/aws-s3-sink.kamelet.yaml
+++ b/kamelets/aws-s3-sink.kamelet.yaml
@@ -96,6 +96,13 @@ spec:
         x-descriptors:
           - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
+      forcePathStyle:
+        title: Force Path Style
+        description: Forces path style when accessing AWS S3 buckets.
+        type: boolean
+        x-descriptors:
+          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+        default: false
       keyName:
         title: Key Name
         description: The key name for saving an element in the bucket.
@@ -113,7 +120,7 @@ spec:
           when:
             - simple: '${propertiesExist:!keyName}'
               steps:
-                - choice:   
+                - choice:
                     when:
                       - simple: "${header[file]}"
                         steps:
@@ -140,4 +147,5 @@ spec:
             useDefaultCredentialsProvider: "{{useDefaultCredentialsProvider}}"
             uriEndpointOverride: "{{?uriEndpointOverride}}"
             overrideEndpoint: "{{overrideEndpoint}}"
+            forcePathStyle: "{{forcePathStyle}}"
             keyName: "{{?keyName}}"

--- a/kamelets/aws-s3-source.kamelet.yaml
+++ b/kamelets/aws-s3-source.kamelet.yaml
@@ -96,6 +96,13 @@ spec:
         x-descriptors:
           - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
+      forcePathStyle:
+        title: Force Path Style
+        description: Forces path style when accessing AWS S3 buckets.
+        type: boolean
+        x-descriptors:
+          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+        default: false
       delay:
         title: Delay
         description: The number of milliseconds before the next poll of the selected bucket.
@@ -188,6 +195,7 @@ spec:
         useDefaultCredentialsProvider: "{{useDefaultCredentialsProvider}}"
         uriEndpointOverride: "{{?uriEndpointOverride}}"
         overrideEndpoint: "{{overrideEndpoint}}"
+        forcePathStyle: "{{forcePathStyle}}"
         delay: "{{delay}}"
         maxMessagesPerPoll: "{{maxMessagesPerPoll}}"
       steps:

--- a/kamelets/aws-s3-streaming-upload-sink.kamelet.yaml
+++ b/kamelets/aws-s3-streaming-upload-sink.kamelet.yaml
@@ -99,7 +99,7 @@ spec:
         description: The naming strategy to use in streaming upload mode. There are 2 enums and the value can be one of progressive, random
         type: string
         default: "progressive"
-      keyName: 
+      keyName:
         title: Key Name
         description: Setting the key name for an element in the bucket through endpoint parameter. In Streaming Upload, with the default configuration, this will be the base for the progressive creation of files.
         type: string
@@ -117,6 +117,13 @@ spec:
       overrideEndpoint:
         title: Endpoint Overwrite
         description: Select this option to override the endpoint URI. To use this option, you must also provide a URI for the `uriEndpointOverride` option.
+        type: boolean
+        x-descriptors:
+          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+        default: false
+      forcePathStyle:
+        title: Force Path Style
+        description: Forces path style when accessing AWS S3 buckets.
         type: boolean
         x-descriptors:
           - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
@@ -145,3 +152,4 @@ spec:
             useDefaultCredentialsProvider: "{{useDefaultCredentialsProvider}}"
             uriEndpointOverride: "{{?uriEndpointOverride}}"
             overrideEndpoint: "{{overrideEndpoint}}"
+            forcePathStyle: "{{forcePathStyle}}"

--- a/library/camel-kamelets/src/main/resources/kamelets/aws-s3-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/aws-s3-sink.kamelet.yaml
@@ -96,6 +96,13 @@ spec:
         x-descriptors:
           - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
+      forcePathStyle:
+        title: Force Path Style
+        description: Forces path style when accessing AWS S3 buckets.
+        type: boolean
+        x-descriptors:
+          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+        default: false
       keyName:
         title: Key Name
         description: The key name for saving an element in the bucket.
@@ -113,7 +120,7 @@ spec:
           when:
             - simple: '${propertiesExist:!keyName}'
               steps:
-                - choice:   
+                - choice:
                     when:
                       - simple: "${header[file]}"
                         steps:
@@ -140,4 +147,5 @@ spec:
             useDefaultCredentialsProvider: "{{useDefaultCredentialsProvider}}"
             uriEndpointOverride: "{{?uriEndpointOverride}}"
             overrideEndpoint: "{{overrideEndpoint}}"
+            forcePathStyle: "{{forcePathStyle}}"
             keyName: "{{?keyName}}"

--- a/library/camel-kamelets/src/main/resources/kamelets/aws-s3-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/aws-s3-source.kamelet.yaml
@@ -96,6 +96,13 @@ spec:
         x-descriptors:
           - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
+      forcePathStyle:
+        title: Force Path Style
+        description: Forces path style when accessing AWS S3 buckets.
+        type: boolean
+        x-descriptors:
+          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+        default: false
       delay:
         title: Delay
         description: The number of milliseconds before the next poll of the selected bucket.
@@ -188,6 +195,7 @@ spec:
         useDefaultCredentialsProvider: "{{useDefaultCredentialsProvider}}"
         uriEndpointOverride: "{{?uriEndpointOverride}}"
         overrideEndpoint: "{{overrideEndpoint}}"
+        forcePathStyle: "{{forcePathStyle}}"
         delay: "{{delay}}"
         maxMessagesPerPoll: "{{maxMessagesPerPoll}}"
       steps:

--- a/library/camel-kamelets/src/main/resources/kamelets/aws-s3-streaming-upload-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/aws-s3-streaming-upload-sink.kamelet.yaml
@@ -99,7 +99,7 @@ spec:
         description: The naming strategy to use in streaming upload mode. There are 2 enums and the value can be one of progressive, random
         type: string
         default: "progressive"
-      keyName: 
+      keyName:
         title: Key Name
         description: Setting the key name for an element in the bucket through endpoint parameter. In Streaming Upload, with the default configuration, this will be the base for the progressive creation of files.
         type: string
@@ -117,6 +117,13 @@ spec:
       overrideEndpoint:
         title: Endpoint Overwrite
         description: Select this option to override the endpoint URI. To use this option, you must also provide a URI for the `uriEndpointOverride` option.
+        type: boolean
+        x-descriptors:
+          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+        default: false
+      forcePathStyle:
+        title: Force Path Style
+        description: Forces path style when accessing AWS S3 buckets.
         type: boolean
         x-descriptors:
           - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
@@ -145,3 +152,4 @@ spec:
             useDefaultCredentialsProvider: "{{useDefaultCredentialsProvider}}"
             uriEndpointOverride: "{{?uriEndpointOverride}}"
             overrideEndpoint: "{{overrideEndpoint}}"
+            forcePathStyle: "{{forcePathStyle}}"

--- a/test/Makefile
+++ b/test/Makefile
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 camel-version := 4.1.0
-camel-kamelets-version := 4.1.0-SNAPSHOT
+camel-kamelets-version := 4.2.0-SNAPSHOT
 kamelets-local-dir := ../../../kamelets
 test := .
 

--- a/test/aws-ddb-sink/verifyItems.groovy
+++ b/test/aws-ddb-sink/verifyItems.groovy
@@ -17,13 +17,13 @@
 
 $(repeatOnError()
     .until('i > ${maxRetryAttempts}')
-    .actions(new com.consol.citrus.TestAction() {
+    .actions(new org.citrusframework.TestAction() {
         @Override
-        void execute(com.consol.citrus.context.TestContext context) {
+        void execute(org.citrusframework.context.TestContext context) {
             try {
                 assert context.getVariable('aws.ddb.items').equals(amazonDDBClient.scan(b -> b.tableName(context.getVariable('aws.ddb.tableName')))?.items()?.toListString())
             } catch (AssertionError e) {
-                throw new com.consol.citrus.exceptions.CitrusRuntimeException("AWS DDB item verification failed", e)
+                throw new org.citrusframework.exceptions.CitrusRuntimeException("AWS DDB item verification failed", e)
             }
         }
     })

--- a/test/aws-ddb-sink/yaks-config.yaml
+++ b/test/aws-ddb-sink/yaks-config.yaml
@@ -51,13 +51,13 @@ config:
       dependencies:
         - groupId: org.apache.camel
           artifactId: camel-aws2-ddb
-          version: "@camel.version@"
+          version: "4.1.0"
         - groupId: software.amazon.awssdk
           artifactId: dynamodb
-          version: "@aws-java-sdk2.version@"
+          version: "2.21.2"
         - groupId: org.apache.camel
           artifactId: camel-jackson
-          version: "@camel.version@"
+          version: "4.1.0"
   dump:
     enabled: true
     failedOnly: true

--- a/test/aws-s3/amazonS3Client.groovy
+++ b/test/aws-s3/amazonS3Client.groovy
@@ -22,12 +22,13 @@ import software.amazon.awssdk.services.s3.S3Client
 
 S3Client s3 = S3Client
         .builder()
-        .endpointOverride(URI.create("${YAKS_TESTCONTAINERS_LOCALSTACK_S3_LOCAL_URL}".replace('localhost', '127.0.0.1')))
+        .endpointOverride(URI.create("${YAKS_TESTCONTAINERS_LOCALSTACK_S3_URL}"))
         .credentialsProvider(StaticCredentialsProvider.create(
                 AwsBasicCredentials.create(
                         "${YAKS_TESTCONTAINERS_LOCALSTACK_ACCESS_KEY}",
                         "${YAKS_TESTCONTAINERS_LOCALSTACK_SECRET_KEY}")
         ))
+        .forcePathStyle(true)
         .region(Region.of("${YAKS_TESTCONTAINERS_LOCALSTACK_REGION}"))
         .build()
 

--- a/test/aws-s3/aws-s3-credentials.properties
+++ b/test/aws-s3/aws-s3-credentials.properties
@@ -1,6 +1,7 @@
 # Please add your AWS S3 account credentials
 camel.kamelet.aws-s3-source.aws-s3-credentials.bucketNameOrArn=${aws.s3.bucketNameOrArn}
 camel.kamelet.aws-s3-source.aws-s3-credentials.overrideEndpoint=true
+camel.kamelet.aws-s3-source.aws-s3-credentials.forcePathStyle=true
 camel.kamelet.aws-s3-source.aws-s3-credentials.uriEndpointOverride=${YAKS_TESTCONTAINERS_LOCALSTACK_S3_URL}
 camel.kamelet.aws-s3-source.aws-s3-credentials.secretKey=${YAKS_TESTCONTAINERS_LOCALSTACK_SECRET_KEY}
 camel.kamelet.aws-s3-source.aws-s3-credentials.accessKey=${YAKS_TESTCONTAINERS_LOCALSTACK_ACCESS_KEY}

--- a/test/aws-s3/aws-s3-to-http.yaml
+++ b/test/aws-s3/aws-s3-to-http.yaml
@@ -31,6 +31,7 @@ spec:
     properties:
       bucketNameOrArn: ${aws.s3.bucketNameOrArn}
       overrideEndpoint: true
+      forcePathStyle: true
       uriEndpointOverride: ${YAKS_TESTCONTAINERS_LOCALSTACK_S3_URL}
       accessKey: ${YAKS_TESTCONTAINERS_LOCALSTACK_ACCESS_KEY}
       secretKey: ${YAKS_TESTCONTAINERS_LOCALSTACK_SECRET_KEY}

--- a/test/aws-s3/aws-s3-to-knative-broker.yaml
+++ b/test/aws-s3/aws-s3-to-knative-broker.yaml
@@ -28,6 +28,7 @@ spec:
     properties:
       bucketNameOrArn: ${aws.s3.bucketNameOrArn}
       overrideEndpoint: true
+      forcePathStyle: true
       uriEndpointOverride: ${YAKS_TESTCONTAINERS_LOCALSTACK_S3_URL}
       accessKey: ${YAKS_TESTCONTAINERS_LOCALSTACK_ACCESS_KEY}
       secretKey: ${YAKS_TESTCONTAINERS_LOCALSTACK_SECRET_KEY}

--- a/test/aws-s3/aws-s3-to-knative-channel.yaml
+++ b/test/aws-s3/aws-s3-to-knative-channel.yaml
@@ -28,6 +28,7 @@ spec:
     properties:
       bucketNameOrArn: ${aws.s3.bucketNameOrArn}
       overrideEndpoint: true
+      forcePathStyle: true
       uriEndpointOverride: ${YAKS_TESTCONTAINERS_LOCALSTACK_S3_URL}
       accessKey: ${YAKS_TESTCONTAINERS_LOCALSTACK_ACCESS_KEY}
       secretKey: ${YAKS_TESTCONTAINERS_LOCALSTACK_SECRET_KEY}

--- a/test/aws-s3/aws-s3-to-log-uri-based.groovy
+++ b/test/aws-s3/aws-s3-to-log-uri-based.groovy
@@ -19,6 +19,7 @@
 
 def parameters = 'bucketNameOrArn=${aws.s3.bucketNameOrArn}&'+
                  'overrideEndpoint=true&' +
+                 'forcePathStyle=true&' +
                  'uriEndpointOverride=${YAKS_TESTCONTAINERS_LOCALSTACK_S3_URL}&' +
                  'accessKey=${YAKS_TESTCONTAINERS_LOCALSTACK_ACCESS_KEY}&' +
                  'secretKey=${YAKS_TESTCONTAINERS_LOCALSTACK_SECRET_KEY}&'+

--- a/test/aws-s3/aws-s3-uri-pipe.yaml
+++ b/test/aws-s3/aws-s3-uri-pipe.yaml
@@ -28,6 +28,7 @@ spec:
     properties:
       bucketNameOrArn: ${aws.s3.bucketNameOrArn}
       overrideEndpoint: true
+      forcePathStyle: true
       uriEndpointOverride: ${YAKS_TESTCONTAINERS_LOCALSTACK_S3_URL}
       accessKey: ${YAKS_TESTCONTAINERS_LOCALSTACK_ACCESS_KEY}
       secretKey: ${YAKS_TESTCONTAINERS_LOCALSTACK_SECRET_KEY}

--- a/test/aws-s3/yaks-config.yaml
+++ b/test/aws-s3/yaks-config.yaml
@@ -60,13 +60,13 @@ config:
       dependencies:
         - groupId: org.apache.camel
           artifactId: camel-aws2-s3
-          version: "@camel.version@"
+          version: "4.1.0"
         - groupId: software.amazon.awssdk
           artifactId: s3
-          version: "@aws-java-sdk2.version@"
+          version: "2.21.2"
         - groupId: org.apache.camel
           artifactId: camel-jackson
-          version: "@camel.version@"
+          version: "4.1.0"
   dump:
     enabled: true
     failedOnly: true

--- a/test/mail-sink/mail-server.groovy
+++ b/test/mail-sink/mail-server.groovy
@@ -20,4 +20,5 @@ System.properties['citrus.mail.marshaller.type'] = "JSON"
 mail()
   .server('mail-server')
   .port(22222)
+  .knownUsers(['${email}:${username}:${password}'])
   .autoStart(true)

--- a/test/mail-sink/mail-sink.feature
+++ b/test/mail-sink/mail-sink.feature
@@ -23,8 +23,8 @@ Feature: Mail Sink
       | port      | yaks:env('MAIL_SERVICE_PORT','22222') |
       | username  | test |
       | password  | secret |
-      | from      | user@demo.yaks |
-      | to        | announcements@demo.yaks |
+      | email     | user@demo.org |
+      | to        | announcements@demo.org |
       | subject   | Kamelet workshop |
       | message   | Camel K rocks |
 
@@ -44,7 +44,7 @@ Feature: Mail Sink
     Then endpoint mail-server should receive body
     """
     {
-      "from": "${from}",
+      "from": "${email}",
       "to": "${to}",
       "cc": "",
       "bcc": "",

--- a/test/mail-sink/timer-to-mail.yaml
+++ b/test/mail-sink/timer-to-mail.yaml
@@ -37,6 +37,6 @@ spec:
       connectionPort: "${port}"
       username: "${username}"
       password: "${password}"
-      from: "${from}"
+      from: "${email}"
       to: "${to}"
       subject: "${subject}"

--- a/test/mail-sink/yaks-config.yaml
+++ b/test/mail-sink/yaks-config.yaml
@@ -35,7 +35,7 @@ config:
       dependencies:
         - groupId: org.citrusframework
           artifactId: citrus-mail
-          version: "@citrus.version@"
+          version: "4.0.0"
     resources:
       - mail-server.groovy
       - timer-to-mail.yaml

--- a/test/mail-sink/yaks-config.yaml
+++ b/test/mail-sink/yaks-config.yaml
@@ -33,7 +33,7 @@ config:
         - name: INTEGRATION_LOGS
           level: INFO
       dependencies:
-        - groupId: com.consol.citrus
+        - groupId: org.citrusframework
           artifactId: citrus-mail
           version: "@citrus.version@"
     resources:


### PR DESCRIPTION
[chore: Fix YAKS tests](https://github.com/apache/camel-kamelets/commit/9824072d459a8dd5a8a4d17c07cb04533ccd790d)
- Use 4.2.0-SNAPSHOT version in camel-kamelets-version
- Update to YAKS 0.17.0
- Update to Citrus 4.0.0

[chore: Add forcePathStyle option to aws-s3 Kamelets](https://github.com/apache/camel-kamelets/commit/a9355ddf41e8131090313a021287894705f7dd31)
- Since Apache Camel 4 the aws-s3 component supports to force the path style when accessing buckets on AWS S3
- Path style access is essential when testing with local AWS S3 instances such as LocalStack