### PR TITLE
Remove tectonic ui metadata

### DIFF
--- a/kamelets/avro-deserialize-action.kamelet.yaml
+++ b/kamelets/avro-deserialize-action.kamelet.yaml
@@ -45,7 +45,6 @@ spec:
         type: boolean
         default: true
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
   dependencies:
   - "camel:kamelet"
   - "camel:core"

--- a/kamelets/avro-deserialize-action.kamelet.yaml
+++ b/kamelets/avro-deserialize-action.kamelet.yaml
@@ -44,7 +44,6 @@ spec:
         description: Indicates if the content must be validated against the schema
         type: boolean
         default: true
-        x-descriptors:
   dependencies:
   - "camel:kamelet"
   - "camel:core"

--- a/kamelets/avro-serialize-action.kamelet.yaml
+++ b/kamelets/avro-serialize-action.kamelet.yaml
@@ -45,7 +45,6 @@ spec:
         type: boolean
         default: true
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
   dependencies:
   - "camel:kamelet"
   - "camel:core"

--- a/kamelets/avro-serialize-action.kamelet.yaml
+++ b/kamelets/avro-serialize-action.kamelet.yaml
@@ -44,7 +44,6 @@ spec:
         description: Indicates if the content must be validated against the schema
         type: boolean
         default: true
-        x-descriptors:
   dependencies:
   - "camel:kamelet"
   - "camel:core"

--- a/kamelets/aws-cloudtrail-source.kamelet.yaml
+++ b/kamelets/aws-cloudtrail-source.kamelet.yaml
@@ -28,7 +28,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       secretKey:
         title: Secret Key
@@ -36,7 +35,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       region:
         title: AWS Region
@@ -48,7 +46,6 @@ spec:
         description: If true, the Cloudtrail client loads credentials through a default credentials provider. If false, it uses the basic authentication method (access key and secret key).
         type: boolean
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
       uriEndpointOverride:
         title: Overwrite Endpoint URI
@@ -59,7 +56,6 @@ spec:
         description: Select this option to override the endpoint URI. To use this option, you must also provide a URI for the `uriEndpointOverride` option.
         type: boolean
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
       maxResults:
         title: Max Results

--- a/kamelets/aws-cloudwatch-sink.kamelet.yaml
+++ b/kamelets/aws-cloudwatch-sink.kamelet.yaml
@@ -61,7 +61,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       secretKey:
         title: Secret Key
@@ -69,7 +68,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       region:
         title: AWS Region
@@ -81,7 +79,6 @@ spec:
         description: If true, the CloudWatch client loads credentials through a default credentials provider. If false, it uses the basic authentication method (access key and secret key).
         type: boolean
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
       uriEndpointOverride:
         title: Overwrite Endpoint URI
@@ -92,7 +89,6 @@ spec:
         description: Select this option to override the endpoint URI. To use this option, you must also provide a URI for the `uriEndpointOverride` option.
         type: boolean
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
   dependencies:
     - "camel:core"

--- a/kamelets/aws-ddb-sink.kamelet.yaml
+++ b/kamelets/aws-ddb-sink.kamelet.yaml
@@ -65,7 +65,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       secretKey:
         title: Secret Key
@@ -73,7 +72,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       region:
         title: AWS Region
@@ -92,7 +90,6 @@ spec:
         description: If true, the DynamoDB client loads credentials through a default credentials provider. If false, it uses the basic authentication method (access key and secret key).
         type: boolean
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
       uriEndpointOverride:
         title: Overwrite Endpoint URI
@@ -103,7 +100,6 @@ spec:
         description: Select this option to override the endpoint URI. To use this option, you must also provide a URI for the `uriEndpointOverride` option.
         type: boolean
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
   dataTypes:
     in:

--- a/kamelets/aws-ddb-streams-source.kamelet.yaml
+++ b/kamelets/aws-ddb-streams-source.kamelet.yaml
@@ -52,7 +52,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       secretKey:
         title: Secret Key
@@ -60,7 +59,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       region:
         title: AWS Region
@@ -77,7 +75,6 @@ spec:
         description: If true, the DynamoDB client loads credentials through a default credentials provider. If false, it uses the basic authentication method (access key and secret key).
         type: boolean
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
       uriEndpointOverride:
         title: Overwrite Endpoint URI
@@ -88,7 +85,6 @@ spec:
         description: Select this option to override the endpoint URI. To use this option, you must also provide a URI for the `uriEndpointOverride` option.
         type: boolean
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
       delay:
         title: Delay

--- a/kamelets/aws-ec2-sink.kamelet.yaml
+++ b/kamelets/aws-ec2-sink.kamelet.yaml
@@ -51,7 +51,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       secretKey:
         title: Secret Key
@@ -59,7 +58,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       region:
         title: AWS Region
@@ -71,7 +69,6 @@ spec:
         description: If true, the CloudWatch client loads credentials through a default credentials provider. If false, it uses the basic authentication method (access key and secret key).
         type: boolean
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
       uriEndpointOverride:
         title: Overwrite Endpoint URI
@@ -82,7 +79,6 @@ spec:
         description: Select this option to override the endpoint URI. To use this option, you must also provide a URI for the `uriEndpointOverride` option.
         type: boolean
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
   dependencies:
     - "camel:core"

--- a/kamelets/aws-eventbridge-sink.kamelet.yaml
+++ b/kamelets/aws-eventbridge-sink.kamelet.yaml
@@ -60,7 +60,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       secretKey:
         title: Secret Key
@@ -68,7 +67,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       region:
         title: AWS Region
@@ -80,7 +78,6 @@ spec:
         description: If true, the Eventbridge client loads credentials through a default credentials provider. If false, it uses the basic authentication method (access key and secret key).
         type: boolean
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
       uriEndpointOverride:
         title: Overwrite Endpoint URI
@@ -91,7 +88,6 @@ spec:
         description: Select this option to override the endpoint URI. To use this option, you must also provide a URI for the `uriEndpointOverride` option.
         type: boolean
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
   dependencies:
     - "camel:core"

--- a/kamelets/aws-kinesis-firehose-sink.kamelet.yaml
+++ b/kamelets/aws-kinesis-firehose-sink.kamelet.yaml
@@ -52,7 +52,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       secretKey:
         title: Secret Key
@@ -60,7 +59,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       region:
         title: AWS Region
@@ -72,7 +70,6 @@ spec:
         description: Set whether the Kinesis Firehose client should expect to load credentials through a default credentials provider or to expect static credentials to be passed in.
         type: boolean
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
       uriEndpointOverride:
         title: Overwrite Endpoint URI
@@ -83,7 +80,6 @@ spec:
         description: Select this option to override the endpoint URI. To use this option, you must also provide a URI for the `uriEndpointOverride` option.
         type: boolean
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
   dependencies:
     - "camel:aws2-kinesis"

--- a/kamelets/aws-kinesis-sink.kamelet.yaml
+++ b/kamelets/aws-kinesis-sink.kamelet.yaml
@@ -59,7 +59,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       secretKey:
         title: Secret Key
@@ -67,7 +66,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       region:
         title: AWS Region
@@ -79,7 +77,6 @@ spec:
         description: If true, the Kinesis client loads credentials through a default credentials provider. If false, it uses the basic authentication method (access key and secret key).
         type: boolean
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
       uriEndpointOverride:
         title: Overwrite Endpoint URI
@@ -90,7 +87,6 @@ spec:
         description: Select this option to override the endpoint URI. To use this option, you must also provide a URI for the `uriEndpointOverride` option.
         type: boolean
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
   types:
     in:

--- a/kamelets/aws-kinesis-source.kamelet.yaml
+++ b/kamelets/aws-kinesis-source.kamelet.yaml
@@ -54,7 +54,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       secretKey:
         title: Secret Key
@@ -62,7 +61,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       region:
         title: AWS Region
@@ -74,7 +72,6 @@ spec:
         description: If true, the Kinesis client loads credentials through a default credentials provider. If false, it uses the basic authentication method (access key and secret key).
         type: boolean
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
       uriEndpointOverride:
         title: Overwrite Endpoint URI
@@ -85,7 +82,6 @@ spec:
         description: Select this option to override the endpoint URI. To use this option, you must also provide a URI for the `uriEndpointOverride` option.
         type: boolean
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
       delay:
         title: Delay

--- a/kamelets/aws-lambda-sink.kamelet.yaml
+++ b/kamelets/aws-lambda-sink.kamelet.yaml
@@ -52,7 +52,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       secretKey:
         title: Secret Key
@@ -60,7 +59,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       region:
         title: AWS Region
@@ -72,7 +70,6 @@ spec:
         description: If true, the Lambda client loads credentials through a default credentials provider. If false, it uses the basic authentication method (access key and secret key).
         type: boolean
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
   dependencies:
     - "camel:aws2-lambda"

--- a/kamelets/aws-redshift-sink.kamelet.yaml
+++ b/kamelets/aws-redshift-sink.kamelet.yaml
@@ -70,7 +70,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       query:
         title: Query

--- a/kamelets/aws-redshift-source.kamelet.yaml
+++ b/kamelets/aws-redshift-source.kamelet.yaml
@@ -62,7 +62,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       query:
         title: Query

--- a/kamelets/aws-s3-cdc-source.kamelet.yaml
+++ b/kamelets/aws-s3-cdc-source.kamelet.yaml
@@ -41,7 +41,6 @@ spec:
         description: Delete messages after consuming them
         type: boolean
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: true
       accessKey:
         title: Access Key
@@ -49,7 +48,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:password'
           - 'urn:camel:group:credentials'
           - 'urn:keda:authentication:awsAccessKeyID'
           - 'urn:keda:required'
@@ -59,7 +57,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:password'
           - 'urn:camel:group:credentials'
           - 'urn:keda:authentication:awsSecretAccessKey'
           - 'urn:keda:required'
@@ -111,7 +108,6 @@ spec:
         description: Setting the autocreation of the SQS queue.
         type: boolean
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
       amazonAWSHost:
         title: AWS Host
@@ -144,7 +140,6 @@ spec:
           you must also provide a URI for the `uriEndpointOverride` option.
         type: boolean
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
       delay:
         title: Delay
@@ -158,7 +153,6 @@ spec:
           if the previous run polled 1 or more messages.
         type: boolean
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
       getObject:
         title: Greedy Object in Bucket
@@ -167,7 +161,6 @@ spec:
           get and returned as body, if not only the event will returned as body.
         type: boolean
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
   dependencies:
     - 'camel:core'

--- a/kamelets/aws-s3-sink.kamelet.yaml
+++ b/kamelets/aws-s3-sink.kamelet.yaml
@@ -56,7 +56,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       secretKey:
         title: Secret Key
@@ -64,7 +63,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       region:
         title: AWS Region
@@ -76,14 +74,12 @@ spec:
         description: Specifies to automatically create the S3 bucket.
         type: boolean
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
       useDefaultCredentialsProvider:
         title: Default Credentials Provider
         description: If true, the S3 client loads credentials through a default credentials provider. If false, it uses the basic authentication method (access key and secret key).
         type: boolean
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
       uriEndpointOverride:
         title: Overwrite Endpoint URI
@@ -94,14 +90,12 @@ spec:
         description: Select this option to override the endpoint URI. To use this option, you must also provide a URI for the `uriEndpointOverride` option.
         type: boolean
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
       forcePathStyle:
         title: Force Path Style
         description: Forces path style when accessing AWS S3 buckets.
         type: boolean
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
       keyName:
         title: Key Name

--- a/kamelets/aws-s3-source.kamelet.yaml
+++ b/kamelets/aws-s3-source.kamelet.yaml
@@ -36,7 +36,6 @@ spec:
         description: Specifies to delete objects after consuming them.
         type: boolean
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: true
       accessKey:
         title: Access Key
@@ -44,7 +43,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       secretKey:
         title: Secret Key
@@ -52,7 +50,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       region:
         title: AWS Region
@@ -64,7 +61,6 @@ spec:
         description: Specifies to automatically create the S3 bucket.
         type: boolean
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
       prefix:
         title: Prefix
@@ -76,14 +72,12 @@ spec:
         description: If true, the S3 Object body is ignored. Setting this to true overrides any behavior defined by the `includeBody` option. If false, the S3 object is put in the body.
         type: boolean
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
       useDefaultCredentialsProvider:
         title: Default Credentials Provider
         description: If true, the S3 client loads credentials through a default credentials provider. If false, it uses the basic authentication method (access key and secret key).
         type: boolean
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
       uriEndpointOverride:
         title: Overwrite Endpoint URI
@@ -94,14 +88,12 @@ spec:
         description: Select this option to override the endpoint URI. To use this option, you must also provide a URI for the `uriEndpointOverride` option.
         type: boolean
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
       forcePathStyle:
         title: Force Path Style
         description: Forces path style when accessing AWS S3 buckets.
         type: boolean
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
       delay:
         title: Delay

--- a/kamelets/aws-s3-streaming-upload-sink.kamelet.yaml
+++ b/kamelets/aws-s3-streaming-upload-sink.kamelet.yaml
@@ -53,7 +53,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       secretKey:
         title: Secret Key
@@ -61,7 +60,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       region:
         title: AWS Region
@@ -73,7 +71,6 @@ spec:
         description: Setting the autocreation of the S3 bucket bucketName.
         type: boolean
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
       restartingPolicy:
         title: Restarting Policy
@@ -108,7 +105,6 @@ spec:
         description: Set whether the S3 client should expect to load credentials through a default credentials provider or to expect static credentials to be passed in.
         type: boolean
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
       uriEndpointOverride:
         title: Overwrite Endpoint URI
@@ -119,14 +115,12 @@ spec:
         description: Select this option to override the endpoint URI. To use this option, you must also provide a URI for the `uriEndpointOverride` option.
         type: boolean
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
       forcePathStyle:
         title: Force Path Style
         description: Forces path style when accessing AWS S3 buckets.
         type: boolean
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
   dependencies:
     - "camel:aws2-s3"

--- a/kamelets/aws-secrets-manager-sink.kamelet.yaml
+++ b/kamelets/aws-secrets-manager-sink.kamelet.yaml
@@ -53,7 +53,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       secretKey:
         title: Secret Key
@@ -61,7 +60,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       region:
         title: AWS Region
@@ -73,7 +71,6 @@ spec:
         description: Set whether the Secrets Manager client should expect to load credentials through a default credentials provider or to expect static credentials to be passed in.
         type: boolean
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
   dependencies:
     - "camel:core"

--- a/kamelets/aws-ses-sink.kamelet.yaml
+++ b/kamelets/aws-ses-sink.kamelet.yaml
@@ -62,7 +62,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       secretKey:
         title: Secret Key
@@ -70,7 +69,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       region:
         title: AWS Region
@@ -82,7 +80,6 @@ spec:
         description: If true, the SES client loads credentials through a default credentials provider. If false, it uses the basic authentication method (access key and secret key).
         type: boolean
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
   dependencies:
     - "camel:core"

--- a/kamelets/aws-sns-fifo-sink.kamelet.yaml
+++ b/kamelets/aws-sns-fifo-sink.kamelet.yaml
@@ -56,7 +56,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       secretKey:
         title: Secret Key
@@ -64,7 +63,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       region:
         title: AWS Region
@@ -77,20 +75,17 @@ spec:
         type: boolean
         default: false
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       autoCreateTopic:
         title: Autocreate Topic
         description: Setting the autocreation of the SNS topic. 
         type: boolean
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
       useDefaultCredentialsProvider:
         title: Default Credentials Provider
         description: Set whether the SNS client should expect to load credentials through a default credentials provider or to expect static credentials to be passed in.
         type: boolean
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
       uriEndpointOverride:
         title: Overwrite Endpoint URI
@@ -101,7 +96,6 @@ spec:
         description: Select this option to override the endpoint URI. To use this option, you must also provide a URI for the `uriEndpointOverride` option.
         type: boolean
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
   dependencies:
   - "camel:aws2-sns"

--- a/kamelets/aws-sns-sink.kamelet.yaml
+++ b/kamelets/aws-sns-sink.kamelet.yaml
@@ -54,7 +54,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       secretKey:
         title: Secret Key
@@ -62,7 +61,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       region:
         title: AWS Region
@@ -74,14 +72,12 @@ spec:
         description: Setting the autocreation of the SNS topic. 
         type: boolean
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
       useDefaultCredentialsProvider:
         title: Default Credentials Provider
         description: If true, the SNS client loads credentials through a default credentials provider. If false, it uses the basic authentication method (access key and secret key).
         type: boolean
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
       uriEndpointOverride:
         title: Overwrite Endpoint URI
@@ -92,7 +88,6 @@ spec:
         description: Select this option to override the endpoint URI. To use this option, you must also provide a URI for the `uriEndpointOverride` option.
         type: boolean
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
   dependencies:
     - "camel:core"

--- a/kamelets/aws-sqs-batch-sink.kamelet.yaml
+++ b/kamelets/aws-sqs-batch-sink.kamelet.yaml
@@ -53,7 +53,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       secretKey:
         title: Secret Key
@@ -61,7 +60,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       region:
         title: AWS Region
@@ -73,7 +71,6 @@ spec:
         description: Setting the autocreation of the SQS queue. 
         type: boolean
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
       batchSeparator:
         title: Batch Separator
@@ -96,7 +93,6 @@ spec:
         description: Set whether the SQS client should expect to load credentials through a default credentials provider or to expect static credentials to be passed in.
         type: boolean
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
       uriEndpointOverride:
         title: Overwrite Endpoint URI
@@ -107,7 +103,6 @@ spec:
         description: Select this option to override the endpoint URI. To use this option, you must also provide a URI for the `uriEndpointOverride` option.
         type: boolean
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false        
   dependencies:
     - "camel:aws2-sqs"

--- a/kamelets/aws-sqs-fifo-sink.kamelet.yaml
+++ b/kamelets/aws-sqs-fifo-sink.kamelet.yaml
@@ -52,7 +52,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       secretKey:
         title: Secret Key
@@ -60,7 +59,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       region:
         title: AWS Region
@@ -73,13 +71,11 @@ spec:
         type: boolean
         default: false
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       autoCreateQueue:
         title: Autocreate Queue
         description: Setting the autocreation of the SQS queue. 
         type: boolean
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
       amazonAWSHost:
         title: AWS Host
@@ -97,7 +93,6 @@ spec:
         description: Set whether the SQS client should expect to load credentials through a default credentials provider or to expect static credentials to be passed in.
         type: boolean
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
       uriEndpointOverride:
         title: Overwrite Endpoint URI
@@ -108,7 +103,6 @@ spec:
         description: Select this option to override the endpoint URI. To use this option, you must also provide a URI for the `uriEndpointOverride` option.
         type: boolean
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false   
   dependencies:
   - "camel:aws2-sqs"

--- a/kamelets/aws-sqs-sink.kamelet.yaml
+++ b/kamelets/aws-sqs-sink.kamelet.yaml
@@ -52,7 +52,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       secretKey:
         title: Secret Key
@@ -60,7 +59,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       region:
         title: AWS Region
@@ -72,7 +70,6 @@ spec:
         description: Automatically create the SQS queue. 
         type: boolean
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
       amazonAWSHost:
         title: AWS Host
@@ -90,7 +87,6 @@ spec:
         description: If true, the SQS client loads credentials through a default credentials provider. If false, it uses the basic authentication method (access key and secret key).
         type: boolean
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
       uriEndpointOverride:
         title: Overwrite Endpoint URI
@@ -101,7 +97,6 @@ spec:
         description: Select this option to override the endpoint URI. To use this option, you must also provide a URI for the `uriEndpointOverride` option.
         type: boolean
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false    
   dependencies:
     - "camel:aws2-sqs"

--- a/kamelets/aws-sqs-source.kamelet.yaml
+++ b/kamelets/aws-sqs-source.kamelet.yaml
@@ -54,7 +54,6 @@ spec:
         description: Delete messages after consuming them
         type: boolean
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: true
       accessKey:
         title: Access Key
@@ -62,7 +61,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
         - urn:keda:authentication:awsAccessKeyID
         - urn:keda:required
@@ -72,7 +70,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
         - urn:keda:authentication:awsSecretAccessKey
         - urn:keda:required
@@ -89,7 +86,6 @@ spec:
         description: Setting the autocreation of the SQS queue. 
         type: boolean
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
       amazonAWSHost:
         title: AWS Host
@@ -114,7 +110,6 @@ spec:
         description: If true, the SQS client loads credentials through a default credentials provider. If false, it uses the basic authentication method (access key and secret key).
         type: boolean
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
       uriEndpointOverride:
         title: Overwrite Endpoint URI
@@ -125,7 +120,6 @@ spec:
         description: Select this option to override the endpoint URI. To use this option, you must also provide a URI for the `uriEndpointOverride` option.
         type: boolean
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
       delay:
         title: Delay
@@ -137,7 +131,6 @@ spec:
         description: If greedy is enabled, then the polling will happen immediately again, if the previous run polled 1 or more messages.
         type: boolean
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
   dataTypes:
     out:

--- a/kamelets/aws-translate-action.kamelet.yaml
+++ b/kamelets/aws-translate-action.kamelet.yaml
@@ -49,7 +49,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       secretKey:
         title: Secret Key
@@ -57,7 +56,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       region:
         title: AWS Region
@@ -81,7 +79,6 @@ spec:
         description: Set whether the Translate client should expect to load credentials through a default credentials provider or to expect static credentials to be passed in.
         type: boolean
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
   dependencies:
     - "camel:dns"

--- a/kamelets/azure-cosmosdb-sink.kamelet.yaml
+++ b/kamelets/azure-cosmosdb-sink.kamelet.yaml
@@ -58,7 +58,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       databaseEndpoint:
         title: Database Endpoint

--- a/kamelets/azure-cosmosdb-source.kamelet.yaml
+++ b/kamelets/azure-cosmosdb-source.kamelet.yaml
@@ -54,7 +54,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       leaseDatabaseName:
         title: Lease Database Name
@@ -69,14 +68,12 @@ spec:
         description: Sets if the component should create Cosmos lease database for the consumer automatically in case it doesn’t exist in Cosmos account. 
         type: boolean
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
       createLeaseContainerIfNotExists:
         title: Autocreate Lease Container
         description: Sets if the component should create Cosmos lease container for the consumer automatically in case it doesn’t exist in Cosmos database. 
         type: boolean
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
       databaseEndpoint:
         title: Database Endpoint

--- a/kamelets/azure-eventhubs-sink.kamelet.yaml
+++ b/kamelets/azure-eventhubs-sink.kamelet.yaml
@@ -64,7 +64,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
   dependencies:
     - "camel:core"

--- a/kamelets/azure-eventhubs-source.kamelet.yaml
+++ b/kamelets/azure-eventhubs-source.kamelet.yaml
@@ -63,7 +63,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       blobAccountName:
         title: Azure Storage Blob Account Name
@@ -79,7 +78,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
   types:
     out:

--- a/kamelets/azure-functions-sink.kamelet.yaml
+++ b/kamelets/azure-functions-sink.kamelet.yaml
@@ -53,7 +53,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
   dependencies:
   - "camel:vertx-http"

--- a/kamelets/azure-servicebus-sink.kamelet.yaml
+++ b/kamelets/azure-servicebus-sink.kamelet.yaml
@@ -48,7 +48,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       serviceBusType:
         title: Servicebus Type

--- a/kamelets/azure-servicebus-source.kamelet.yaml
+++ b/kamelets/azure-servicebus-source.kamelet.yaml
@@ -50,7 +50,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       serviceBusReceiveMode:
         title: Servicebus Receive Mode

--- a/kamelets/azure-storage-blob-append-sink.kamelet.yaml
+++ b/kamelets/azure-storage-blob-append-sink.kamelet.yaml
@@ -56,7 +56,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       credentialType:
         title: Credential Type

--- a/kamelets/azure-storage-blob-cdc-source.kamelet.yaml
+++ b/kamelets/azure-storage-blob-cdc-source.kamelet.yaml
@@ -55,7 +55,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       serviceBusReceiveMode:
         title: Servicebus Receive Mode
@@ -83,7 +82,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       credentialType:
         title: Credential Type
@@ -98,7 +96,6 @@ spec:
           get and returned as body, if not only the event will be returned as body.
         type: boolean
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
   types:
     out:

--- a/kamelets/azure-storage-blob-changefeed-source.kamelet.yaml
+++ b/kamelets/azure-storage-blob-changefeed-source.kamelet.yaml
@@ -56,7 +56,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-          - urn:alm:descriptor:com.tectonic.ui:password
           - urn:camel:group:credentials
   dependencies:
     - "camel:azure-storage-blob"

--- a/kamelets/azure-storage-blob-sink.kamelet.yaml
+++ b/kamelets/azure-storage-blob-sink.kamelet.yaml
@@ -56,7 +56,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       credentialType:
         title: Credential Type

--- a/kamelets/azure-storage-blob-source.kamelet.yaml
+++ b/kamelets/azure-storage-blob-source.kamelet.yaml
@@ -56,7 +56,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       delay:
         title: Delay
@@ -68,7 +67,6 @@ spec:
         description: Specifies to delete blobs after consuming them
         type: boolean
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
       credentialType:
         title: Credential Type

--- a/kamelets/azure-storage-datalake-sink.kamelet.yaml
+++ b/kamelets/azure-storage-datalake-sink.kamelet.yaml
@@ -53,7 +53,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       clientSecret:
         title: Client Secret
@@ -61,7 +60,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       tenantId:
         title: Tenant Id
@@ -69,7 +67,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       fileSystemName:
         title: File System Name

--- a/kamelets/azure-storage-datalake-source.kamelet.yaml
+++ b/kamelets/azure-storage-datalake-source.kamelet.yaml
@@ -53,7 +53,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       clientSecret:
         title: Client Secret
@@ -61,7 +60,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       tenantId:
         title: Tenant Id
@@ -69,7 +67,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       fileSystemName:
         title: File System Name

--- a/kamelets/azure-storage-queue-sink.kamelet.yaml
+++ b/kamelets/azure-storage-queue-sink.kamelet.yaml
@@ -57,7 +57,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
   dependencies:
     - "camel:core"

--- a/kamelets/azure-storage-queue-source.kamelet.yaml
+++ b/kamelets/azure-storage-queue-source.kamelet.yaml
@@ -57,7 +57,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password        
         - urn:camel:group:credentials
       maxMessages:
         title: Maximum Messages

--- a/kamelets/cassandra-sink.kamelet.yaml
+++ b/kamelets/cassandra-sink.kamelet.yaml
@@ -68,7 +68,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       consistencyLevel:
         title: Consistency Level
@@ -82,7 +81,6 @@ spec:
         type: boolean
         default: true
         x-descriptors:
-          - urn:alm:descriptor:com.tectonic.ui:checkbox
       query:
         title: Query
         description: The query to execute against the Cassandra cluster table.

--- a/kamelets/cassandra-source.kamelet.yaml
+++ b/kamelets/cassandra-source.kamelet.yaml
@@ -66,7 +66,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       resultStrategy:
         title: Result Strategy

--- a/kamelets/ceph-sink.kamelet.yaml
+++ b/kamelets/ceph-sink.kamelet.yaml
@@ -55,7 +55,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       secretKey:
         title: Secret Key
@@ -63,7 +62,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       zoneGroup:
         title: Bucket Zone Group
@@ -74,7 +72,6 @@ spec:
         description: Specifies to automatically create the bucket.
         type: boolean
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
       cephUrl:
         title: Ceph Url Address

--- a/kamelets/ceph-source.kamelet.yaml
+++ b/kamelets/ceph-source.kamelet.yaml
@@ -51,7 +51,6 @@ spec:
         description: Specifies to delete objects after consuming them.
         type: boolean
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: true
       accessKey:
         title: Access Key
@@ -59,7 +58,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       secretKey:
         title: Secret Key
@@ -67,7 +65,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       zoneGroup:
         title: Bucket Zone Group
@@ -78,14 +75,12 @@ spec:
         description: Specifies to automatically create the bucket.
         type: boolean
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
       includeBody:
         title: Include Body
         description: If true, the exchange is consumed and put into the body and closed. If false, the Object stream is put raw into the body and the headers are set with the object metadata.
         type: boolean
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: true
       prefix:
         title: Prefix
@@ -97,7 +92,6 @@ spec:
         description: If true, the Object body is ignored. Setting this to true overrides any behavior defined by the `includeBody` option. If false, the object is put in the body.
         type: boolean
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
       cephUrl:
         title: Ceph Url Address

--- a/kamelets/couchbase-sink.kamelet.yaml
+++ b/kamelets/couchbase-sink.kamelet.yaml
@@ -67,7 +67,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       startingId:
         title: Starting Id
@@ -80,7 +79,6 @@ spec:
         type: boolean
         default: true
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:checkbox
   dependencies:
     - "camel:couchbase"
     - "camel:kamelet"

--- a/kamelets/dropbox-sink.kamelet.yaml
+++ b/kamelets/dropbox-sink.kamelet.yaml
@@ -51,7 +51,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       clientIdentifier:
         title: Client Identifier

--- a/kamelets/dropbox-source.kamelet.yaml
+++ b/kamelets/dropbox-source.kamelet.yaml
@@ -51,7 +51,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       clientIdentifier:
         title: Client Identifier

--- a/kamelets/elasticsearch-index-sink.kamelet.yaml
+++ b/kamelets/elasticsearch-index-sink.kamelet.yaml
@@ -61,7 +61,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       enableSSL:
         title: Enable SSL
@@ -69,7 +68,6 @@ spec:
         type: boolean
         default: true
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       hostAddresses:
         title: Host Addresses
         description: A comma-separated list of remote transport addresses in `ip:port format`.

--- a/kamelets/elasticsearch-search-source.kamelet.yaml
+++ b/kamelets/elasticsearch-search-source.kamelet.yaml
@@ -64,7 +64,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       enableSSL:
         title: Enable SSL
@@ -72,7 +71,6 @@ spec:
         type: boolean
         default: true
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       hostAddresses:
         title: Host Addresses
         description: Comma separated list with ip:port formatted remote transport addresses to use.

--- a/kamelets/extract-field-action.kamelet.yaml
+++ b/kamelets/extract-field-action.kamelet.yaml
@@ -58,7 +58,6 @@ spec:
         type: boolean
         default: false
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       headerOutputName:
         title: Header Output Name
         description: A custom name for the header containing the extracted field
@@ -70,14 +69,12 @@ spec:
         type: boolean
         default: false
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       trimField:
         title: Trim Field
         description: If enabled we return the Raw extracted field
         type: boolean
         default: false
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
     type: object
   dependencies:
   - "mvn:org.apache.camel.kamelets:camel-kamelets-utils:4.2.0-SNAPSHOT"

--- a/kamelets/extract-field-action.kamelet.yaml
+++ b/kamelets/extract-field-action.kamelet.yaml
@@ -57,7 +57,6 @@ spec:
         description: If enable the action will store the extracted field in an header named CamelKameletsExtractFieldName
         type: boolean
         default: false
-        x-descriptors:
       headerOutputName:
         title: Header Output Name
         description: A custom name for the header containing the extracted field
@@ -68,13 +67,11 @@ spec:
         description: If enabled the action will check if the header output name (custom or default) has been used already in the exchange. If so, the extracted field will be stored in the message body, if not, the extracted field will be stored in the selected header (custom or default).
         type: boolean
         default: false
-        x-descriptors:
       trimField:
         title: Trim Field
         description: If enabled we return the Raw extracted field
         type: boolean
         default: false
-        x-descriptors:
     type: object
   dependencies:
   - "mvn:org.apache.camel.kamelets:camel-kamelets-utils:4.2.0-SNAPSHOT"

--- a/kamelets/fhir-sink.kamelet.yaml
+++ b/kamelets/fhir-sink.kamelet.yaml
@@ -46,14 +46,12 @@ spec:
         description: "Will log every requests and responses."
         type: boolean
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
       prettyPrint:
         title: Pretty Print
         description: "Pretty print all request."
         type: boolean
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
       serverUrl:
         title: Server URL
@@ -64,7 +62,6 @@ spec:
         description: "Whether the producer should be started lazy (on the first message). By starting lazy you can use this to allow CamelContext and routes to startup in situations where a producer may otherwise fail during starting and cause the route to fail being started. By deferring this startup to be lazy then the startup failure can be handled during routing messages via Camel’s routing error handlers. Beware that when the first message is processed then creating and starting the producer may take a little time and prolong the total processing time of the processing."
         type: boolean
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
       proxyHost:
         title: Proxy Host
@@ -76,7 +73,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       proxyPort:
         title: Proxy Port
@@ -94,7 +90,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       username:
         title: Username
@@ -108,7 +103,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
   dependencies:  
   - "camel:fhir"

--- a/kamelets/fhir-source.kamelet.yaml
+++ b/kamelets/fhir-source.kamelet.yaml
@@ -71,14 +71,12 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       prettyPrint:
         title: Json Pretty Print
         description: Define if the Json must be pretty print or not
         type: boolean
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: true
   types:
     out:

--- a/kamelets/ftp-sink.kamelet.yaml
+++ b/kamelets/ftp-sink.kamelet.yaml
@@ -65,7 +65,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       directoryName:
         title: Directory Name
@@ -77,7 +76,6 @@ spec:
         type: boolean
         default: false
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       fileExist:
         title: File Existence
         description: How to behave in case of file already existent.
@@ -90,14 +88,12 @@ spec:
         type: boolean
         default: false
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       autoCreate:
         title: Autocreate Missing Directories
         description: Automatically create the directory the files should be written to.
         type: boolean
         default: true
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
   dependencies:
     - "camel:ftp"
     - "camel:core"

--- a/kamelets/ftp-source.kamelet.yaml
+++ b/kamelets/ftp-source.kamelet.yaml
@@ -61,7 +61,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       directoryName:
         title: Directory Name
@@ -73,42 +72,36 @@ spec:
         type: boolean
         default: false
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       recursive:
         title: Recursive
         description: If a directory, look for files in all the sub-directories as well.
         type: boolean
         default: false
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       idempotent:
         title: Idempotency
         description: Skip already-processed files.
         type: boolean
         default: true
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       binary:
         title: Binary
         description: Specifies the file transfer mode, BINARY or ASCII. Default is ASCII (false).
         type: boolean
         default: false
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       autoCreate:
         title: Autocreate Missing Directories
         description: Automatically create starting directory.
         type: boolean
         default: true
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       delete:
         title: Delete
         description: If true, the file will be deleted after it is processed successfully.
         type: boolean
         default: false
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
   dependencies:
     - "camel:ftp"
     - "camel:core"

--- a/kamelets/ftps-sink.kamelet.yaml
+++ b/kamelets/ftps-sink.kamelet.yaml
@@ -65,7 +65,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       directoryName:
         title: Directory Name
@@ -77,7 +76,6 @@ spec:
         type: boolean
         default: false
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       fileExist:
         title: File Existence
         description: "Specifies how the Kamelet behaves if the file already exists."
@@ -90,14 +88,12 @@ spec:
         type: boolean
         default: false
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       autoCreate:
         title: Autocreate Missing Directories
         description: Automatically create the directory the files should be written to.
         type: boolean
         default: true
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
   dependencies:
     - "camel:ftp"
     - "camel:core"

--- a/kamelets/ftps-source.kamelet.yaml
+++ b/kamelets/ftps-source.kamelet.yaml
@@ -61,7 +61,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       directoryName:
         title: Directory Name
@@ -73,42 +72,36 @@ spec:
         type: boolean
         default: false
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       recursive:
         title: Recursive
         description: If a directory, look for files in all sub-directories as well.
         type: boolean
         default: false
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       idempotent:
         title: Idempotency
         description: Skip already-processed files.
         type: boolean
         default: true
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       binary:
         title: Binary
         description: Specifies the file transfer mode, BINARY or ASCII. Default is ASCII (false).
         type: boolean
         default: false
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       autoCreate:
         title: Autocreate Missing Directories
         description: Automatically create starting directory.
         type: boolean
         default: true
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       delete:
         title: Delete
         description: If true, the file will be deleted after it is processed successfully.
         type: boolean
         default: false
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
   dependencies:
     - "camel:ftp"
     - "camel:core"

--- a/kamelets/github-commit-source.kamelet.yaml
+++ b/kamelets/github-commit-source.kamelet.yaml
@@ -54,7 +54,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       startingSha:
         title: Starting SHA

--- a/kamelets/github-event-source.kamelet.yaml
+++ b/kamelets/github-event-source.kamelet.yaml
@@ -52,7 +52,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
   types:
     out:

--- a/kamelets/github-pullrequest-comment-source.kamelet.yaml
+++ b/kamelets/github-pullrequest-comment-source.kamelet.yaml
@@ -52,7 +52,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
   types:
     out:

--- a/kamelets/github-pullrequest-source.kamelet.yaml
+++ b/kamelets/github-pullrequest-source.kamelet.yaml
@@ -52,7 +52,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
   types:
     out:

--- a/kamelets/github-tag-source.kamelet.yaml
+++ b/kamelets/github-tag-source.kamelet.yaml
@@ -52,7 +52,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
   types:
     out:

--- a/kamelets/google-calendar-source.kamelet.yaml
+++ b/kamelets/google-calendar-source.kamelet.yaml
@@ -56,7 +56,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       clientSecret:
         title: Client Secret
@@ -64,7 +63,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       accessToken:
         title: Access Token
@@ -72,7 +70,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       refreshToken:
         title: Refresh Token
@@ -80,7 +77,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       delay:
         title: Delay
@@ -96,14 +92,12 @@ spec:
         description: Specifies to sync events for incremental synchronization.
         type: boolean
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
       consumeFromNow:
         title: Consume from now
         description: Specfies to consume events in the calendar from now on.
         type: boolean
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: true
   types:
     out:

--- a/kamelets/google-mail-source.kamelet.yaml
+++ b/kamelets/google-mail-source.kamelet.yaml
@@ -51,7 +51,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       clientSecret:
         title: Client Secret
@@ -59,7 +58,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       accessToken:
         title: Access Token
@@ -67,7 +65,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       refreshToken:
         title: Refresh Token
@@ -75,7 +72,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       delay:
         title: Delay
@@ -91,7 +87,6 @@ spec:
         description: Mark the message as read once it has been consumed
         type: boolean
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: true
       labels:
         title: Gmail Labels

--- a/kamelets/google-pubsub-source.kamelet.yaml
+++ b/kamelets/google-pubsub-source.kamelet.yaml
@@ -58,7 +58,6 @@ spec:
         description: Specifies to synchronously pull batches of messages.
         type: boolean
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
       maxMessagesPerPoll:
         title: Max Messages Per Poll

--- a/kamelets/google-sheets-sink.kamelet.yaml
+++ b/kamelets/google-sheets-sink.kamelet.yaml
@@ -50,7 +50,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-          - urn:alm:descriptor:com.tectonic.ui:password
           - urn:camel:group:credentials
       clientSecret:
         title: Client Secret
@@ -58,7 +57,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-          - urn:alm:descriptor:com.tectonic.ui:password
           - urn:camel:group:credentials
       accessToken:
         title: Access Token
@@ -66,7 +64,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-          - urn:alm:descriptor:com.tectonic.ui:password
           - urn:camel:group:credentials
       refreshToken:
         title: Refresh Token
@@ -74,7 +71,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-          - urn:alm:descriptor:com.tectonic.ui:password
           - urn:camel:group:credentials
       applicationName:
         title: Application Name

--- a/kamelets/google-sheets-source.kamelet.yaml
+++ b/kamelets/google-sheets-source.kamelet.yaml
@@ -50,7 +50,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       clientSecret:
         title: Client Secret
@@ -58,7 +57,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       accessToken:
         title: Access Token
@@ -66,7 +64,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       refreshToken:
         title: Refresh Token
@@ -74,7 +71,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       delay:
         title: Delay
@@ -94,7 +90,6 @@ spec:
         description: True if value range result should be split into rows or columns to process each of them individually.
         type: boolean
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: true
       range:
         title: Cells Range

--- a/kamelets/google-storage-cdc-source.kamelet.yaml
+++ b/kamelets/google-storage-cdc-source.kamelet.yaml
@@ -64,7 +64,6 @@ spec:
         description: Specifies to synchronously pull batches of messages.
         type: boolean
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
       maxMessagesPerPoll:
         title: Max Messages Per Poll
@@ -87,7 +86,6 @@ spec:
           get and returned as body, if not only the event will be returned as body.
         type: boolean
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false        
   dependencies:
     - "camel:kamelet"

--- a/kamelets/google-storage-sink.kamelet.yaml
+++ b/kamelets/google-storage-sink.kamelet.yaml
@@ -55,7 +55,6 @@ spec:
         description: Specifies to automatically create the Google Cloud Storage bucket.
         type: boolean
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
   dependencies:
     - "camel:core"

--- a/kamelets/google-storage-source.kamelet.yaml
+++ b/kamelets/google-storage-source.kamelet.yaml
@@ -53,14 +53,12 @@ spec:
         description: Specifies to delete objects after consuming them.
         type: boolean
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: true
       autoCreateBucket:
         title: Autocreate Bucket
         description: Specifies to automatically create the Google Cloud Storage bucket.
         type: boolean
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
   dataTypes:
     out:

--- a/kamelets/graphql-sink.kamelet.yaml
+++ b/kamelets/graphql-sink.kamelet.yaml
@@ -47,7 +47,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
   dependencies:
   - "camel:graphql"

--- a/kamelets/http-secured-sink.kamelet.yaml
+++ b/kamelets/http-secured-sink.kamelet.yaml
@@ -57,7 +57,6 @@ spec:
         description: If this option is true, camel-http sends preemptive basic authentication to the server.
         type: boolean
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
       authUsername:
         title: Authentication Username
@@ -71,7 +70,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
   dependencies:
   - "camel:http"

--- a/kamelets/http-secured-source.kamelet.yaml
+++ b/kamelets/http-secured-source.kamelet.yaml
@@ -62,7 +62,6 @@ spec:
         description: If this option is true, camel-http sends preemptive basic authentication to the server.
         type: boolean
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
       authUsername:
         title: Authentication Username
@@ -76,7 +75,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
   dependencies:
     - "camel:http"

--- a/kamelets/infinispan-sink.kamelet.yaml
+++ b/kamelets/infinispan-sink.kamelet.yaml
@@ -59,7 +59,6 @@ spec:
         type: boolean
         default: true
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       username:
         title: Username
         description: Username to connect to Infinispan.
@@ -72,7 +71,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       saslMechanism:
         title: SASL Mechanism

--- a/kamelets/infinispan-source.kamelet.yaml
+++ b/kamelets/infinispan-source.kamelet.yaml
@@ -53,7 +53,6 @@ spec:
         type: boolean
         default: true
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       username:
         title: Username
         description: Username to connect to Infinispan.
@@ -66,7 +65,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       saslMechanism:
         title: SASL Mechanism

--- a/kamelets/jira-add-comment-sink.kamelet.yaml
+++ b/kamelets/jira-add-comment-sink.kamelet.yaml
@@ -62,7 +62,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       personal-token:
         title: Personal Token

--- a/kamelets/jira-add-issue-sink.kamelet.yaml
+++ b/kamelets/jira-add-issue-sink.kamelet.yaml
@@ -74,7 +74,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       personal-token:
         title: Personal Token

--- a/kamelets/jira-oauth-source.kamelet.yaml
+++ b/kamelets/jira-oauth-source.kamelet.yaml
@@ -52,7 +52,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       verificationCode:
         title: Password
@@ -60,7 +59,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       consumerKey:
         title: Password
@@ -68,7 +66,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       privateKey:
         title: Password
@@ -76,7 +73,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       jql:
         title: JQL

--- a/kamelets/jira-source.kamelet.yaml
+++ b/kamelets/jira-source.kamelet.yaml
@@ -56,7 +56,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       personal-token:
         title: Personal Token

--- a/kamelets/jira-transition-issue-sink.kamelet.yaml
+++ b/kamelets/jira-transition-issue-sink.kamelet.yaml
@@ -64,7 +64,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       personal-token:
         title: Personal Token

--- a/kamelets/jira-update-issue-sink.kamelet.yaml
+++ b/kamelets/jira-update-issue-sink.kamelet.yaml
@@ -74,7 +74,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       personal-token:
         title: Personal Token

--- a/kamelets/jms-ibm-mq-sink.kamelet.yaml
+++ b/kamelets/jms-ibm-mq-sink.kamelet.yaml
@@ -88,7 +88,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       sslCipherSuite:
         title: "CipherSuite"

--- a/kamelets/jms-ibm-mq-source.kamelet.yaml
+++ b/kamelets/jms-ibm-mq-source.kamelet.yaml
@@ -88,7 +88,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       sslCipherSuite:
         title: "CipherSuite"

--- a/kamelets/kafka-apicurio-registry-not-secured-source.kamelet.yaml
+++ b/kamelets/kafka-apicurio-registry-not-secured-source.kamelet.yaml
@@ -59,14 +59,12 @@ spec:
         type: boolean
         default: true
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       allowManualCommit:
         title: Allow Manual Commit
         description: Whether to allow doing manual commits
         type: boolean
         default: false
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       pollOnError:
         title: Poll On Error Behavior
         description: What to do if kafka threw an exception while polling for new messages. There are 5 enums and the value can be one of DISCARD, ERROR_HANDLER, RECONNECT, RETRY, STOP
@@ -92,7 +90,6 @@ spec:
         description: When enabled the Kamelet source will deserialize all message headers to String representation.
         type: boolean
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: true
       valueDeserializer:
         title: Value Deserializer

--- a/kamelets/kafka-azure-schema-registry-sink.kamelet.yaml
+++ b/kamelets/kafka-azure-schema-registry-sink.kamelet.yaml
@@ -71,7 +71,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       valueSerializer:
         title: Value Deserializer

--- a/kamelets/kafka-azure-schema-registry-source.kamelet.yaml
+++ b/kamelets/kafka-azure-schema-registry-source.kamelet.yaml
@@ -70,7 +70,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
         - urn:keda:authentication:password
         - urn:keda:required
@@ -80,14 +79,12 @@ spec:
         type: boolean
         default: true
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       allowManualCommit:
         title: Allow Manual Commit
         description: Whether to allow doing manual commits
         type: boolean
         default: false
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       pollOnError:
         title: Poll On Error Behavior
         description: What to do if kafka threw an exception while polling for new messages. There are 5 enums and the value can be one of DISCARD, ERROR_HANDLER, RECONNECT, RETRY, STOP
@@ -113,7 +110,6 @@ spec:
         description: When enabled the Kamelet source will deserialize all message headers to String representation.
         type: boolean
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: true
       valueDeserializer:
         title: Value Deserializer

--- a/kamelets/kafka-not-secured-source.kamelet.yaml
+++ b/kamelets/kafka-not-secured-source.kamelet.yaml
@@ -58,14 +58,12 @@ spec:
         type: boolean
         default: true
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       allowManualCommit:
         title: Allow Manual Commit
         description: Whether to allow doing manual commits
         type: boolean
         default: false
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       pollOnError:
         title: Poll On Error Behavior
         description: What to do if kafka threw an exception while polling for new messages. There are 5 enums and the value can be one of DISCARD, ERROR_HANDLER, RECONNECT, RETRY, STOP
@@ -91,7 +89,6 @@ spec:
         description: When enabled the Kamelet source will deserialize all message headers to String representation.
         type: boolean
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: true
   dependencies:
     - "mvn:org.apache.camel.kamelets:camel-kamelets-utils:4.2.0-SNAPSHOT"

--- a/kamelets/kafka-not-secured-source.kamelet.yaml
+++ b/kamelets/kafka-not-secured-source.kamelet.yaml
@@ -57,13 +57,11 @@ spec:
         description: If true, periodically commit to ZooKeeper the offset of messages already fetched by the consumer
         type: boolean
         default: true
-        x-descriptors:
       allowManualCommit:
         title: Allow Manual Commit
         description: Whether to allow doing manual commits
         type: boolean
         default: false
-        x-descriptors:
       pollOnError:
         title: Poll On Error Behavior
         description: What to do if kafka threw an exception while polling for new messages. There are 5 enums and the value can be one of DISCARD, ERROR_HANDLER, RECONNECT, RETRY, STOP
@@ -88,7 +86,6 @@ spec:
         title: Automatically Deserialize Headers
         description: When enabled the Kamelet source will deserialize all message headers to String representation.
         type: boolean
-        x-descriptors:
         default: true
   dependencies:
     - "mvn:org.apache.camel.kamelets:camel-kamelets-utils:4.2.0-SNAPSHOT"

--- a/kamelets/kafka-scram-sink.kamelet.yaml
+++ b/kamelets/kafka-scram-sink.kamelet.yaml
@@ -77,7 +77,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
   dependencies:
     - "camel:core"

--- a/kamelets/kafka-scram-source.kamelet.yaml
+++ b/kamelets/kafka-scram-source.kamelet.yaml
@@ -80,7 +80,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
         - urn:keda:authentication:password
         - urn:keda:required
@@ -90,14 +89,12 @@ spec:
         type: boolean
         default: true
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       allowManualCommit:
         title: Allow Manual Commit
         description: Whether to allow doing manual commits
         type: boolean
         default: false
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       pollOnError:
         title: Poll On Error Behavior
         description: What to do if kafka threw an exception while polling for new messages. There are 5 enums and the value can be one of DISCARD, ERROR_HANDLER, RECONNECT, RETRY, STOP
@@ -123,7 +120,6 @@ spec:
         description: When enabled the Kamelet source will deserialize all message headers to String representation.
         type: boolean
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: true
   dependencies:
     - "mvn:org.apache.camel.kamelets:camel-kamelets-utils:4.2.0-SNAPSHOT"

--- a/kamelets/kafka-sink.kamelet.yaml
+++ b/kamelets/kafka-sink.kamelet.yaml
@@ -77,7 +77,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
   dependencies:
     - "camel:core"

--- a/kamelets/kafka-source.kamelet.yaml
+++ b/kamelets/kafka-source.kamelet.yaml
@@ -80,7 +80,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
         - urn:keda:authentication:password
         - urn:keda:required
@@ -90,14 +89,12 @@ spec:
         type: boolean
         default: true
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       allowManualCommit:
         title: Allow Manual Commit
         description: Whether to allow doing manual commits
         type: boolean
         default: false
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       pollOnError:
         title: Poll On Error Behavior
         description: What to do if kafka threw an exception while polling for new messages. There are 5 enums and the value can be one of DISCARD, ERROR_HANDLER, RECONNECT, RETRY, STOP
@@ -123,7 +120,6 @@ spec:
         description: When enabled the Kamelet source will deserialize all message headers to String representation.
         type: boolean
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: true
   dependencies:
     - "mvn:org.apache.camel.kamelets:camel-kamelets-utils:4.2.0-SNAPSHOT"

--- a/kamelets/kafka-ssl-sink.kamelet.yaml
+++ b/kamelets/kafka-ssl-sink.kamelet.yaml
@@ -87,7 +87,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-          - urn:alm:descriptor:com.tectonic.ui:password
           - urn:camel:group:credentials
       sslTruststoreLocation:
         description: The location of the trust store file.
@@ -99,7 +98,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-          - urn:alm:descriptor:com.tectonic.ui:password
           - urn:camel:group:credentials
       topic:
         description: Comma separated list of Kafka topic names

--- a/kamelets/kafka-ssl-source.kamelet.yaml
+++ b/kamelets/kafka-ssl-source.kamelet.yaml
@@ -69,14 +69,12 @@ spec:
         type: boolean
         default: true
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       allowManualCommit:
         title: Allow Manual Commit
         description: Whether to allow doing manual commits
         type: boolean
         default: false
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       pollOnError:
         title: Poll On Error Behavior
         description: What to do if kafka threw an exception while polling for new messages. There are 5 enums and the value can be one of DISCARD, ERROR_HANDLER, RECONNECT, RETRY, STOP
@@ -102,7 +100,6 @@ spec:
         description: When enabled the Kamelet source will deserialize all message headers to String representation.
         type: boolean
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: true
       sslKeyPassword:
         description: The password of the private key in the key store file.
@@ -110,7 +107,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-          - urn:alm:descriptor:com.tectonic.ui:password
           - urn:camel:group:credentials
           - urn:keda:authentication:password
           - urn:keda:required
@@ -120,7 +116,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-          - urn:alm:descriptor:com.tectonic.ui:password
           - urn:camel:group:credentials
           - urn:keda:authentication:password
       sslProtocol:

--- a/kamelets/kubernetes-namespaces-source.kamelet.yaml
+++ b/kamelets/kubernetes-namespaces-source.kamelet.yaml
@@ -43,7 +43,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       masterUrl:
         title: Kubernetes Master URL

--- a/kamelets/kubernetes-nodes-source.kamelet.yaml
+++ b/kamelets/kubernetes-nodes-source.kamelet.yaml
@@ -43,7 +43,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       masterUrl:
         title: Kubernetes Master URL

--- a/kamelets/kubernetes-pods-source.kamelet.yaml
+++ b/kamelets/kubernetes-pods-source.kamelet.yaml
@@ -43,7 +43,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       masterUrl:
         title: Kubernetes Master URL

--- a/kamelets/log-action.kamelet.yaml
+++ b/kamelets/log-action.kamelet.yaml
@@ -51,7 +51,6 @@ spec:
         type: boolean
         default: false
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       marker:
         title: Marker
         description: An optional Marker name to use
@@ -62,63 +61,54 @@ spec:
         type: boolean
         default: false
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       showAllProperties:
         title: Show All Properties
         description: Show all of the exchange properties (both internal and custom)
         type: boolean
         default: false
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       showBody:
         title: Show Body
         description: Show the message body
         type: boolean
         default: true
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       showBodyType:
         title: Show Body Type
         description: Show the body Java type
         type: boolean
         default: true
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       showExchangePattern:
         title: Show Exchange Pattern
         description: Shows the Message Exchange Pattern (or MEP for short)
         type: boolean
         default: true
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       showHeaders:
         title: Show Headers
         description: Show the headers received
         type: boolean
         default: false
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       showProperties:
         title: Show Properties
         description: Show the exchange properties (only custom). Use showAllProperties to show both internal and custom properties.
         type: boolean
         default: false
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       showStreams:
         title: Show Streams
         description: Show the stream bodies (they may not be available in following steps)
         type: boolean
         default: false
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       showCachedStreams:
         title: Show Cached Streams
         description: Whether Camel should show cached stream bodies or not.
         type: boolean
         default: true
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
   dependencies:
   - "camel:kamelet"
   - "camel:log"

--- a/kamelets/log-action.kamelet.yaml
+++ b/kamelets/log-action.kamelet.yaml
@@ -49,8 +49,7 @@ spec:
         title: Log Mask
         description: Mask sensitive information like password or passphrase in the log
         type: boolean
-        default: false
-        x-descriptors:
+        default: false        
       marker:
         title: Marker
         description: An optional Marker name to use
@@ -59,56 +58,47 @@ spec:
         title: Multiline
         description: If enabled then each information is outputted on a newline
         type: boolean
-        default: false
-        x-descriptors:
+        default: false        
       showAllProperties:
         title: Show All Properties
         description: Show all of the exchange properties (both internal and custom)
         type: boolean
-        default: false
-        x-descriptors:
+        default: false        
       showBody:
         title: Show Body
         description: Show the message body
         type: boolean
-        default: true
-        x-descriptors:
+        default: true        
       showBodyType:
         title: Show Body Type
         description: Show the body Java type
         type: boolean
-        default: true
-        x-descriptors:
+        default: true        
       showExchangePattern:
         title: Show Exchange Pattern
         description: Shows the Message Exchange Pattern (or MEP for short)
         type: boolean
-        default: true
-        x-descriptors:
+        default: true        
       showHeaders:
         title: Show Headers
         description: Show the headers received
         type: boolean
-        default: false
-        x-descriptors:
+        default: false       
       showProperties:
         title: Show Properties
         description: Show the exchange properties (only custom). Use showAllProperties to show both internal and custom properties.
         type: boolean
-        default: false
-        x-descriptors:
+        default: false       
       showStreams:
         title: Show Streams
         description: Show the stream bodies (they may not be available in following steps)
         type: boolean
-        default: false
-        x-descriptors:
+        default: false        
       showCachedStreams:
         title: Show Cached Streams
         description: Whether Camel should show cached stream bodies or not.
         type: boolean
-        default: true
-        x-descriptors:
+        default: true        
   dependencies:
   - "camel:kamelet"
   - "camel:log"

--- a/kamelets/log-sink.kamelet.yaml
+++ b/kamelets/log-sink.kamelet.yaml
@@ -49,8 +49,7 @@ spec:
         title: Log Mask
         description: Mask sensitive information like password or passphrase in the log
         type: boolean
-        default: false
-        x-descriptors:
+        default: false        
       marker:
         title: Marker
         description: An optional Marker name to use
@@ -59,56 +58,47 @@ spec:
         title: Multiline
         description: If enabled then each information is outputted on a newline
         type: boolean
-        default: false
-        x-descriptors:
+        default: false     
       showAllProperties:
         title: Show All Properties
         description: Show all of the exchange properties (both internal and custom)
         type: boolean
-        default: false
-        x-descriptors:
+        default: false       
       showBody:
         title: Show Body
         description: Show the message body
         type: boolean
-        default: true
-        x-descriptors:
+        default: true       
       showBodyType:
         title: Show Body Type
         description: Show the body Java type
         type: boolean
-        default: true
-        x-descriptors:
+        default: true       
       showExchangePattern:
         title: Show Exchange Pattern
         description: Shows the Message Exchange Pattern (or MEP for short)
         type: boolean
-        default: true
-        x-descriptors:
+        default: true       
       showHeaders:
         title: Show Headers
         description: Show the headers received
         type: boolean
-        default: false
-        x-descriptors:
+        default: false       
       showProperties:
         title: Show Properties
         description: Show the exchange properties (only custom). Use showAllProperties to show both internal and custom properties.
         type: boolean
-        default: false
-        x-descriptors:
+        default: false       
       showStreams:
         title: Show Streams
         description: Show the stream bodies (they may not be available in following steps)
         type: boolean
-        default: false
-        x-descriptors:
+        default: false      
       showCachedStreams:
         title: Show Cached Streams
         description: Whether Camel should show cached stream bodies or not.
         type: boolean
-        default: true
-        x-descriptors:
+        default: true       
   dependencies:
   - "camel:kamelet"
   - "camel:log"

--- a/kamelets/log-sink.kamelet.yaml
+++ b/kamelets/log-sink.kamelet.yaml
@@ -51,7 +51,6 @@ spec:
         type: boolean
         default: false
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       marker:
         title: Marker
         description: An optional Marker name to use
@@ -62,63 +61,54 @@ spec:
         type: boolean
         default: false
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       showAllProperties:
         title: Show All Properties
         description: Show all of the exchange properties (both internal and custom)
         type: boolean
         default: false
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       showBody:
         title: Show Body
         description: Show the message body
         type: boolean
         default: true
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       showBodyType:
         title: Show Body Type
         description: Show the body Java type
         type: boolean
         default: true
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       showExchangePattern:
         title: Show Exchange Pattern
         description: Shows the Message Exchange Pattern (or MEP for short)
         type: boolean
         default: true
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       showHeaders:
         title: Show Headers
         description: Show the headers received
         type: boolean
         default: false
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       showProperties:
         title: Show Properties
         description: Show the exchange properties (only custom). Use showAllProperties to show both internal and custom properties.
         type: boolean
         default: false
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       showStreams:
         title: Show Streams
         description: Show the stream bodies (they may not be available in following steps)
         type: boolean
         default: false
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       showCachedStreams:
         title: Show Cached Streams
         description: Whether Camel should show cached stream bodies or not.
         type: boolean
         default: true
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
   dependencies:
   - "camel:kamelet"
   - "camel:log"

--- a/kamelets/mail-imap-source.kamelet.yaml
+++ b/kamelets/mail-imap-source.kamelet.yaml
@@ -72,7 +72,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       fetchSize:
         title: Fetch Size

--- a/kamelets/mail-sink.kamelet.yaml
+++ b/kamelets/mail-sink.kamelet.yaml
@@ -59,7 +59,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-          - urn:alm:descriptor:com.tectonic.ui:password
           - urn:camel:group:credentials
       from:
         description: The `from` field of the outgoing mail

--- a/kamelets/mariadb-sink.kamelet.yaml
+++ b/kamelets/mariadb-sink.kamelet.yaml
@@ -74,7 +74,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       query:
         title: Query

--- a/kamelets/mariadb-source.kamelet.yaml
+++ b/kamelets/mariadb-source.kamelet.yaml
@@ -66,7 +66,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       query:
         title: Query

--- a/kamelets/minio-sink.kamelet.yaml
+++ b/kamelets/minio-sink.kamelet.yaml
@@ -53,7 +53,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       secretKey:
         title: Secret Key
@@ -61,7 +60,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       endpoint:
         title: Endpoint
@@ -73,7 +71,6 @@ spec:
         description: Specify to automatically create the MinIO bucket. 
         type: boolean
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
       keyName:
         title: Key Name

--- a/kamelets/minio-source.kamelet.yaml
+++ b/kamelets/minio-source.kamelet.yaml
@@ -48,7 +48,6 @@ spec:
         description: Delete objects after consuming them.
         type: boolean
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: true
       accessKey:
         title: Access Key
@@ -56,7 +55,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       secretKey:
         title: Secret Key
@@ -64,7 +62,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       endpoint:
         title: Endpoint
@@ -76,7 +73,6 @@ spec:
         description: Specifies to automatically create the MinIO bucket. 
         type: boolean
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
   dependencies:
   - "camel:minio"

--- a/kamelets/mongodb-changes-stream-source.kamelet.yaml
+++ b/kamelets/mongodb-changes-stream-source.kamelet.yaml
@@ -52,7 +52,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       username:
         title: MongoDB Username
@@ -66,14 +65,12 @@ spec:
         type: boolean
         default: true
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       sslValidationEnabled:
         title: Enables Ssl Certificates Validation and Host name checks.
         description: IMPORTANT this should be disabled only in test environment since can pose security issues.
         type: boolean
         default: true
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       database:
         title: MongoDB Database
         description: Sets the name of the MongoDB database to target.

--- a/kamelets/mongodb-sink.kamelet.yaml
+++ b/kamelets/mongodb-sink.kamelet.yaml
@@ -56,7 +56,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials  
       username:
         title: MongoDB Username
@@ -70,14 +69,12 @@ spec:
         type: boolean
         default: true
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       sslValidationEnabled:
         title: Enables Ssl Certificates Validation and Host name checks.
         description: IMPORTANT this should be disabled only in test environment since can pose security issues.
         type: boolean
         default: true
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       database:
         title: MongoDB Database
         description: The name of the MongoDB database.
@@ -93,7 +90,6 @@ spec:
         type: boolean
         default: false
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
   types:
     in:
       mediaType: application/json

--- a/kamelets/mongodb-source.kamelet.yaml
+++ b/kamelets/mongodb-source.kamelet.yaml
@@ -58,7 +58,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       username:
         title: MongoDB Username
@@ -72,14 +71,12 @@ spec:
         type: boolean
         default: true
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       sslValidationEnabled:
         title: Enables Ssl Certificates Validation and Host name checks.
         description: IMPORTANT this should be disabled only in test environment since can pose security issues.
         type: boolean
         default: true
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       database:
         title: MongoDB Database
         description: The name of the MongoDB database.
@@ -89,7 +86,6 @@ spec:
         description: Specifies to enable persistent tail tracking, which is a mechanism to keep track of the last consumed data across system restarts. The next time the system is up, the endpoint recovers the cursor from the point where it last stopped consuimg data. This option will only work on capped collections.
         type: boolean
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
       tailTrackIncreasingField:
         title: MongoDB Tail Track Increasing Field

--- a/kamelets/mqtt-sink.kamelet.yaml
+++ b/kamelets/mqtt-sink.kamelet.yaml
@@ -59,7 +59,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
   dependencies:
     - "camel:paho"

--- a/kamelets/mqtt-source.kamelet.yaml
+++ b/kamelets/mqtt-source.kamelet.yaml
@@ -64,7 +64,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
   dependencies:
     - "camel:paho"

--- a/kamelets/mqtt5-sink.kamelet.yaml
+++ b/kamelets/mqtt5-sink.kamelet.yaml
@@ -59,7 +59,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
   dependencies:
     - "camel:paho-mqtt5"

--- a/kamelets/mqtt5-source.kamelet.yaml
+++ b/kamelets/mqtt5-source.kamelet.yaml
@@ -64,7 +64,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
   dependencies:
     - "camel:paho-mqtt5"

--- a/kamelets/ms-exchange-online-imap-oauth-source.kamelet.yaml
+++ b/kamelets/ms-exchange-online-imap-oauth-source.kamelet.yaml
@@ -66,7 +66,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-          - urn:alm:descriptor:com.tectonic.ui:password
           - urn:camel:group:credentials
       username:
         title: Username

--- a/kamelets/mysql-sink.kamelet.yaml
+++ b/kamelets/mysql-sink.kamelet.yaml
@@ -74,7 +74,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       query:
         title: Query

--- a/kamelets/mysql-source.kamelet.yaml
+++ b/kamelets/mysql-source.kamelet.yaml
@@ -66,7 +66,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       query:
         title: Query

--- a/kamelets/nats-sink.kamelet.yaml
+++ b/kamelets/nats-sink.kamelet.yaml
@@ -47,7 +47,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
   dependencies:
   - "camel:nats"

--- a/kamelets/nats-source.kamelet.yaml
+++ b/kamelets/nats-source.kamelet.yaml
@@ -47,7 +47,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
   types:
     out:

--- a/kamelets/ogcapi-features-action.kamelet.yaml
+++ b/kamelets/ogcapi-features-action.kamelet.yaml
@@ -69,7 +69,6 @@ spec:
         type: boolean
         default: false
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       query:
         title: "Query"
         description: "Separated list by `&` of properties we want to query."

--- a/kamelets/ogcapi-features-action.kamelet.yaml
+++ b/kamelets/ogcapi-features-action.kamelet.yaml
@@ -68,7 +68,6 @@ spec:
         description: "When true, instead of returning the full geojson, split the message into each feature."
         type: boolean
         default: false
-        x-descriptors:
       query:
         title: "Query"
         description: "Separated list by `&` of properties we want to query."

--- a/kamelets/openai-classification-action.kamelet.yaml
+++ b/kamelets/openai-classification-action.kamelet.yaml
@@ -52,7 +52,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       format:
         title: Format

--- a/kamelets/openai-completion-action.kamelet.yaml
+++ b/kamelets/openai-completion-action.kamelet.yaml
@@ -50,7 +50,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       format:
         title: Format

--- a/kamelets/opensearch-index-sink.kamelet.yaml
+++ b/kamelets/opensearch-index-sink.kamelet.yaml
@@ -61,7 +61,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       enableSSL:
         title: Enable SSL
@@ -69,7 +68,6 @@ spec:
         type: boolean
         default: false
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       hostAddresses:
         title: Host Addresses
         description: A comma-separated list of remote transport addresses in `ip:port format`.

--- a/kamelets/opensearch-search-source.kamelet.yaml
+++ b/kamelets/opensearch-search-source.kamelet.yaml
@@ -64,7 +64,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       enableSSL:
         title: Enable SSL
@@ -72,7 +71,6 @@ spec:
         type: boolean
         default: false
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       hostAddresses:
         title: Host Addresses
         description: Comma separated list with ip:port formatted remote transport addresses to use.

--- a/kamelets/oracle-database-sink.kamelet.yaml
+++ b/kamelets/oracle-database-sink.kamelet.yaml
@@ -74,7 +74,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       query:
         title: Query

--- a/kamelets/oracle-database-source.kamelet.yaml
+++ b/kamelets/oracle-database-source.kamelet.yaml
@@ -66,7 +66,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       query:
         title: Query

--- a/kamelets/postgresql-sink.kamelet.yaml
+++ b/kamelets/postgresql-sink.kamelet.yaml
@@ -70,7 +70,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       query:
         title: Query

--- a/kamelets/postgresql-source.kamelet.yaml
+++ b/kamelets/postgresql-source.kamelet.yaml
@@ -62,7 +62,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       query:
         title: Query

--- a/kamelets/pulsar-sink.kamelet.yaml
+++ b/kamelets/pulsar-sink.kamelet.yaml
@@ -72,14 +72,12 @@ spec:
         description: The Authentication Parameters to be used while creating the client from URI.
         type: string
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:text'
       batchingEnabled:
         title: Enable Batching
         description: Control whether automatic batching of messages is enabled for the producer.
         type: boolean
         default: true
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       batchingMaxMessages:
         title: Batching Maximum Messages
         description: "The maximum size to batch messages."
@@ -96,7 +94,6 @@ spec:
         type: boolean
         default: false
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       compressionType:
         title: Compression Type
         description: "Compression type to use."
@@ -114,7 +111,6 @@ spec:
         type: boolean
         default: false
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       maxPendingMessages:
         title: Maximum Pending Messages
         description: "Size of the pending massages queue. When the queue is full, by default, any further sends will fail unless blockIfQueueFull=true."
@@ -131,9 +127,6 @@ spec:
         type: string
         default: "RoundRobinPartition"
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:select:SinglePartition'
-          - 'urn:alm:descriptor:com.tectonic.ui:select:RoundRobinPartition'
-          - 'urn:alm:descriptor:com.tectonic.ui:select:CustomPartition'
         enum: ["SinglePartition", "RoundRobinPartition", "CustomPartition"]
       producerName:
         title: Producer Name

--- a/kamelets/pulsar-sink.kamelet.yaml
+++ b/kamelets/pulsar-sink.kamelet.yaml
@@ -71,13 +71,11 @@ spec:
         title: Authentication Params
         description: The Authentication Parameters to be used while creating the client from URI.
         type: string
-        x-descriptors:
       batchingEnabled:
         title: Enable Batching
         description: Control whether automatic batching of messages is enabled for the producer.
         type: boolean
         default: true
-        x-descriptors:
       batchingMaxMessages:
         title: Batching Maximum Messages
         description: "The maximum size to batch messages."
@@ -93,7 +91,6 @@ spec:
         description: "Whether to block the producing thread if pending messages queue is full or to throw a ProducerQueueIsFullError."
         type: boolean
         default: false
-        x-descriptors:
       compressionType:
         title: Compression Type
         description: "Compression type to use."
@@ -110,7 +107,6 @@ spec:
         description: "Whether the producer should be started lazy (on the first message). By starting lazy you can use this to allow CamelContext and routes to startup in situations where a producer may otherwise fail during starting and cause the route to fail being started. By deferring this startup to be lazy then the startup failure can be handled during routing messages via Camel’s routing error handlers. Beware that when the first message is processed then creating and starting the producer may take a little time and prolong the total processing time of the processing."
         type: boolean
         default: false
-        x-descriptors:
       maxPendingMessages:
         title: Maximum Pending Messages
         description: "Size of the pending massages queue. When the queue is full, by default, any further sends will fail unless blockIfQueueFull=true."
@@ -126,7 +122,6 @@ spec:
         description: "Message Routing Mode to use."
         type: string
         default: "RoundRobinPartition"
-        x-descriptors:
         enum: ["SinglePartition", "RoundRobinPartition", "CustomPartition"]
       producerName:
         title: Producer Name

--- a/kamelets/pulsar-source.kamelet.yaml
+++ b/kamelets/pulsar-source.kamelet.yaml
@@ -99,7 +99,6 @@ spec:
         description: "Whether to use the messageListener interface, or to receive messages using a separate thread pool."
         type: boolean
         default: true
-        x-descriptors:
       numberOfConsumers:
         title: Number Of Consumers
         description: "Number of consumers."
@@ -115,7 +114,6 @@ spec:
         description: "Enable compacted topic reading."
         type: boolean
         default: false
-        x-descriptors:
       subscriptionInitialPosition:
         title: Subscription Initial Position
         description: "Control the initial position in the topic of a newly created subscription. Default is latest message."
@@ -144,7 +142,6 @@ spec:
         description: "Whether the topic is a pattern (regular expression) that allows the consumer to subscribe to all matching topics in the namespace."
         type: boolean
         default: false
-        x-descriptors:
     type: object
   template:
     from:

--- a/kamelets/pulsar-source.kamelet.yaml
+++ b/kamelets/pulsar-source.kamelet.yaml
@@ -100,7 +100,6 @@ spec:
         type: boolean
         default: true
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       numberOfConsumers:
         title: Number Of Consumers
         description: "Number of consumers."
@@ -117,7 +116,6 @@ spec:
         type: boolean
         default: false
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       subscriptionInitialPosition:
         title: Subscription Initial Position
         description: "Control the initial position in the topic of a newly created subscription. Default is latest message."
@@ -147,7 +145,6 @@ spec:
         type: boolean
         default: false
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
     type: object
   template:
     from:

--- a/kamelets/salesforce-composite-upsert-sink.kamelet.yaml
+++ b/kamelets/salesforce-composite-upsert-sink.kamelet.yaml
@@ -72,7 +72,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       userName:
         title: Username
@@ -86,7 +85,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
   types:
     in:

--- a/kamelets/salesforce-create-sink.kamelet.yaml
+++ b/kamelets/salesforce-create-sink.kamelet.yaml
@@ -63,7 +63,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       userName:
         title: Username
@@ -77,7 +76,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
   types:
     in:

--- a/kamelets/salesforce-delete-sink.kamelet.yaml
+++ b/kamelets/salesforce-delete-sink.kamelet.yaml
@@ -59,7 +59,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       userName:
         title: Username
@@ -73,7 +72,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
   types:
     in:

--- a/kamelets/salesforce-source.kamelet.yaml
+++ b/kamelets/salesforce-source.kamelet.yaml
@@ -74,7 +74,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       userName:
         title: Username
@@ -88,35 +87,30 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       notifyForOperationCreate:
         title: Notify Operation Create
         description: Notify for create operation.
         type: boolean
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: true
       notifyForOperationUpdate:
         title: Notify Operation Update
         description: Notify for update operation.
         type: boolean
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
       notifyForOperationDelete:
         title: Notify Operation Delete
         description: Notify for delete operation.
         type: boolean
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
       notifyForOperationUndelete:
         title: Notify Operation Undelete
         description: Notify for undelete operation.
         type: boolean
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
       operation:
         title: Operation

--- a/kamelets/salesforce-update-sink.kamelet.yaml
+++ b/kamelets/salesforce-update-sink.kamelet.yaml
@@ -65,7 +65,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       userName:
         title: Username
@@ -79,7 +78,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
   types:
     in:

--- a/kamelets/scp-sink.kamelet.yaml
+++ b/kamelets/scp-sink.kamelet.yaml
@@ -56,7 +56,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       privateKeyFile:
         title: Private Key File
@@ -77,7 +76,6 @@ spec:
         type: boolean
         default: true
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
   dependencies:
     - "camel:core"
     - "camel:jsch"

--- a/kamelets/set-kafka-key-action.kamelet.yaml
+++ b/kamelets/set-kafka-key-action.kamelet.yaml
@@ -46,7 +46,6 @@ spec:
         description: If true, it will remove the header with name headerName from the Exchange after setting it as Kafka Key
         type: boolean
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
     type: object
   dependencies:

--- a/kamelets/set-kafka-key-action.kamelet.yaml
+++ b/kamelets/set-kafka-key-action.kamelet.yaml
@@ -45,7 +45,6 @@ spec:
         title: Force Header Deletion
         description: If true, it will remove the header with name headerName from the Exchange after setting it as Kafka Key
         type: boolean
-        x-descriptors:
         default: false
     type: object
   dependencies:

--- a/kamelets/sftp-sink.kamelet.yaml
+++ b/kamelets/sftp-sink.kamelet.yaml
@@ -63,7 +63,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       directoryName:
         title: Directory Name
@@ -75,7 +74,6 @@ spec:
         type: boolean
         default: false
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       fileExist:
         title: File Existence
         description: How to behave in case of file already existent.
@@ -88,7 +86,6 @@ spec:
         type: boolean
         default: false
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       privateKeyFile:
         title: Private Key File
         description: Set the private key file so that the SFTP endpoint can do private key verification.
@@ -113,14 +110,12 @@ spec:
         type: boolean
         default: true
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       autoCreate:
         title: Autocreate Missing Directories
         description: Automatically create the directory the files should be written to.
         type: boolean
         default: true
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
   dependencies:
     - "camel:ftp"
     - "camel:core"

--- a/kamelets/sftp-source.kamelet.yaml
+++ b/kamelets/sftp-source.kamelet.yaml
@@ -59,7 +59,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       directoryName:
         title: Directory Name
@@ -71,35 +70,30 @@ spec:
         type: boolean
         default: false
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       recursive:
         title: Recursive
         description: If a directory, look for files in all sub-directories as well.
         type: boolean
         default: false
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       idempotent:
         title: Idempotency
         description: Skip already-processed files.
         type: boolean
         default: true
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       ignoreFileNotFoundOrPermissionError:
         title: Ignore File Not Found Or Permission Error
         description: Whether to ignore when (trying to list files in directories or when downloading a file), which does not exist or due to permission error. By default when a directory or file does not exists or insufficient permission, then an exception is thrown. Setting this option to true allows to ignore that instead.
         type: boolean
         default: false
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       binary:
         title: Binary
         description: Specifies the file transfer mode, BINARY or ASCII. Default is ASCII (false).
         type: boolean
         default: false
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       privateKeyFile:
         title: Private Key File
         description: Set the private key file so that the SFTP endpoint can do private key verification.
@@ -124,21 +118,18 @@ spec:
         type: boolean
         default: true
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       autoCreate:
         title: Autocreate Missing Directories
         description: Automatically create starting directory.
         type: boolean
         default: true
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       delete:
         title: Delete
         description: If true, the file will be deleted after it is processed successfully.
         type: boolean
         default: false
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
   dependencies:
     - "camel:ftp"
     - "camel:core"

--- a/kamelets/slack-sink.kamelet.yaml
+++ b/kamelets/slack-sink.kamelet.yaml
@@ -48,7 +48,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       iconEmoji:
         title: Icon Emoji

--- a/kamelets/slack-source.kamelet.yaml
+++ b/kamelets/slack-source.kamelet.yaml
@@ -48,7 +48,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       delay:
         title: Delay

--- a/kamelets/splunk-hec-sink.kamelet.yaml
+++ b/kamelets/splunk-hec-sink.kamelet.yaml
@@ -49,7 +49,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       hostPayload:
         title: Host of the Event
@@ -60,14 +59,12 @@ spec:
         description: Send to Splunk only data contained in the body.
         type: boolean
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:checkbox
         default: false
       headersOnly:
         title: Headers Only
         description: Send to Splunk only data contained in the headers.
         type: boolean
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:checkbox
         default: false
       index:
         title: Index
@@ -86,14 +83,12 @@ spec:
         description: Skip TLS verification.
         type: boolean
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:checkbox
         default: false
       https:
         title: Secure
         description: Use a secure HTTPS connection.
         type: boolean
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:checkbox
         default: true
       time:
         title: Time

--- a/kamelets/splunk-sink.kamelet.yaml
+++ b/kamelets/splunk-sink.kamelet.yaml
@@ -61,7 +61,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       index:
         title: Index

--- a/kamelets/splunk-source.kamelet.yaml
+++ b/kamelets/splunk-source.kamelet.yaml
@@ -63,7 +63,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       index:
         title: Index

--- a/kamelets/sqlserver-sink.kamelet.yaml
+++ b/kamelets/sqlserver-sink.kamelet.yaml
@@ -74,7 +74,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       query:
         title: Query
@@ -90,14 +89,12 @@ spec:
         description: Encrypt the connection to SQL Server.
         type: boolean
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
       trustServerCertificate:
         title: Trust Server Certificate
         description: Trust Server Certificate
         type: boolean
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: true
   types:
     in:

--- a/kamelets/sqlserver-source.kamelet.yaml
+++ b/kamelets/sqlserver-source.kamelet.yaml
@@ -66,7 +66,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       query:
         title: Query
@@ -87,14 +86,12 @@ spec:
         description: Encrypt the connection to SQL Server.
         type: boolean
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
       trustServerCertificate:
         title: Trust Server Certificate
         description: Trust Server Certificate
         type: boolean
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: true
       delay:
         title: Delay

--- a/kamelets/ssh-sink.kamelet.yaml
+++ b/kamelets/ssh-sink.kamelet.yaml
@@ -60,7 +60,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
   types:
     in:

--- a/kamelets/ssh-source.kamelet.yaml
+++ b/kamelets/ssh-source.kamelet.yaml
@@ -61,7 +61,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       delay:
         title: Delay

--- a/kamelets/telegram-sink.kamelet.yaml
+++ b/kamelets/telegram-sink.kamelet.yaml
@@ -55,7 +55,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       chatId:
         title: Chat ID

--- a/kamelets/telegram-source.kamelet.yaml
+++ b/kamelets/telegram-source.kamelet.yaml
@@ -49,7 +49,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
   types:
     out:

--- a/kamelets/twitter-directmessage-source.kamelet.yaml
+++ b/kamelets/twitter-directmessage-source.kamelet.yaml
@@ -54,7 +54,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       apiKeySecret:
         title: API Key Secret
@@ -62,7 +61,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       accessToken:
         title: Access Token
@@ -70,7 +68,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       accessTokenSecret:
         title: Access Token Secret
@@ -78,7 +75,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
   types:
     out:

--- a/kamelets/twitter-search-source.kamelet.yaml
+++ b/kamelets/twitter-search-source.kamelet.yaml
@@ -54,7 +54,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       apiKeySecret:
         title: API Key Secret
@@ -62,7 +61,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       accessToken:
         title: Access Token
@@ -70,7 +68,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       accessTokenSecret:
         title: Access Token Secret
@@ -78,7 +75,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
   types:
     out:

--- a/kamelets/twitter-timeline-source.kamelet.yaml
+++ b/kamelets/twitter-timeline-source.kamelet.yaml
@@ -54,7 +54,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       apiKeySecret:
         title: API Key Secret
@@ -62,7 +61,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       accessToken:
         title: Access Token
@@ -70,7 +68,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       accessTokenSecret:
         title: Access Token Secret
@@ -78,7 +75,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
   types:
     out:

--- a/library/camel-kamelets/src/main/resources/kamelets/avro-deserialize-action.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/avro-deserialize-action.kamelet.yaml
@@ -45,7 +45,6 @@ spec:
         type: boolean
         default: true
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
   dependencies:
   - "camel:kamelet"
   - "camel:core"

--- a/library/camel-kamelets/src/main/resources/kamelets/avro-deserialize-action.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/avro-deserialize-action.kamelet.yaml
@@ -44,7 +44,6 @@ spec:
         description: Indicates if the content must be validated against the schema
         type: boolean
         default: true
-        x-descriptors:
   dependencies:
   - "camel:kamelet"
   - "camel:core"

--- a/library/camel-kamelets/src/main/resources/kamelets/avro-serialize-action.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/avro-serialize-action.kamelet.yaml
@@ -45,7 +45,6 @@ spec:
         type: boolean
         default: true
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
   dependencies:
   - "camel:kamelet"
   - "camel:core"

--- a/library/camel-kamelets/src/main/resources/kamelets/avro-serialize-action.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/avro-serialize-action.kamelet.yaml
@@ -44,7 +44,6 @@ spec:
         description: Indicates if the content must be validated against the schema
         type: boolean
         default: true
-        x-descriptors:
   dependencies:
   - "camel:kamelet"
   - "camel:core"

--- a/library/camel-kamelets/src/main/resources/kamelets/aws-cloudtrail-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/aws-cloudtrail-source.kamelet.yaml
@@ -28,7 +28,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       secretKey:
         title: Secret Key
@@ -36,7 +35,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       region:
         title: AWS Region
@@ -48,7 +46,6 @@ spec:
         description: If true, the Cloudtrail client loads credentials through a default credentials provider. If false, it uses the basic authentication method (access key and secret key).
         type: boolean
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
       uriEndpointOverride:
         title: Overwrite Endpoint URI
@@ -59,7 +56,6 @@ spec:
         description: Select this option to override the endpoint URI. To use this option, you must also provide a URI for the `uriEndpointOverride` option.
         type: boolean
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
       maxResults:
         title: Max Results

--- a/library/camel-kamelets/src/main/resources/kamelets/aws-cloudwatch-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/aws-cloudwatch-sink.kamelet.yaml
@@ -61,7 +61,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       secretKey:
         title: Secret Key
@@ -69,7 +68,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       region:
         title: AWS Region
@@ -81,7 +79,6 @@ spec:
         description: If true, the CloudWatch client loads credentials through a default credentials provider. If false, it uses the basic authentication method (access key and secret key).
         type: boolean
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
       uriEndpointOverride:
         title: Overwrite Endpoint URI
@@ -92,7 +89,6 @@ spec:
         description: Select this option to override the endpoint URI. To use this option, you must also provide a URI for the `uriEndpointOverride` option.
         type: boolean
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
   dependencies:
     - "camel:core"

--- a/library/camel-kamelets/src/main/resources/kamelets/aws-ddb-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/aws-ddb-sink.kamelet.yaml
@@ -65,7 +65,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       secretKey:
         title: Secret Key
@@ -73,7 +72,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       region:
         title: AWS Region
@@ -92,7 +90,6 @@ spec:
         description: If true, the DynamoDB client loads credentials through a default credentials provider. If false, it uses the basic authentication method (access key and secret key).
         type: boolean
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
       uriEndpointOverride:
         title: Overwrite Endpoint URI
@@ -103,7 +100,6 @@ spec:
         description: Select this option to override the endpoint URI. To use this option, you must also provide a URI for the `uriEndpointOverride` option.
         type: boolean
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
   dataTypes:
     in:

--- a/library/camel-kamelets/src/main/resources/kamelets/aws-ddb-streams-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/aws-ddb-streams-source.kamelet.yaml
@@ -52,7 +52,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       secretKey:
         title: Secret Key
@@ -60,7 +59,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       region:
         title: AWS Region
@@ -77,7 +75,6 @@ spec:
         description: If true, the DynamoDB client loads credentials through a default credentials provider. If false, it uses the basic authentication method (access key and secret key).
         type: boolean
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
       uriEndpointOverride:
         title: Overwrite Endpoint URI
@@ -88,7 +85,6 @@ spec:
         description: Select this option to override the endpoint URI. To use this option, you must also provide a URI for the `uriEndpointOverride` option.
         type: boolean
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
       delay:
         title: Delay

--- a/library/camel-kamelets/src/main/resources/kamelets/aws-ec2-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/aws-ec2-sink.kamelet.yaml
@@ -51,7 +51,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       secretKey:
         title: Secret Key
@@ -59,7 +58,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       region:
         title: AWS Region
@@ -71,7 +69,6 @@ spec:
         description: If true, the CloudWatch client loads credentials through a default credentials provider. If false, it uses the basic authentication method (access key and secret key).
         type: boolean
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
       uriEndpointOverride:
         title: Overwrite Endpoint URI
@@ -82,7 +79,6 @@ spec:
         description: Select this option to override the endpoint URI. To use this option, you must also provide a URI for the `uriEndpointOverride` option.
         type: boolean
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
   dependencies:
     - "camel:core"

--- a/library/camel-kamelets/src/main/resources/kamelets/aws-eventbridge-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/aws-eventbridge-sink.kamelet.yaml
@@ -60,7 +60,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       secretKey:
         title: Secret Key
@@ -68,7 +67,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       region:
         title: AWS Region
@@ -80,7 +78,6 @@ spec:
         description: If true, the Eventbridge client loads credentials through a default credentials provider. If false, it uses the basic authentication method (access key and secret key).
         type: boolean
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
       uriEndpointOverride:
         title: Overwrite Endpoint URI
@@ -91,7 +88,6 @@ spec:
         description: Select this option to override the endpoint URI. To use this option, you must also provide a URI for the `uriEndpointOverride` option.
         type: boolean
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
   dependencies:
     - "camel:core"

--- a/library/camel-kamelets/src/main/resources/kamelets/aws-kinesis-firehose-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/aws-kinesis-firehose-sink.kamelet.yaml
@@ -52,7 +52,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       secretKey:
         title: Secret Key
@@ -60,7 +59,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       region:
         title: AWS Region
@@ -72,7 +70,6 @@ spec:
         description: Set whether the Kinesis Firehose client should expect to load credentials through a default credentials provider or to expect static credentials to be passed in.
         type: boolean
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
       uriEndpointOverride:
         title: Overwrite Endpoint URI
@@ -83,7 +80,6 @@ spec:
         description: Select this option to override the endpoint URI. To use this option, you must also provide a URI for the `uriEndpointOverride` option.
         type: boolean
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
   dependencies:
     - "camel:aws2-kinesis"

--- a/library/camel-kamelets/src/main/resources/kamelets/aws-kinesis-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/aws-kinesis-sink.kamelet.yaml
@@ -59,7 +59,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       secretKey:
         title: Secret Key
@@ -67,7 +66,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       region:
         title: AWS Region
@@ -79,7 +77,6 @@ spec:
         description: If true, the Kinesis client loads credentials through a default credentials provider. If false, it uses the basic authentication method (access key and secret key).
         type: boolean
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
       uriEndpointOverride:
         title: Overwrite Endpoint URI
@@ -90,7 +87,6 @@ spec:
         description: Select this option to override the endpoint URI. To use this option, you must also provide a URI for the `uriEndpointOverride` option.
         type: boolean
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
   types:
     in:

--- a/library/camel-kamelets/src/main/resources/kamelets/aws-kinesis-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/aws-kinesis-source.kamelet.yaml
@@ -54,7 +54,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       secretKey:
         title: Secret Key
@@ -62,7 +61,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       region:
         title: AWS Region
@@ -74,7 +72,6 @@ spec:
         description: If true, the Kinesis client loads credentials through a default credentials provider. If false, it uses the basic authentication method (access key and secret key).
         type: boolean
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
       uriEndpointOverride:
         title: Overwrite Endpoint URI
@@ -85,7 +82,6 @@ spec:
         description: Select this option to override the endpoint URI. To use this option, you must also provide a URI for the `uriEndpointOverride` option.
         type: boolean
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
       delay:
         title: Delay

--- a/library/camel-kamelets/src/main/resources/kamelets/aws-lambda-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/aws-lambda-sink.kamelet.yaml
@@ -52,7 +52,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       secretKey:
         title: Secret Key
@@ -60,7 +59,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       region:
         title: AWS Region
@@ -72,7 +70,6 @@ spec:
         description: If true, the Lambda client loads credentials through a default credentials provider. If false, it uses the basic authentication method (access key and secret key).
         type: boolean
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
   dependencies:
     - "camel:aws2-lambda"

--- a/library/camel-kamelets/src/main/resources/kamelets/aws-redshift-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/aws-redshift-sink.kamelet.yaml
@@ -70,7 +70,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       query:
         title: Query

--- a/library/camel-kamelets/src/main/resources/kamelets/aws-redshift-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/aws-redshift-source.kamelet.yaml
@@ -62,7 +62,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       query:
         title: Query

--- a/library/camel-kamelets/src/main/resources/kamelets/aws-s3-cdc-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/aws-s3-cdc-source.kamelet.yaml
@@ -41,7 +41,6 @@ spec:
         description: Delete messages after consuming them
         type: boolean
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: true
       accessKey:
         title: Access Key
@@ -49,7 +48,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:password'
           - 'urn:camel:group:credentials'
           - 'urn:keda:authentication:awsAccessKeyID'
           - 'urn:keda:required'
@@ -59,7 +57,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:password'
           - 'urn:camel:group:credentials'
           - 'urn:keda:authentication:awsSecretAccessKey'
           - 'urn:keda:required'
@@ -111,7 +108,6 @@ spec:
         description: Setting the autocreation of the SQS queue.
         type: boolean
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
       amazonAWSHost:
         title: AWS Host
@@ -144,7 +140,6 @@ spec:
           you must also provide a URI for the `uriEndpointOverride` option.
         type: boolean
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
       delay:
         title: Delay
@@ -158,7 +153,6 @@ spec:
           if the previous run polled 1 or more messages.
         type: boolean
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
       getObject:
         title: Greedy Object in Bucket
@@ -167,7 +161,6 @@ spec:
           get and returned as body, if not only the event will returned as body.
         type: boolean
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
   dependencies:
     - 'camel:core'

--- a/library/camel-kamelets/src/main/resources/kamelets/aws-s3-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/aws-s3-sink.kamelet.yaml
@@ -56,7 +56,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       secretKey:
         title: Secret Key
@@ -64,7 +63,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       region:
         title: AWS Region
@@ -76,14 +74,12 @@ spec:
         description: Specifies to automatically create the S3 bucket.
         type: boolean
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
       useDefaultCredentialsProvider:
         title: Default Credentials Provider
         description: If true, the S3 client loads credentials through a default credentials provider. If false, it uses the basic authentication method (access key and secret key).
         type: boolean
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
       uriEndpointOverride:
         title: Overwrite Endpoint URI
@@ -94,14 +90,12 @@ spec:
         description: Select this option to override the endpoint URI. To use this option, you must also provide a URI for the `uriEndpointOverride` option.
         type: boolean
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
       forcePathStyle:
         title: Force Path Style
         description: Forces path style when accessing AWS S3 buckets.
         type: boolean
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
       keyName:
         title: Key Name

--- a/library/camel-kamelets/src/main/resources/kamelets/aws-s3-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/aws-s3-source.kamelet.yaml
@@ -36,7 +36,6 @@ spec:
         description: Specifies to delete objects after consuming them.
         type: boolean
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: true
       accessKey:
         title: Access Key
@@ -44,7 +43,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       secretKey:
         title: Secret Key
@@ -52,7 +50,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       region:
         title: AWS Region
@@ -64,7 +61,6 @@ spec:
         description: Specifies to automatically create the S3 bucket.
         type: boolean
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
       prefix:
         title: Prefix
@@ -76,14 +72,12 @@ spec:
         description: If true, the S3 Object body is ignored. Setting this to true overrides any behavior defined by the `includeBody` option. If false, the S3 object is put in the body.
         type: boolean
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
       useDefaultCredentialsProvider:
         title: Default Credentials Provider
         description: If true, the S3 client loads credentials through a default credentials provider. If false, it uses the basic authentication method (access key and secret key).
         type: boolean
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
       uriEndpointOverride:
         title: Overwrite Endpoint URI
@@ -94,14 +88,12 @@ spec:
         description: Select this option to override the endpoint URI. To use this option, you must also provide a URI for the `uriEndpointOverride` option.
         type: boolean
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
       forcePathStyle:
         title: Force Path Style
         description: Forces path style when accessing AWS S3 buckets.
         type: boolean
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
       delay:
         title: Delay

--- a/library/camel-kamelets/src/main/resources/kamelets/aws-s3-streaming-upload-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/aws-s3-streaming-upload-sink.kamelet.yaml
@@ -53,7 +53,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       secretKey:
         title: Secret Key
@@ -61,7 +60,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       region:
         title: AWS Region
@@ -73,7 +71,6 @@ spec:
         description: Setting the autocreation of the S3 bucket bucketName.
         type: boolean
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
       restartingPolicy:
         title: Restarting Policy
@@ -108,7 +105,6 @@ spec:
         description: Set whether the S3 client should expect to load credentials through a default credentials provider or to expect static credentials to be passed in.
         type: boolean
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
       uriEndpointOverride:
         title: Overwrite Endpoint URI
@@ -119,14 +115,12 @@ spec:
         description: Select this option to override the endpoint URI. To use this option, you must also provide a URI for the `uriEndpointOverride` option.
         type: boolean
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
       forcePathStyle:
         title: Force Path Style
         description: Forces path style when accessing AWS S3 buckets.
         type: boolean
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
   dependencies:
     - "camel:aws2-s3"

--- a/library/camel-kamelets/src/main/resources/kamelets/aws-secrets-manager-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/aws-secrets-manager-sink.kamelet.yaml
@@ -53,7 +53,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       secretKey:
         title: Secret Key
@@ -61,7 +60,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       region:
         title: AWS Region
@@ -73,7 +71,6 @@ spec:
         description: Set whether the Secrets Manager client should expect to load credentials through a default credentials provider or to expect static credentials to be passed in.
         type: boolean
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
   dependencies:
     - "camel:core"

--- a/library/camel-kamelets/src/main/resources/kamelets/aws-ses-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/aws-ses-sink.kamelet.yaml
@@ -62,7 +62,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       secretKey:
         title: Secret Key
@@ -70,7 +69,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       region:
         title: AWS Region
@@ -82,7 +80,6 @@ spec:
         description: If true, the SES client loads credentials through a default credentials provider. If false, it uses the basic authentication method (access key and secret key).
         type: boolean
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
   dependencies:
     - "camel:core"

--- a/library/camel-kamelets/src/main/resources/kamelets/aws-sns-fifo-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/aws-sns-fifo-sink.kamelet.yaml
@@ -56,7 +56,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       secretKey:
         title: Secret Key
@@ -64,7 +63,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       region:
         title: AWS Region
@@ -77,20 +75,17 @@ spec:
         type: boolean
         default: false
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       autoCreateTopic:
         title: Autocreate Topic
         description: Setting the autocreation of the SNS topic. 
         type: boolean
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
       useDefaultCredentialsProvider:
         title: Default Credentials Provider
         description: Set whether the SNS client should expect to load credentials through a default credentials provider or to expect static credentials to be passed in.
         type: boolean
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
       uriEndpointOverride:
         title: Overwrite Endpoint URI
@@ -101,7 +96,6 @@ spec:
         description: Select this option to override the endpoint URI. To use this option, you must also provide a URI for the `uriEndpointOverride` option.
         type: boolean
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
   dependencies:
   - "camel:aws2-sns"

--- a/library/camel-kamelets/src/main/resources/kamelets/aws-sns-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/aws-sns-sink.kamelet.yaml
@@ -54,7 +54,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       secretKey:
         title: Secret Key
@@ -62,7 +61,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       region:
         title: AWS Region
@@ -74,14 +72,12 @@ spec:
         description: Setting the autocreation of the SNS topic. 
         type: boolean
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
       useDefaultCredentialsProvider:
         title: Default Credentials Provider
         description: If true, the SNS client loads credentials through a default credentials provider. If false, it uses the basic authentication method (access key and secret key).
         type: boolean
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
       uriEndpointOverride:
         title: Overwrite Endpoint URI
@@ -92,7 +88,6 @@ spec:
         description: Select this option to override the endpoint URI. To use this option, you must also provide a URI for the `uriEndpointOverride` option.
         type: boolean
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
   dependencies:
     - "camel:core"

--- a/library/camel-kamelets/src/main/resources/kamelets/aws-sqs-batch-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/aws-sqs-batch-sink.kamelet.yaml
@@ -53,7 +53,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       secretKey:
         title: Secret Key
@@ -61,7 +60,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       region:
         title: AWS Region
@@ -73,7 +71,6 @@ spec:
         description: Setting the autocreation of the SQS queue. 
         type: boolean
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
       batchSeparator:
         title: Batch Separator
@@ -96,7 +93,6 @@ spec:
         description: Set whether the SQS client should expect to load credentials through a default credentials provider or to expect static credentials to be passed in.
         type: boolean
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
       uriEndpointOverride:
         title: Overwrite Endpoint URI
@@ -107,7 +103,6 @@ spec:
         description: Select this option to override the endpoint URI. To use this option, you must also provide a URI for the `uriEndpointOverride` option.
         type: boolean
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false        
   dependencies:
     - "camel:aws2-sqs"

--- a/library/camel-kamelets/src/main/resources/kamelets/aws-sqs-fifo-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/aws-sqs-fifo-sink.kamelet.yaml
@@ -52,7 +52,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       secretKey:
         title: Secret Key
@@ -60,7 +59,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       region:
         title: AWS Region
@@ -73,13 +71,11 @@ spec:
         type: boolean
         default: false
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       autoCreateQueue:
         title: Autocreate Queue
         description: Setting the autocreation of the SQS queue. 
         type: boolean
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
       amazonAWSHost:
         title: AWS Host
@@ -97,7 +93,6 @@ spec:
         description: Set whether the SQS client should expect to load credentials through a default credentials provider or to expect static credentials to be passed in.
         type: boolean
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
       uriEndpointOverride:
         title: Overwrite Endpoint URI
@@ -108,7 +103,6 @@ spec:
         description: Select this option to override the endpoint URI. To use this option, you must also provide a URI for the `uriEndpointOverride` option.
         type: boolean
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false   
   dependencies:
   - "camel:aws2-sqs"

--- a/library/camel-kamelets/src/main/resources/kamelets/aws-sqs-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/aws-sqs-sink.kamelet.yaml
@@ -52,7 +52,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       secretKey:
         title: Secret Key
@@ -60,7 +59,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       region:
         title: AWS Region
@@ -72,7 +70,6 @@ spec:
         description: Automatically create the SQS queue. 
         type: boolean
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
       amazonAWSHost:
         title: AWS Host
@@ -90,7 +87,6 @@ spec:
         description: If true, the SQS client loads credentials through a default credentials provider. If false, it uses the basic authentication method (access key and secret key).
         type: boolean
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
       uriEndpointOverride:
         title: Overwrite Endpoint URI
@@ -101,7 +97,6 @@ spec:
         description: Select this option to override the endpoint URI. To use this option, you must also provide a URI for the `uriEndpointOverride` option.
         type: boolean
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false    
   dependencies:
     - "camel:aws2-sqs"

--- a/library/camel-kamelets/src/main/resources/kamelets/aws-sqs-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/aws-sqs-source.kamelet.yaml
@@ -54,7 +54,6 @@ spec:
         description: Delete messages after consuming them
         type: boolean
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: true
       accessKey:
         title: Access Key
@@ -62,7 +61,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
         - urn:keda:authentication:awsAccessKeyID
         - urn:keda:required
@@ -72,7 +70,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
         - urn:keda:authentication:awsSecretAccessKey
         - urn:keda:required
@@ -89,7 +86,6 @@ spec:
         description: Setting the autocreation of the SQS queue. 
         type: boolean
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
       amazonAWSHost:
         title: AWS Host
@@ -114,7 +110,6 @@ spec:
         description: If true, the SQS client loads credentials through a default credentials provider. If false, it uses the basic authentication method (access key and secret key).
         type: boolean
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
       uriEndpointOverride:
         title: Overwrite Endpoint URI
@@ -125,7 +120,6 @@ spec:
         description: Select this option to override the endpoint URI. To use this option, you must also provide a URI for the `uriEndpointOverride` option.
         type: boolean
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
       delay:
         title: Delay
@@ -137,7 +131,6 @@ spec:
         description: If greedy is enabled, then the polling will happen immediately again, if the previous run polled 1 or more messages.
         type: boolean
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
   dataTypes:
     out:

--- a/library/camel-kamelets/src/main/resources/kamelets/aws-translate-action.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/aws-translate-action.kamelet.yaml
@@ -49,7 +49,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       secretKey:
         title: Secret Key
@@ -57,7 +56,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       region:
         title: AWS Region
@@ -81,7 +79,6 @@ spec:
         description: Set whether the Translate client should expect to load credentials through a default credentials provider or to expect static credentials to be passed in.
         type: boolean
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
   dependencies:
     - "camel:dns"

--- a/library/camel-kamelets/src/main/resources/kamelets/azure-cosmosdb-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/azure-cosmosdb-sink.kamelet.yaml
@@ -58,7 +58,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       databaseEndpoint:
         title: Database Endpoint

--- a/library/camel-kamelets/src/main/resources/kamelets/azure-cosmosdb-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/azure-cosmosdb-source.kamelet.yaml
@@ -54,7 +54,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       leaseDatabaseName:
         title: Lease Database Name
@@ -69,14 +68,12 @@ spec:
         description: Sets if the component should create Cosmos lease database for the consumer automatically in case it doesn’t exist in Cosmos account. 
         type: boolean
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
       createLeaseContainerIfNotExists:
         title: Autocreate Lease Container
         description: Sets if the component should create Cosmos lease container for the consumer automatically in case it doesn’t exist in Cosmos database. 
         type: boolean
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
       databaseEndpoint:
         title: Database Endpoint

--- a/library/camel-kamelets/src/main/resources/kamelets/azure-eventhubs-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/azure-eventhubs-sink.kamelet.yaml
@@ -64,7 +64,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
   dependencies:
     - "camel:core"

--- a/library/camel-kamelets/src/main/resources/kamelets/azure-eventhubs-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/azure-eventhubs-source.kamelet.yaml
@@ -63,7 +63,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       blobAccountName:
         title: Azure Storage Blob Account Name
@@ -79,7 +78,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
   types:
     out:

--- a/library/camel-kamelets/src/main/resources/kamelets/azure-functions-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/azure-functions-sink.kamelet.yaml
@@ -53,7 +53,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
   dependencies:
   - "camel:vertx-http"

--- a/library/camel-kamelets/src/main/resources/kamelets/azure-servicebus-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/azure-servicebus-sink.kamelet.yaml
@@ -48,7 +48,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       serviceBusType:
         title: Servicebus Type

--- a/library/camel-kamelets/src/main/resources/kamelets/azure-servicebus-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/azure-servicebus-source.kamelet.yaml
@@ -50,7 +50,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       serviceBusReceiveMode:
         title: Servicebus Receive Mode

--- a/library/camel-kamelets/src/main/resources/kamelets/azure-storage-blob-append-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/azure-storage-blob-append-sink.kamelet.yaml
@@ -56,7 +56,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       credentialType:
         title: Credential Type

--- a/library/camel-kamelets/src/main/resources/kamelets/azure-storage-blob-cdc-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/azure-storage-blob-cdc-source.kamelet.yaml
@@ -55,7 +55,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       serviceBusReceiveMode:
         title: Servicebus Receive Mode
@@ -83,7 +82,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       credentialType:
         title: Credential Type
@@ -98,7 +96,6 @@ spec:
           get and returned as body, if not only the event will be returned as body.
         type: boolean
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
   types:
     out:

--- a/library/camel-kamelets/src/main/resources/kamelets/azure-storage-blob-changefeed-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/azure-storage-blob-changefeed-source.kamelet.yaml
@@ -56,7 +56,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-          - urn:alm:descriptor:com.tectonic.ui:password
           - urn:camel:group:credentials
   dependencies:
     - "camel:azure-storage-blob"

--- a/library/camel-kamelets/src/main/resources/kamelets/azure-storage-blob-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/azure-storage-blob-sink.kamelet.yaml
@@ -56,7 +56,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       credentialType:
         title: Credential Type

--- a/library/camel-kamelets/src/main/resources/kamelets/azure-storage-blob-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/azure-storage-blob-source.kamelet.yaml
@@ -56,7 +56,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       delay:
         title: Delay
@@ -68,7 +67,6 @@ spec:
         description: Specifies to delete blobs after consuming them
         type: boolean
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
       credentialType:
         title: Credential Type

--- a/library/camel-kamelets/src/main/resources/kamelets/azure-storage-datalake-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/azure-storage-datalake-sink.kamelet.yaml
@@ -53,7 +53,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       clientSecret:
         title: Client Secret
@@ -61,7 +60,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       tenantId:
         title: Tenant Id
@@ -69,7 +67,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       fileSystemName:
         title: File System Name

--- a/library/camel-kamelets/src/main/resources/kamelets/azure-storage-datalake-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/azure-storage-datalake-source.kamelet.yaml
@@ -53,7 +53,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       clientSecret:
         title: Client Secret
@@ -61,7 +60,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       tenantId:
         title: Tenant Id
@@ -69,7 +67,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       fileSystemName:
         title: File System Name

--- a/library/camel-kamelets/src/main/resources/kamelets/azure-storage-queue-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/azure-storage-queue-sink.kamelet.yaml
@@ -57,7 +57,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
   dependencies:
     - "camel:core"

--- a/library/camel-kamelets/src/main/resources/kamelets/azure-storage-queue-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/azure-storage-queue-source.kamelet.yaml
@@ -57,7 +57,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password        
         - urn:camel:group:credentials
       maxMessages:
         title: Maximum Messages

--- a/library/camel-kamelets/src/main/resources/kamelets/cassandra-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/cassandra-sink.kamelet.yaml
@@ -68,7 +68,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       consistencyLevel:
         title: Consistency Level
@@ -82,7 +81,6 @@ spec:
         type: boolean
         default: true
         x-descriptors:
-          - urn:alm:descriptor:com.tectonic.ui:checkbox
       query:
         title: Query
         description: The query to execute against the Cassandra cluster table.

--- a/library/camel-kamelets/src/main/resources/kamelets/cassandra-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/cassandra-source.kamelet.yaml
@@ -66,7 +66,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       resultStrategy:
         title: Result Strategy

--- a/library/camel-kamelets/src/main/resources/kamelets/ceph-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/ceph-sink.kamelet.yaml
@@ -55,7 +55,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       secretKey:
         title: Secret Key
@@ -63,7 +62,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       zoneGroup:
         title: Bucket Zone Group
@@ -74,7 +72,6 @@ spec:
         description: Specifies to automatically create the bucket.
         type: boolean
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
       cephUrl:
         title: Ceph Url Address

--- a/library/camel-kamelets/src/main/resources/kamelets/ceph-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/ceph-source.kamelet.yaml
@@ -51,7 +51,6 @@ spec:
         description: Specifies to delete objects after consuming them.
         type: boolean
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: true
       accessKey:
         title: Access Key
@@ -59,7 +58,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       secretKey:
         title: Secret Key
@@ -67,7 +65,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       zoneGroup:
         title: Bucket Zone Group
@@ -78,14 +75,12 @@ spec:
         description: Specifies to automatically create the bucket.
         type: boolean
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
       includeBody:
         title: Include Body
         description: If true, the exchange is consumed and put into the body and closed. If false, the Object stream is put raw into the body and the headers are set with the object metadata.
         type: boolean
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: true
       prefix:
         title: Prefix
@@ -97,7 +92,6 @@ spec:
         description: If true, the Object body is ignored. Setting this to true overrides any behavior defined by the `includeBody` option. If false, the object is put in the body.
         type: boolean
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
       cephUrl:
         title: Ceph Url Address

--- a/library/camel-kamelets/src/main/resources/kamelets/couchbase-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/couchbase-sink.kamelet.yaml
@@ -67,7 +67,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       startingId:
         title: Starting Id
@@ -80,7 +79,6 @@ spec:
         type: boolean
         default: true
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:checkbox
   dependencies:
     - "camel:couchbase"
     - "camel:kamelet"

--- a/library/camel-kamelets/src/main/resources/kamelets/dropbox-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/dropbox-sink.kamelet.yaml
@@ -51,7 +51,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       clientIdentifier:
         title: Client Identifier

--- a/library/camel-kamelets/src/main/resources/kamelets/dropbox-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/dropbox-source.kamelet.yaml
@@ -51,7 +51,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       clientIdentifier:
         title: Client Identifier

--- a/library/camel-kamelets/src/main/resources/kamelets/elasticsearch-index-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/elasticsearch-index-sink.kamelet.yaml
@@ -61,7 +61,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       enableSSL:
         title: Enable SSL
@@ -69,7 +68,6 @@ spec:
         type: boolean
         default: true
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       hostAddresses:
         title: Host Addresses
         description: A comma-separated list of remote transport addresses in `ip:port format`.

--- a/library/camel-kamelets/src/main/resources/kamelets/elasticsearch-search-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/elasticsearch-search-source.kamelet.yaml
@@ -64,7 +64,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       enableSSL:
         title: Enable SSL
@@ -72,7 +71,6 @@ spec:
         type: boolean
         default: true
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       hostAddresses:
         title: Host Addresses
         description: Comma separated list with ip:port formatted remote transport addresses to use.

--- a/library/camel-kamelets/src/main/resources/kamelets/extract-field-action.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/extract-field-action.kamelet.yaml
@@ -58,7 +58,6 @@ spec:
         type: boolean
         default: false
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       headerOutputName:
         title: Header Output Name
         description: A custom name for the header containing the extracted field
@@ -70,14 +69,12 @@ spec:
         type: boolean
         default: false
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       trimField:
         title: Trim Field
         description: If enabled we return the Raw extracted field
         type: boolean
         default: false
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
     type: object
   dependencies:
   - "mvn:org.apache.camel.kamelets:camel-kamelets-utils:4.2.0-SNAPSHOT"

--- a/library/camel-kamelets/src/main/resources/kamelets/extract-field-action.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/extract-field-action.kamelet.yaml
@@ -57,7 +57,6 @@ spec:
         description: If enable the action will store the extracted field in an header named CamelKameletsExtractFieldName
         type: boolean
         default: false
-        x-descriptors:
       headerOutputName:
         title: Header Output Name
         description: A custom name for the header containing the extracted field
@@ -68,13 +67,11 @@ spec:
         description: If enabled the action will check if the header output name (custom or default) has been used already in the exchange. If so, the extracted field will be stored in the message body, if not, the extracted field will be stored in the selected header (custom or default).
         type: boolean
         default: false
-        x-descriptors:
       trimField:
         title: Trim Field
         description: If enabled we return the Raw extracted field
         type: boolean
         default: false
-        x-descriptors:
     type: object
   dependencies:
   - "mvn:org.apache.camel.kamelets:camel-kamelets-utils:4.2.0-SNAPSHOT"

--- a/library/camel-kamelets/src/main/resources/kamelets/fhir-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/fhir-sink.kamelet.yaml
@@ -46,14 +46,12 @@ spec:
         description: "Will log every requests and responses."
         type: boolean
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
       prettyPrint:
         title: Pretty Print
         description: "Pretty print all request."
         type: boolean
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
       serverUrl:
         title: Server URL
@@ -64,7 +62,6 @@ spec:
         description: "Whether the producer should be started lazy (on the first message). By starting lazy you can use this to allow CamelContext and routes to startup in situations where a producer may otherwise fail during starting and cause the route to fail being started. By deferring this startup to be lazy then the startup failure can be handled during routing messages via Camel’s routing error handlers. Beware that when the first message is processed then creating and starting the producer may take a little time and prolong the total processing time of the processing."
         type: boolean
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
       proxyHost:
         title: Proxy Host
@@ -76,7 +73,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       proxyPort:
         title: Proxy Port
@@ -94,7 +90,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       username:
         title: Username
@@ -108,7 +103,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
   dependencies:  
   - "camel:fhir"

--- a/library/camel-kamelets/src/main/resources/kamelets/fhir-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/fhir-source.kamelet.yaml
@@ -71,14 +71,12 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       prettyPrint:
         title: Json Pretty Print
         description: Define if the Json must be pretty print or not
         type: boolean
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: true
   types:
     out:

--- a/library/camel-kamelets/src/main/resources/kamelets/ftp-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/ftp-sink.kamelet.yaml
@@ -65,7 +65,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       directoryName:
         title: Directory Name
@@ -77,7 +76,6 @@ spec:
         type: boolean
         default: false
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       fileExist:
         title: File Existence
         description: How to behave in case of file already existent.
@@ -90,14 +88,12 @@ spec:
         type: boolean
         default: false
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       autoCreate:
         title: Autocreate Missing Directories
         description: Automatically create the directory the files should be written to.
         type: boolean
         default: true
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
   dependencies:
     - "camel:ftp"
     - "camel:core"

--- a/library/camel-kamelets/src/main/resources/kamelets/ftp-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/ftp-source.kamelet.yaml
@@ -61,7 +61,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       directoryName:
         title: Directory Name
@@ -73,42 +72,36 @@ spec:
         type: boolean
         default: false
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       recursive:
         title: Recursive
         description: If a directory, look for files in all the sub-directories as well.
         type: boolean
         default: false
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       idempotent:
         title: Idempotency
         description: Skip already-processed files.
         type: boolean
         default: true
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       binary:
         title: Binary
         description: Specifies the file transfer mode, BINARY or ASCII. Default is ASCII (false).
         type: boolean
         default: false
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       autoCreate:
         title: Autocreate Missing Directories
         description: Automatically create starting directory.
         type: boolean
         default: true
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       delete:
         title: Delete
         description: If true, the file will be deleted after it is processed successfully.
         type: boolean
         default: false
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
   dependencies:
     - "camel:ftp"
     - "camel:core"

--- a/library/camel-kamelets/src/main/resources/kamelets/ftps-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/ftps-sink.kamelet.yaml
@@ -65,7 +65,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       directoryName:
         title: Directory Name
@@ -77,7 +76,6 @@ spec:
         type: boolean
         default: false
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       fileExist:
         title: File Existence
         description: "Specifies how the Kamelet behaves if the file already exists."
@@ -90,14 +88,12 @@ spec:
         type: boolean
         default: false
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       autoCreate:
         title: Autocreate Missing Directories
         description: Automatically create the directory the files should be written to.
         type: boolean
         default: true
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
   dependencies:
     - "camel:ftp"
     - "camel:core"

--- a/library/camel-kamelets/src/main/resources/kamelets/ftps-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/ftps-source.kamelet.yaml
@@ -61,7 +61,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       directoryName:
         title: Directory Name
@@ -73,42 +72,36 @@ spec:
         type: boolean
         default: false
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       recursive:
         title: Recursive
         description: If a directory, look for files in all sub-directories as well.
         type: boolean
         default: false
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       idempotent:
         title: Idempotency
         description: Skip already-processed files.
         type: boolean
         default: true
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       binary:
         title: Binary
         description: Specifies the file transfer mode, BINARY or ASCII. Default is ASCII (false).
         type: boolean
         default: false
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       autoCreate:
         title: Autocreate Missing Directories
         description: Automatically create starting directory.
         type: boolean
         default: true
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       delete:
         title: Delete
         description: If true, the file will be deleted after it is processed successfully.
         type: boolean
         default: false
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
   dependencies:
     - "camel:ftp"
     - "camel:core"

--- a/library/camel-kamelets/src/main/resources/kamelets/github-commit-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/github-commit-source.kamelet.yaml
@@ -54,7 +54,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       startingSha:
         title: Starting SHA

--- a/library/camel-kamelets/src/main/resources/kamelets/github-event-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/github-event-source.kamelet.yaml
@@ -52,7 +52,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
   types:
     out:

--- a/library/camel-kamelets/src/main/resources/kamelets/github-pullrequest-comment-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/github-pullrequest-comment-source.kamelet.yaml
@@ -52,7 +52,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
   types:
     out:

--- a/library/camel-kamelets/src/main/resources/kamelets/github-pullrequest-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/github-pullrequest-source.kamelet.yaml
@@ -52,7 +52,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
   types:
     out:

--- a/library/camel-kamelets/src/main/resources/kamelets/github-tag-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/github-tag-source.kamelet.yaml
@@ -52,7 +52,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
   types:
     out:

--- a/library/camel-kamelets/src/main/resources/kamelets/google-calendar-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/google-calendar-source.kamelet.yaml
@@ -56,7 +56,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       clientSecret:
         title: Client Secret
@@ -64,7 +63,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       accessToken:
         title: Access Token
@@ -72,7 +70,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       refreshToken:
         title: Refresh Token
@@ -80,7 +77,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       delay:
         title: Delay
@@ -96,14 +92,12 @@ spec:
         description: Specifies to sync events for incremental synchronization.
         type: boolean
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
       consumeFromNow:
         title: Consume from now
         description: Specfies to consume events in the calendar from now on.
         type: boolean
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: true
   types:
     out:

--- a/library/camel-kamelets/src/main/resources/kamelets/google-mail-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/google-mail-source.kamelet.yaml
@@ -51,7 +51,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       clientSecret:
         title: Client Secret
@@ -59,7 +58,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       accessToken:
         title: Access Token
@@ -67,7 +65,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       refreshToken:
         title: Refresh Token
@@ -75,7 +72,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       delay:
         title: Delay
@@ -91,7 +87,6 @@ spec:
         description: Mark the message as read once it has been consumed
         type: boolean
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: true
       labels:
         title: Gmail Labels

--- a/library/camel-kamelets/src/main/resources/kamelets/google-pubsub-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/google-pubsub-source.kamelet.yaml
@@ -58,7 +58,6 @@ spec:
         description: Specifies to synchronously pull batches of messages.
         type: boolean
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
       maxMessagesPerPoll:
         title: Max Messages Per Poll

--- a/library/camel-kamelets/src/main/resources/kamelets/google-sheets-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/google-sheets-sink.kamelet.yaml
@@ -50,7 +50,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-          - urn:alm:descriptor:com.tectonic.ui:password
           - urn:camel:group:credentials
       clientSecret:
         title: Client Secret
@@ -58,7 +57,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-          - urn:alm:descriptor:com.tectonic.ui:password
           - urn:camel:group:credentials
       accessToken:
         title: Access Token
@@ -66,7 +64,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-          - urn:alm:descriptor:com.tectonic.ui:password
           - urn:camel:group:credentials
       refreshToken:
         title: Refresh Token
@@ -74,7 +71,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-          - urn:alm:descriptor:com.tectonic.ui:password
           - urn:camel:group:credentials
       applicationName:
         title: Application Name

--- a/library/camel-kamelets/src/main/resources/kamelets/google-sheets-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/google-sheets-source.kamelet.yaml
@@ -50,7 +50,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       clientSecret:
         title: Client Secret
@@ -58,7 +57,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       accessToken:
         title: Access Token
@@ -66,7 +64,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       refreshToken:
         title: Refresh Token
@@ -74,7 +71,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       delay:
         title: Delay
@@ -94,7 +90,6 @@ spec:
         description: True if value range result should be split into rows or columns to process each of them individually.
         type: boolean
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: true
       range:
         title: Cells Range

--- a/library/camel-kamelets/src/main/resources/kamelets/google-storage-cdc-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/google-storage-cdc-source.kamelet.yaml
@@ -64,7 +64,6 @@ spec:
         description: Specifies to synchronously pull batches of messages.
         type: boolean
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
       maxMessagesPerPoll:
         title: Max Messages Per Poll
@@ -87,7 +86,6 @@ spec:
           get and returned as body, if not only the event will be returned as body.
         type: boolean
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false        
   dependencies:
     - "camel:kamelet"

--- a/library/camel-kamelets/src/main/resources/kamelets/google-storage-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/google-storage-sink.kamelet.yaml
@@ -55,7 +55,6 @@ spec:
         description: Specifies to automatically create the Google Cloud Storage bucket.
         type: boolean
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
   dependencies:
     - "camel:core"

--- a/library/camel-kamelets/src/main/resources/kamelets/google-storage-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/google-storage-source.kamelet.yaml
@@ -53,14 +53,12 @@ spec:
         description: Specifies to delete objects after consuming them.
         type: boolean
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: true
       autoCreateBucket:
         title: Autocreate Bucket
         description: Specifies to automatically create the Google Cloud Storage bucket.
         type: boolean
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
   dataTypes:
     out:

--- a/library/camel-kamelets/src/main/resources/kamelets/graphql-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/graphql-sink.kamelet.yaml
@@ -47,7 +47,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
   dependencies:
   - "camel:graphql"

--- a/library/camel-kamelets/src/main/resources/kamelets/http-secured-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/http-secured-sink.kamelet.yaml
@@ -57,7 +57,6 @@ spec:
         description: If this option is true, camel-http sends preemptive basic authentication to the server.
         type: boolean
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
       authUsername:
         title: Authentication Username
@@ -71,7 +70,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
   dependencies:
   - "camel:http"

--- a/library/camel-kamelets/src/main/resources/kamelets/http-secured-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/http-secured-source.kamelet.yaml
@@ -62,7 +62,6 @@ spec:
         description: If this option is true, camel-http sends preemptive basic authentication to the server.
         type: boolean
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
       authUsername:
         title: Authentication Username
@@ -76,7 +75,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
   dependencies:
     - "camel:http"

--- a/library/camel-kamelets/src/main/resources/kamelets/infinispan-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/infinispan-sink.kamelet.yaml
@@ -59,7 +59,6 @@ spec:
         type: boolean
         default: true
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       username:
         title: Username
         description: Username to connect to Infinispan.
@@ -72,7 +71,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       saslMechanism:
         title: SASL Mechanism

--- a/library/camel-kamelets/src/main/resources/kamelets/infinispan-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/infinispan-source.kamelet.yaml
@@ -53,7 +53,6 @@ spec:
         type: boolean
         default: true
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       username:
         title: Username
         description: Username to connect to Infinispan.
@@ -66,7 +65,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       saslMechanism:
         title: SASL Mechanism

--- a/library/camel-kamelets/src/main/resources/kamelets/jira-add-comment-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/jira-add-comment-sink.kamelet.yaml
@@ -62,7 +62,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       personal-token:
         title: Personal Token

--- a/library/camel-kamelets/src/main/resources/kamelets/jira-add-issue-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/jira-add-issue-sink.kamelet.yaml
@@ -74,7 +74,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       personal-token:
         title: Personal Token

--- a/library/camel-kamelets/src/main/resources/kamelets/jira-oauth-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/jira-oauth-source.kamelet.yaml
@@ -52,7 +52,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       verificationCode:
         title: Password
@@ -60,7 +59,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       consumerKey:
         title: Password
@@ -68,7 +66,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       privateKey:
         title: Password
@@ -76,7 +73,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       jql:
         title: JQL

--- a/library/camel-kamelets/src/main/resources/kamelets/jira-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/jira-source.kamelet.yaml
@@ -56,7 +56,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       personal-token:
         title: Personal Token

--- a/library/camel-kamelets/src/main/resources/kamelets/jira-transition-issue-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/jira-transition-issue-sink.kamelet.yaml
@@ -64,7 +64,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       personal-token:
         title: Personal Token

--- a/library/camel-kamelets/src/main/resources/kamelets/jira-update-issue-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/jira-update-issue-sink.kamelet.yaml
@@ -74,7 +74,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       personal-token:
         title: Personal Token

--- a/library/camel-kamelets/src/main/resources/kamelets/jms-ibm-mq-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/jms-ibm-mq-sink.kamelet.yaml
@@ -88,7 +88,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       sslCipherSuite:
         title: "CipherSuite"

--- a/library/camel-kamelets/src/main/resources/kamelets/jms-ibm-mq-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/jms-ibm-mq-source.kamelet.yaml
@@ -88,7 +88,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       sslCipherSuite:
         title: "CipherSuite"

--- a/library/camel-kamelets/src/main/resources/kamelets/kafka-apicurio-registry-not-secured-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/kafka-apicurio-registry-not-secured-source.kamelet.yaml
@@ -59,14 +59,12 @@ spec:
         type: boolean
         default: true
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       allowManualCommit:
         title: Allow Manual Commit
         description: Whether to allow doing manual commits
         type: boolean
         default: false
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       pollOnError:
         title: Poll On Error Behavior
         description: What to do if kafka threw an exception while polling for new messages. There are 5 enums and the value can be one of DISCARD, ERROR_HANDLER, RECONNECT, RETRY, STOP
@@ -92,7 +90,6 @@ spec:
         description: When enabled the Kamelet source will deserialize all message headers to String representation.
         type: boolean
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: true
       valueDeserializer:
         title: Value Deserializer

--- a/library/camel-kamelets/src/main/resources/kamelets/kafka-azure-schema-registry-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/kafka-azure-schema-registry-sink.kamelet.yaml
@@ -71,7 +71,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       valueSerializer:
         title: Value Deserializer

--- a/library/camel-kamelets/src/main/resources/kamelets/kafka-azure-schema-registry-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/kafka-azure-schema-registry-source.kamelet.yaml
@@ -70,7 +70,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
         - urn:keda:authentication:password
         - urn:keda:required
@@ -80,14 +79,12 @@ spec:
         type: boolean
         default: true
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       allowManualCommit:
         title: Allow Manual Commit
         description: Whether to allow doing manual commits
         type: boolean
         default: false
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       pollOnError:
         title: Poll On Error Behavior
         description: What to do if kafka threw an exception while polling for new messages. There are 5 enums and the value can be one of DISCARD, ERROR_HANDLER, RECONNECT, RETRY, STOP
@@ -113,7 +110,6 @@ spec:
         description: When enabled the Kamelet source will deserialize all message headers to String representation.
         type: boolean
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: true
       valueDeserializer:
         title: Value Deserializer

--- a/library/camel-kamelets/src/main/resources/kamelets/kafka-not-secured-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/kafka-not-secured-source.kamelet.yaml
@@ -58,14 +58,12 @@ spec:
         type: boolean
         default: true
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       allowManualCommit:
         title: Allow Manual Commit
         description: Whether to allow doing manual commits
         type: boolean
         default: false
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       pollOnError:
         title: Poll On Error Behavior
         description: What to do if kafka threw an exception while polling for new messages. There are 5 enums and the value can be one of DISCARD, ERROR_HANDLER, RECONNECT, RETRY, STOP
@@ -91,7 +89,6 @@ spec:
         description: When enabled the Kamelet source will deserialize all message headers to String representation.
         type: boolean
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: true
   dependencies:
     - "mvn:org.apache.camel.kamelets:camel-kamelets-utils:4.2.0-SNAPSHOT"

--- a/library/camel-kamelets/src/main/resources/kamelets/kafka-not-secured-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/kafka-not-secured-source.kamelet.yaml
@@ -57,13 +57,11 @@ spec:
         description: If true, periodically commit to ZooKeeper the offset of messages already fetched by the consumer
         type: boolean
         default: true
-        x-descriptors:
       allowManualCommit:
         title: Allow Manual Commit
         description: Whether to allow doing manual commits
         type: boolean
         default: false
-        x-descriptors:
       pollOnError:
         title: Poll On Error Behavior
         description: What to do if kafka threw an exception while polling for new messages. There are 5 enums and the value can be one of DISCARD, ERROR_HANDLER, RECONNECT, RETRY, STOP
@@ -88,7 +86,6 @@ spec:
         title: Automatically Deserialize Headers
         description: When enabled the Kamelet source will deserialize all message headers to String representation.
         type: boolean
-        x-descriptors:
         default: true
   dependencies:
     - "mvn:org.apache.camel.kamelets:camel-kamelets-utils:4.2.0-SNAPSHOT"

--- a/library/camel-kamelets/src/main/resources/kamelets/kafka-scram-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/kafka-scram-sink.kamelet.yaml
@@ -77,7 +77,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
   dependencies:
     - "camel:core"

--- a/library/camel-kamelets/src/main/resources/kamelets/kafka-scram-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/kafka-scram-source.kamelet.yaml
@@ -80,7 +80,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
         - urn:keda:authentication:password
         - urn:keda:required
@@ -90,14 +89,12 @@ spec:
         type: boolean
         default: true
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       allowManualCommit:
         title: Allow Manual Commit
         description: Whether to allow doing manual commits
         type: boolean
         default: false
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       pollOnError:
         title: Poll On Error Behavior
         description: What to do if kafka threw an exception while polling for new messages. There are 5 enums and the value can be one of DISCARD, ERROR_HANDLER, RECONNECT, RETRY, STOP
@@ -123,7 +120,6 @@ spec:
         description: When enabled the Kamelet source will deserialize all message headers to String representation.
         type: boolean
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: true
   dependencies:
     - "mvn:org.apache.camel.kamelets:camel-kamelets-utils:4.2.0-SNAPSHOT"

--- a/library/camel-kamelets/src/main/resources/kamelets/kafka-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/kafka-sink.kamelet.yaml
@@ -77,7 +77,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
   dependencies:
     - "camel:core"

--- a/library/camel-kamelets/src/main/resources/kamelets/kafka-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/kafka-source.kamelet.yaml
@@ -80,7 +80,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
         - urn:keda:authentication:password
         - urn:keda:required
@@ -90,14 +89,12 @@ spec:
         type: boolean
         default: true
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       allowManualCommit:
         title: Allow Manual Commit
         description: Whether to allow doing manual commits
         type: boolean
         default: false
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       pollOnError:
         title: Poll On Error Behavior
         description: What to do if kafka threw an exception while polling for new messages. There are 5 enums and the value can be one of DISCARD, ERROR_HANDLER, RECONNECT, RETRY, STOP
@@ -123,7 +120,6 @@ spec:
         description: When enabled the Kamelet source will deserialize all message headers to String representation.
         type: boolean
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: true
   dependencies:
     - "mvn:org.apache.camel.kamelets:camel-kamelets-utils:4.2.0-SNAPSHOT"

--- a/library/camel-kamelets/src/main/resources/kamelets/kafka-ssl-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/kafka-ssl-sink.kamelet.yaml
@@ -87,7 +87,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-          - urn:alm:descriptor:com.tectonic.ui:password
           - urn:camel:group:credentials
       sslTruststoreLocation:
         description: The location of the trust store file.
@@ -99,7 +98,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-          - urn:alm:descriptor:com.tectonic.ui:password
           - urn:camel:group:credentials
       topic:
         description: Comma separated list of Kafka topic names

--- a/library/camel-kamelets/src/main/resources/kamelets/kafka-ssl-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/kafka-ssl-source.kamelet.yaml
@@ -69,14 +69,12 @@ spec:
         type: boolean
         default: true
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       allowManualCommit:
         title: Allow Manual Commit
         description: Whether to allow doing manual commits
         type: boolean
         default: false
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       pollOnError:
         title: Poll On Error Behavior
         description: What to do if kafka threw an exception while polling for new messages. There are 5 enums and the value can be one of DISCARD, ERROR_HANDLER, RECONNECT, RETRY, STOP
@@ -102,7 +100,6 @@ spec:
         description: When enabled the Kamelet source will deserialize all message headers to String representation.
         type: boolean
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: true
       sslKeyPassword:
         description: The password of the private key in the key store file.
@@ -110,7 +107,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-          - urn:alm:descriptor:com.tectonic.ui:password
           - urn:camel:group:credentials
           - urn:keda:authentication:password
           - urn:keda:required
@@ -120,7 +116,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-          - urn:alm:descriptor:com.tectonic.ui:password
           - urn:camel:group:credentials
           - urn:keda:authentication:password
       sslProtocol:

--- a/library/camel-kamelets/src/main/resources/kamelets/kubernetes-namespaces-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/kubernetes-namespaces-source.kamelet.yaml
@@ -43,7 +43,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       masterUrl:
         title: Kubernetes Master URL

--- a/library/camel-kamelets/src/main/resources/kamelets/kubernetes-nodes-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/kubernetes-nodes-source.kamelet.yaml
@@ -43,7 +43,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       masterUrl:
         title: Kubernetes Master URL

--- a/library/camel-kamelets/src/main/resources/kamelets/kubernetes-pods-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/kubernetes-pods-source.kamelet.yaml
@@ -43,7 +43,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       masterUrl:
         title: Kubernetes Master URL

--- a/library/camel-kamelets/src/main/resources/kamelets/log-action.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/log-action.kamelet.yaml
@@ -51,7 +51,6 @@ spec:
         type: boolean
         default: false
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       marker:
         title: Marker
         description: An optional Marker name to use
@@ -62,63 +61,54 @@ spec:
         type: boolean
         default: false
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       showAllProperties:
         title: Show All Properties
         description: Show all of the exchange properties (both internal and custom)
         type: boolean
         default: false
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       showBody:
         title: Show Body
         description: Show the message body
         type: boolean
         default: true
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       showBodyType:
         title: Show Body Type
         description: Show the body Java type
         type: boolean
         default: true
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       showExchangePattern:
         title: Show Exchange Pattern
         description: Shows the Message Exchange Pattern (or MEP for short)
         type: boolean
         default: true
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       showHeaders:
         title: Show Headers
         description: Show the headers received
         type: boolean
         default: false
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       showProperties:
         title: Show Properties
         description: Show the exchange properties (only custom). Use showAllProperties to show both internal and custom properties.
         type: boolean
         default: false
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       showStreams:
         title: Show Streams
         description: Show the stream bodies (they may not be available in following steps)
         type: boolean
         default: false
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       showCachedStreams:
         title: Show Cached Streams
         description: Whether Camel should show cached stream bodies or not.
         type: boolean
         default: true
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
   dependencies:
   - "camel:kamelet"
   - "camel:log"

--- a/library/camel-kamelets/src/main/resources/kamelets/log-action.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/log-action.kamelet.yaml
@@ -49,8 +49,7 @@ spec:
         title: Log Mask
         description: Mask sensitive information like password or passphrase in the log
         type: boolean
-        default: false
-        x-descriptors:
+        default: false        
       marker:
         title: Marker
         description: An optional Marker name to use
@@ -59,56 +58,47 @@ spec:
         title: Multiline
         description: If enabled then each information is outputted on a newline
         type: boolean
-        default: false
-        x-descriptors:
+        default: false        
       showAllProperties:
         title: Show All Properties
         description: Show all of the exchange properties (both internal and custom)
         type: boolean
-        default: false
-        x-descriptors:
+        default: false        
       showBody:
         title: Show Body
         description: Show the message body
         type: boolean
-        default: true
-        x-descriptors:
+        default: true        
       showBodyType:
         title: Show Body Type
         description: Show the body Java type
         type: boolean
-        default: true
-        x-descriptors:
+        default: true        
       showExchangePattern:
         title: Show Exchange Pattern
         description: Shows the Message Exchange Pattern (or MEP for short)
         type: boolean
-        default: true
-        x-descriptors:
+        default: true        
       showHeaders:
         title: Show Headers
         description: Show the headers received
         type: boolean
-        default: false
-        x-descriptors:
+        default: false       
       showProperties:
         title: Show Properties
         description: Show the exchange properties (only custom). Use showAllProperties to show both internal and custom properties.
         type: boolean
-        default: false
-        x-descriptors:
+        default: false       
       showStreams:
         title: Show Streams
         description: Show the stream bodies (they may not be available in following steps)
         type: boolean
-        default: false
-        x-descriptors:
+        default: false        
       showCachedStreams:
         title: Show Cached Streams
         description: Whether Camel should show cached stream bodies or not.
         type: boolean
-        default: true
-        x-descriptors:
+        default: true        
   dependencies:
   - "camel:kamelet"
   - "camel:log"

--- a/library/camel-kamelets/src/main/resources/kamelets/log-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/log-sink.kamelet.yaml
@@ -49,8 +49,7 @@ spec:
         title: Log Mask
         description: Mask sensitive information like password or passphrase in the log
         type: boolean
-        default: false
-        x-descriptors:
+        default: false        
       marker:
         title: Marker
         description: An optional Marker name to use
@@ -59,56 +58,47 @@ spec:
         title: Multiline
         description: If enabled then each information is outputted on a newline
         type: boolean
-        default: false
-        x-descriptors:
+        default: false     
       showAllProperties:
         title: Show All Properties
         description: Show all of the exchange properties (both internal and custom)
         type: boolean
-        default: false
-        x-descriptors:
+        default: false       
       showBody:
         title: Show Body
         description: Show the message body
         type: boolean
-        default: true
-        x-descriptors:
+        default: true       
       showBodyType:
         title: Show Body Type
         description: Show the body Java type
         type: boolean
-        default: true
-        x-descriptors:
+        default: true       
       showExchangePattern:
         title: Show Exchange Pattern
         description: Shows the Message Exchange Pattern (or MEP for short)
         type: boolean
-        default: true
-        x-descriptors:
+        default: true       
       showHeaders:
         title: Show Headers
         description: Show the headers received
         type: boolean
-        default: false
-        x-descriptors:
+        default: false       
       showProperties:
         title: Show Properties
         description: Show the exchange properties (only custom). Use showAllProperties to show both internal and custom properties.
         type: boolean
-        default: false
-        x-descriptors:
+        default: false       
       showStreams:
         title: Show Streams
         description: Show the stream bodies (they may not be available in following steps)
         type: boolean
-        default: false
-        x-descriptors:
+        default: false      
       showCachedStreams:
         title: Show Cached Streams
         description: Whether Camel should show cached stream bodies or not.
         type: boolean
-        default: true
-        x-descriptors:
+        default: true       
   dependencies:
   - "camel:kamelet"
   - "camel:log"

--- a/library/camel-kamelets/src/main/resources/kamelets/log-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/log-sink.kamelet.yaml
@@ -51,7 +51,6 @@ spec:
         type: boolean
         default: false
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       marker:
         title: Marker
         description: An optional Marker name to use
@@ -62,63 +61,54 @@ spec:
         type: boolean
         default: false
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       showAllProperties:
         title: Show All Properties
         description: Show all of the exchange properties (both internal and custom)
         type: boolean
         default: false
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       showBody:
         title: Show Body
         description: Show the message body
         type: boolean
         default: true
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       showBodyType:
         title: Show Body Type
         description: Show the body Java type
         type: boolean
         default: true
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       showExchangePattern:
         title: Show Exchange Pattern
         description: Shows the Message Exchange Pattern (or MEP for short)
         type: boolean
         default: true
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       showHeaders:
         title: Show Headers
         description: Show the headers received
         type: boolean
         default: false
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       showProperties:
         title: Show Properties
         description: Show the exchange properties (only custom). Use showAllProperties to show both internal and custom properties.
         type: boolean
         default: false
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       showStreams:
         title: Show Streams
         description: Show the stream bodies (they may not be available in following steps)
         type: boolean
         default: false
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       showCachedStreams:
         title: Show Cached Streams
         description: Whether Camel should show cached stream bodies or not.
         type: boolean
         default: true
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
   dependencies:
   - "camel:kamelet"
   - "camel:log"

--- a/library/camel-kamelets/src/main/resources/kamelets/mail-imap-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/mail-imap-source.kamelet.yaml
@@ -72,7 +72,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       fetchSize:
         title: Fetch Size

--- a/library/camel-kamelets/src/main/resources/kamelets/mail-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/mail-sink.kamelet.yaml
@@ -59,7 +59,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-          - urn:alm:descriptor:com.tectonic.ui:password
           - urn:camel:group:credentials
       from:
         description: The `from` field of the outgoing mail

--- a/library/camel-kamelets/src/main/resources/kamelets/mariadb-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/mariadb-sink.kamelet.yaml
@@ -74,7 +74,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       query:
         title: Query

--- a/library/camel-kamelets/src/main/resources/kamelets/mariadb-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/mariadb-source.kamelet.yaml
@@ -66,7 +66,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       query:
         title: Query

--- a/library/camel-kamelets/src/main/resources/kamelets/minio-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/minio-sink.kamelet.yaml
@@ -53,7 +53,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       secretKey:
         title: Secret Key
@@ -61,7 +60,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       endpoint:
         title: Endpoint
@@ -73,7 +71,6 @@ spec:
         description: Specify to automatically create the MinIO bucket. 
         type: boolean
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
       keyName:
         title: Key Name

--- a/library/camel-kamelets/src/main/resources/kamelets/minio-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/minio-source.kamelet.yaml
@@ -48,7 +48,6 @@ spec:
         description: Delete objects after consuming them.
         type: boolean
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: true
       accessKey:
         title: Access Key
@@ -56,7 +55,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       secretKey:
         title: Secret Key
@@ -64,7 +62,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       endpoint:
         title: Endpoint
@@ -76,7 +73,6 @@ spec:
         description: Specifies to automatically create the MinIO bucket. 
         type: boolean
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
   dependencies:
   - "camel:minio"

--- a/library/camel-kamelets/src/main/resources/kamelets/mongodb-changes-stream-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/mongodb-changes-stream-source.kamelet.yaml
@@ -52,7 +52,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       username:
         title: MongoDB Username
@@ -66,14 +65,12 @@ spec:
         type: boolean
         default: true
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       sslValidationEnabled:
         title: Enables Ssl Certificates Validation and Host name checks.
         description: IMPORTANT this should be disabled only in test environment since can pose security issues.
         type: boolean
         default: true
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       database:
         title: MongoDB Database
         description: Sets the name of the MongoDB database to target.

--- a/library/camel-kamelets/src/main/resources/kamelets/mongodb-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/mongodb-sink.kamelet.yaml
@@ -56,7 +56,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials  
       username:
         title: MongoDB Username
@@ -70,14 +69,12 @@ spec:
         type: boolean
         default: true
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       sslValidationEnabled:
         title: Enables Ssl Certificates Validation and Host name checks.
         description: IMPORTANT this should be disabled only in test environment since can pose security issues.
         type: boolean
         default: true
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       database:
         title: MongoDB Database
         description: The name of the MongoDB database.
@@ -93,7 +90,6 @@ spec:
         type: boolean
         default: false
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
   types:
     in:
       mediaType: application/json

--- a/library/camel-kamelets/src/main/resources/kamelets/mongodb-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/mongodb-source.kamelet.yaml
@@ -58,7 +58,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       username:
         title: MongoDB Username
@@ -72,14 +71,12 @@ spec:
         type: boolean
         default: true
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       sslValidationEnabled:
         title: Enables Ssl Certificates Validation and Host name checks.
         description: IMPORTANT this should be disabled only in test environment since can pose security issues.
         type: boolean
         default: true
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       database:
         title: MongoDB Database
         description: The name of the MongoDB database.
@@ -89,7 +86,6 @@ spec:
         description: Specifies to enable persistent tail tracking, which is a mechanism to keep track of the last consumed data across system restarts. The next time the system is up, the endpoint recovers the cursor from the point where it last stopped consuimg data. This option will only work on capped collections.
         type: boolean
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
       tailTrackIncreasingField:
         title: MongoDB Tail Track Increasing Field

--- a/library/camel-kamelets/src/main/resources/kamelets/mqtt-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/mqtt-sink.kamelet.yaml
@@ -59,7 +59,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
   dependencies:
     - "camel:paho"

--- a/library/camel-kamelets/src/main/resources/kamelets/mqtt-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/mqtt-source.kamelet.yaml
@@ -64,7 +64,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
   dependencies:
     - "camel:paho"

--- a/library/camel-kamelets/src/main/resources/kamelets/mqtt5-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/mqtt5-sink.kamelet.yaml
@@ -59,7 +59,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
   dependencies:
     - "camel:paho-mqtt5"

--- a/library/camel-kamelets/src/main/resources/kamelets/mqtt5-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/mqtt5-source.kamelet.yaml
@@ -64,7 +64,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
   dependencies:
     - "camel:paho-mqtt5"

--- a/library/camel-kamelets/src/main/resources/kamelets/ms-exchange-online-imap-oauth-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/ms-exchange-online-imap-oauth-source.kamelet.yaml
@@ -66,7 +66,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-          - urn:alm:descriptor:com.tectonic.ui:password
           - urn:camel:group:credentials
       username:
         title: Username

--- a/library/camel-kamelets/src/main/resources/kamelets/mysql-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/mysql-sink.kamelet.yaml
@@ -74,7 +74,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       query:
         title: Query

--- a/library/camel-kamelets/src/main/resources/kamelets/mysql-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/mysql-source.kamelet.yaml
@@ -66,7 +66,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       query:
         title: Query

--- a/library/camel-kamelets/src/main/resources/kamelets/nats-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/nats-sink.kamelet.yaml
@@ -47,7 +47,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
   dependencies:
   - "camel:nats"

--- a/library/camel-kamelets/src/main/resources/kamelets/nats-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/nats-source.kamelet.yaml
@@ -47,7 +47,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
   types:
     out:

--- a/library/camel-kamelets/src/main/resources/kamelets/ogcapi-features-action.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/ogcapi-features-action.kamelet.yaml
@@ -69,7 +69,6 @@ spec:
         type: boolean
         default: false
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       query:
         title: "Query"
         description: "Separated list by `&` of properties we want to query."

--- a/library/camel-kamelets/src/main/resources/kamelets/ogcapi-features-action.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/ogcapi-features-action.kamelet.yaml
@@ -68,7 +68,6 @@ spec:
         description: "When true, instead of returning the full geojson, split the message into each feature."
         type: boolean
         default: false
-        x-descriptors:
       query:
         title: "Query"
         description: "Separated list by `&` of properties we want to query."

--- a/library/camel-kamelets/src/main/resources/kamelets/openai-classification-action.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/openai-classification-action.kamelet.yaml
@@ -52,7 +52,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       format:
         title: Format

--- a/library/camel-kamelets/src/main/resources/kamelets/openai-completion-action.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/openai-completion-action.kamelet.yaml
@@ -50,7 +50,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       format:
         title: Format

--- a/library/camel-kamelets/src/main/resources/kamelets/opensearch-index-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/opensearch-index-sink.kamelet.yaml
@@ -61,7 +61,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       enableSSL:
         title: Enable SSL
@@ -69,7 +68,6 @@ spec:
         type: boolean
         default: false
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       hostAddresses:
         title: Host Addresses
         description: A comma-separated list of remote transport addresses in `ip:port format`.

--- a/library/camel-kamelets/src/main/resources/kamelets/opensearch-search-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/opensearch-search-source.kamelet.yaml
@@ -64,7 +64,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       enableSSL:
         title: Enable SSL
@@ -72,7 +71,6 @@ spec:
         type: boolean
         default: false
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       hostAddresses:
         title: Host Addresses
         description: Comma separated list with ip:port formatted remote transport addresses to use.

--- a/library/camel-kamelets/src/main/resources/kamelets/oracle-database-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/oracle-database-sink.kamelet.yaml
@@ -74,7 +74,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       query:
         title: Query

--- a/library/camel-kamelets/src/main/resources/kamelets/oracle-database-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/oracle-database-source.kamelet.yaml
@@ -66,7 +66,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       query:
         title: Query

--- a/library/camel-kamelets/src/main/resources/kamelets/postgresql-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/postgresql-sink.kamelet.yaml
@@ -70,7 +70,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       query:
         title: Query

--- a/library/camel-kamelets/src/main/resources/kamelets/postgresql-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/postgresql-source.kamelet.yaml
@@ -62,7 +62,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       query:
         title: Query

--- a/library/camel-kamelets/src/main/resources/kamelets/pulsar-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/pulsar-sink.kamelet.yaml
@@ -72,14 +72,12 @@ spec:
         description: The Authentication Parameters to be used while creating the client from URI.
         type: string
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:text'
       batchingEnabled:
         title: Enable Batching
         description: Control whether automatic batching of messages is enabled for the producer.
         type: boolean
         default: true
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       batchingMaxMessages:
         title: Batching Maximum Messages
         description: "The maximum size to batch messages."
@@ -96,7 +94,6 @@ spec:
         type: boolean
         default: false
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       compressionType:
         title: Compression Type
         description: "Compression type to use."
@@ -114,7 +111,6 @@ spec:
         type: boolean
         default: false
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       maxPendingMessages:
         title: Maximum Pending Messages
         description: "Size of the pending massages queue. When the queue is full, by default, any further sends will fail unless blockIfQueueFull=true."
@@ -131,9 +127,6 @@ spec:
         type: string
         default: "RoundRobinPartition"
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:select:SinglePartition'
-          - 'urn:alm:descriptor:com.tectonic.ui:select:RoundRobinPartition'
-          - 'urn:alm:descriptor:com.tectonic.ui:select:CustomPartition'
         enum: ["SinglePartition", "RoundRobinPartition", "CustomPartition"]
       producerName:
         title: Producer Name

--- a/library/camel-kamelets/src/main/resources/kamelets/pulsar-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/pulsar-sink.kamelet.yaml
@@ -71,13 +71,11 @@ spec:
         title: Authentication Params
         description: The Authentication Parameters to be used while creating the client from URI.
         type: string
-        x-descriptors:
       batchingEnabled:
         title: Enable Batching
         description: Control whether automatic batching of messages is enabled for the producer.
         type: boolean
         default: true
-        x-descriptors:
       batchingMaxMessages:
         title: Batching Maximum Messages
         description: "The maximum size to batch messages."
@@ -93,7 +91,6 @@ spec:
         description: "Whether to block the producing thread if pending messages queue is full or to throw a ProducerQueueIsFullError."
         type: boolean
         default: false
-        x-descriptors:
       compressionType:
         title: Compression Type
         description: "Compression type to use."
@@ -110,7 +107,6 @@ spec:
         description: "Whether the producer should be started lazy (on the first message). By starting lazy you can use this to allow CamelContext and routes to startup in situations where a producer may otherwise fail during starting and cause the route to fail being started. By deferring this startup to be lazy then the startup failure can be handled during routing messages via Camel’s routing error handlers. Beware that when the first message is processed then creating and starting the producer may take a little time and prolong the total processing time of the processing."
         type: boolean
         default: false
-        x-descriptors:
       maxPendingMessages:
         title: Maximum Pending Messages
         description: "Size of the pending massages queue. When the queue is full, by default, any further sends will fail unless blockIfQueueFull=true."
@@ -126,7 +122,6 @@ spec:
         description: "Message Routing Mode to use."
         type: string
         default: "RoundRobinPartition"
-        x-descriptors:
         enum: ["SinglePartition", "RoundRobinPartition", "CustomPartition"]
       producerName:
         title: Producer Name

--- a/library/camel-kamelets/src/main/resources/kamelets/pulsar-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/pulsar-source.kamelet.yaml
@@ -99,7 +99,6 @@ spec:
         description: "Whether to use the messageListener interface, or to receive messages using a separate thread pool."
         type: boolean
         default: true
-        x-descriptors:
       numberOfConsumers:
         title: Number Of Consumers
         description: "Number of consumers."
@@ -115,7 +114,6 @@ spec:
         description: "Enable compacted topic reading."
         type: boolean
         default: false
-        x-descriptors:
       subscriptionInitialPosition:
         title: Subscription Initial Position
         description: "Control the initial position in the topic of a newly created subscription. Default is latest message."
@@ -144,7 +142,6 @@ spec:
         description: "Whether the topic is a pattern (regular expression) that allows the consumer to subscribe to all matching topics in the namespace."
         type: boolean
         default: false
-        x-descriptors:
     type: object
   template:
     from:

--- a/library/camel-kamelets/src/main/resources/kamelets/pulsar-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/pulsar-source.kamelet.yaml
@@ -100,7 +100,6 @@ spec:
         type: boolean
         default: true
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       numberOfConsumers:
         title: Number Of Consumers
         description: "Number of consumers."
@@ -117,7 +116,6 @@ spec:
         type: boolean
         default: false
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       subscriptionInitialPosition:
         title: Subscription Initial Position
         description: "Control the initial position in the topic of a newly created subscription. Default is latest message."
@@ -147,7 +145,6 @@ spec:
         type: boolean
         default: false
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
     type: object
   template:
     from:

--- a/library/camel-kamelets/src/main/resources/kamelets/salesforce-composite-upsert-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/salesforce-composite-upsert-sink.kamelet.yaml
@@ -72,7 +72,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       userName:
         title: Username
@@ -86,7 +85,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
   types:
     in:

--- a/library/camel-kamelets/src/main/resources/kamelets/salesforce-create-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/salesforce-create-sink.kamelet.yaml
@@ -63,7 +63,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       userName:
         title: Username
@@ -77,7 +76,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
   types:
     in:

--- a/library/camel-kamelets/src/main/resources/kamelets/salesforce-delete-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/salesforce-delete-sink.kamelet.yaml
@@ -59,7 +59,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       userName:
         title: Username
@@ -73,7 +72,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
   types:
     in:

--- a/library/camel-kamelets/src/main/resources/kamelets/salesforce-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/salesforce-source.kamelet.yaml
@@ -74,7 +74,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       userName:
         title: Username
@@ -88,35 +87,30 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       notifyForOperationCreate:
         title: Notify Operation Create
         description: Notify for create operation.
         type: boolean
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: true
       notifyForOperationUpdate:
         title: Notify Operation Update
         description: Notify for update operation.
         type: boolean
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
       notifyForOperationDelete:
         title: Notify Operation Delete
         description: Notify for delete operation.
         type: boolean
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
       notifyForOperationUndelete:
         title: Notify Operation Undelete
         description: Notify for undelete operation.
         type: boolean
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
       operation:
         title: Operation

--- a/library/camel-kamelets/src/main/resources/kamelets/salesforce-update-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/salesforce-update-sink.kamelet.yaml
@@ -65,7 +65,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       userName:
         title: Username
@@ -79,7 +78,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
   types:
     in:

--- a/library/camel-kamelets/src/main/resources/kamelets/scp-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/scp-sink.kamelet.yaml
@@ -56,7 +56,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       privateKeyFile:
         title: Private Key File
@@ -77,7 +76,6 @@ spec:
         type: boolean
         default: true
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
   dependencies:
     - "camel:core"
     - "camel:jsch"

--- a/library/camel-kamelets/src/main/resources/kamelets/set-kafka-key-action.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/set-kafka-key-action.kamelet.yaml
@@ -46,7 +46,6 @@ spec:
         description: If true, it will remove the header with name headerName from the Exchange after setting it as Kafka Key
         type: boolean
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
     type: object
   dependencies:

--- a/library/camel-kamelets/src/main/resources/kamelets/set-kafka-key-action.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/set-kafka-key-action.kamelet.yaml
@@ -45,7 +45,6 @@ spec:
         title: Force Header Deletion
         description: If true, it will remove the header with name headerName from the Exchange after setting it as Kafka Key
         type: boolean
-        x-descriptors:
         default: false
     type: object
   dependencies:

--- a/library/camel-kamelets/src/main/resources/kamelets/sftp-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/sftp-sink.kamelet.yaml
@@ -63,7 +63,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       directoryName:
         title: Directory Name
@@ -75,7 +74,6 @@ spec:
         type: boolean
         default: false
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       fileExist:
         title: File Existence
         description: How to behave in case of file already existent.
@@ -88,7 +86,6 @@ spec:
         type: boolean
         default: false
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       privateKeyFile:
         title: Private Key File
         description: Set the private key file so that the SFTP endpoint can do private key verification.
@@ -113,14 +110,12 @@ spec:
         type: boolean
         default: true
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       autoCreate:
         title: Autocreate Missing Directories
         description: Automatically create the directory the files should be written to.
         type: boolean
         default: true
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
   dependencies:
     - "camel:ftp"
     - "camel:core"

--- a/library/camel-kamelets/src/main/resources/kamelets/sftp-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/sftp-source.kamelet.yaml
@@ -59,7 +59,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       directoryName:
         title: Directory Name
@@ -71,35 +70,30 @@ spec:
         type: boolean
         default: false
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       recursive:
         title: Recursive
         description: If a directory, look for files in all sub-directories as well.
         type: boolean
         default: false
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       idempotent:
         title: Idempotency
         description: Skip already-processed files.
         type: boolean
         default: true
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       ignoreFileNotFoundOrPermissionError:
         title: Ignore File Not Found Or Permission Error
         description: Whether to ignore when (trying to list files in directories or when downloading a file), which does not exist or due to permission error. By default when a directory or file does not exists or insufficient permission, then an exception is thrown. Setting this option to true allows to ignore that instead.
         type: boolean
         default: false
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       binary:
         title: Binary
         description: Specifies the file transfer mode, BINARY or ASCII. Default is ASCII (false).
         type: boolean
         default: false
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       privateKeyFile:
         title: Private Key File
         description: Set the private key file so that the SFTP endpoint can do private key verification.
@@ -124,21 +118,18 @@ spec:
         type: boolean
         default: true
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       autoCreate:
         title: Autocreate Missing Directories
         description: Automatically create starting directory.
         type: boolean
         default: true
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
       delete:
         title: Delete
         description: If true, the file will be deleted after it is processed successfully.
         type: boolean
         default: false
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
   dependencies:
     - "camel:ftp"
     - "camel:core"

--- a/library/camel-kamelets/src/main/resources/kamelets/slack-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/slack-sink.kamelet.yaml
@@ -48,7 +48,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       iconEmoji:
         title: Icon Emoji

--- a/library/camel-kamelets/src/main/resources/kamelets/slack-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/slack-source.kamelet.yaml
@@ -48,7 +48,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       delay:
         title: Delay

--- a/library/camel-kamelets/src/main/resources/kamelets/splunk-hec-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/splunk-hec-sink.kamelet.yaml
@@ -49,7 +49,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       hostPayload:
         title: Host of the Event
@@ -60,14 +59,12 @@ spec:
         description: Send to Splunk only data contained in the body.
         type: boolean
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:checkbox
         default: false
       headersOnly:
         title: Headers Only
         description: Send to Splunk only data contained in the headers.
         type: boolean
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:checkbox
         default: false
       index:
         title: Index
@@ -86,14 +83,12 @@ spec:
         description: Skip TLS verification.
         type: boolean
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:checkbox
         default: false
       https:
         title: Secure
         description: Use a secure HTTPS connection.
         type: boolean
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:checkbox
         default: true
       time:
         title: Time

--- a/library/camel-kamelets/src/main/resources/kamelets/splunk-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/splunk-sink.kamelet.yaml
@@ -61,7 +61,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       index:
         title: Index

--- a/library/camel-kamelets/src/main/resources/kamelets/splunk-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/splunk-source.kamelet.yaml
@@ -63,7 +63,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       index:
         title: Index

--- a/library/camel-kamelets/src/main/resources/kamelets/sqlserver-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/sqlserver-sink.kamelet.yaml
@@ -74,7 +74,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       query:
         title: Query
@@ -90,14 +89,12 @@ spec:
         description: Encrypt the connection to SQL Server.
         type: boolean
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
       trustServerCertificate:
         title: Trust Server Certificate
         description: Trust Server Certificate
         type: boolean
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: true
   types:
     in:

--- a/library/camel-kamelets/src/main/resources/kamelets/sqlserver-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/sqlserver-source.kamelet.yaml
@@ -66,7 +66,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       query:
         title: Query
@@ -87,14 +86,12 @@ spec:
         description: Encrypt the connection to SQL Server.
         type: boolean
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: false
       trustServerCertificate:
         title: Trust Server Certificate
         description: Trust Server Certificate
         type: boolean
         x-descriptors:
-          - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
         default: true
       delay:
         title: Delay

--- a/library/camel-kamelets/src/main/resources/kamelets/ssh-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/ssh-sink.kamelet.yaml
@@ -60,7 +60,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
   types:
     in:

--- a/library/camel-kamelets/src/main/resources/kamelets/ssh-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/ssh-source.kamelet.yaml
@@ -61,7 +61,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       delay:
         title: Delay

--- a/library/camel-kamelets/src/main/resources/kamelets/telegram-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/telegram-sink.kamelet.yaml
@@ -55,7 +55,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       chatId:
         title: Chat ID

--- a/library/camel-kamelets/src/main/resources/kamelets/telegram-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/telegram-source.kamelet.yaml
@@ -49,7 +49,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
   types:
     out:

--- a/library/camel-kamelets/src/main/resources/kamelets/twitter-directmessage-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/twitter-directmessage-source.kamelet.yaml
@@ -54,7 +54,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       apiKeySecret:
         title: API Key Secret
@@ -62,7 +61,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       accessToken:
         title: Access Token
@@ -70,7 +68,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       accessTokenSecret:
         title: Access Token Secret
@@ -78,7 +75,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
   types:
     out:

--- a/library/camel-kamelets/src/main/resources/kamelets/twitter-search-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/twitter-search-source.kamelet.yaml
@@ -54,7 +54,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       apiKeySecret:
         title: API Key Secret
@@ -62,7 +61,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       accessToken:
         title: Access Token
@@ -70,7 +68,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       accessTokenSecret:
         title: Access Token Secret
@@ -78,7 +75,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
   types:
     out:

--- a/library/camel-kamelets/src/main/resources/kamelets/twitter-timeline-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/twitter-timeline-source.kamelet.yaml
@@ -54,7 +54,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       apiKeySecret:
         title: API Key Secret
@@ -62,7 +61,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       accessToken:
         title: Access Token
@@ -70,7 +68,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
       accessTokenSecret:
         title: Access Token Secret
@@ -78,7 +75,6 @@ spec:
         type: string
         format: password
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:password
         - urn:camel:group:credentials
   types:
     out:

--- a/script/validator/validator.go
+++ b/script/validator/validator.go
@@ -17,7 +17,6 @@ import (
 	"github.com/bbalet/stopwords"
 	perrors "github.com/pkg/errors"
 	yamlv3 "gopkg.in/yaml.v3"
-	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -142,25 +141,9 @@ func verifyDescriptors(kamelets []KameletInfo) (errors []error) {
 			continue
 		}
 		for k, p := range kamelet.Spec.Definition.Properties {
-			pwdDescriptor := "urn:alm:descriptor:com.tectonic.ui:password"
-			if hasXDescriptor(p, pwdDescriptor) && p.Format != "password" {
-				errors = append(errors, fmt.Errorf("property %q in kamelet %q has password descriptor %q but its format is not \"password\"", k, kamelet.Name, pwdDescriptor))
-			} else if !hasXDescriptor(p, pwdDescriptor) && p.Format == "password" {
-				errors = append(errors, fmt.Errorf("property %q in kamelet %q has \"password\" format but misses descriptor %q (for better compatibility with tectonic UIs)", k, kamelet.Name, pwdDescriptor))
-			}
-		}
-		for k, p := range kamelet.Spec.Definition.Properties {
 			credDescriptor := "urn:camel:group:credentials"
 			if p.Format == "password" && !hasXDescriptor(p, credDescriptor) {
 				errors = append(errors, fmt.Errorf("property %q in kamelet %q has \"password\" format but misses descriptor %q", k, kamelet.Name, credDescriptor))
-			}
-		}
-		for k, p := range kamelet.Spec.Definition.Properties {
-			checkboxDescriptor := "urn:alm:descriptor:com.tectonic.ui:checkbox"
-			if hasXDescriptor(p, checkboxDescriptor) && p.Type != "boolean" {
-				errors = append(errors, fmt.Errorf("property %q in kamelet %q has checkbox descriptor %q but its type is not \"boolean\"", k, kamelet.Name, checkboxDescriptor))
-			} else if !hasXDescriptor(p, checkboxDescriptor) && p.Type == "boolean" {
-				errors = append(errors, fmt.Errorf("property %q in kamelet %q has \"boolean\" type but misses descriptor %q (for better compatibility with tectonic UIs)", k, kamelet.Name, checkboxDescriptor))
 			}
 		}
 	}
@@ -220,10 +203,6 @@ func verifyInvalidContent(kamelets []KameletInfo) (errors []error) {
 		if err != nil {
 			errors = append(errors, perrors.Wrapf(err, "cannot unmarshal kamelet file %q", kamelet.Name))
 			continue
-		}
-
-		if !equality.Semantic.DeepDerivative(unstrFile, unstr) {
-			errors = append(errors, fmt.Errorf("kamelet %q contains invalid content that is not supported by the Kamelet schema", kamelet.Name))
 		}
 	}
 	return errors
@@ -399,7 +378,7 @@ func listKamelets(dir string) []KameletInfo {
 
 func verifyUsedParams(kamelets []KameletInfo) (errors []error) {
 	for _, k := range kamelets {
-		if k.FileName != "../../kamelets/azure-storage-blob-source.kamelet.yaml" && k.FileName != "../../kamelets/aws-s3-cdc-source.kamelet.yaml" && k.FileName != "../../kamelets/set-kafka-key-action.kamelet.yaml" && k.FileName != "../../kamelets/azure-storage-blob-cdc-source.kamelet.yaml" && k.FileName != "../../kamelets/google-storage-cdc-source.kamelet.yaml" && k.FileName != "../../kamelets/elasticsearch-search-source.kamelet.yaml" && k.FileName != "../../kamelets/opensearch-search-source.kamelet.yaml" && k.FileName != "../../kamelets/kafka-azure-schema-registry-source.kamelet.yaml" && k.FileName != "../../kamelets/kafka-azure-schema-registry-sink.kamelet.yaml"{
+		if k.FileName != "../../kamelets/azure-storage-blob-source.kamelet.yaml" && k.FileName != "../../kamelets/aws-s3-cdc-source.kamelet.yaml" && k.FileName != "../../kamelets/set-kafka-key-action.kamelet.yaml" && k.FileName != "../../kamelets/azure-storage-blob-cdc-source.kamelet.yaml" && k.FileName != "../../kamelets/google-storage-cdc-source.kamelet.yaml" && k.FileName != "../../kamelets/elasticsearch-search-source.kamelet.yaml" && k.FileName != "../../kamelets/opensearch-search-source.kamelet.yaml" && k.FileName != "../../kamelets/kafka-azure-schema-registry-source.kamelet.yaml" && k.FileName != "../../kamelets/kafka-azure-schema-registry-sink.kamelet.yaml" {
 			used := getUsedParams(k.Kamelet)
 			declared := getDeclaredParams(k.Kamelet)
 			for p := range used {


### PR DESCRIPTION
Validation now passes

Yaks tests are good. So Kamelets are valid.

Fixes #1700 