### PR TITLE
chore: Fix YAKS tests

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 camel-version := 4.2.0
-camel-kamelets-version := 4.2.0-SNAPSHOT
+camel-kamelets-version := 4.3.0-SNAPSHOT
 kamelets-local-dir := ../../../kamelets
 test := .
 


### PR DESCRIPTION
- Need to use 4.3.0-SNAPSHOT version for Kamelets library