### PR TITLE
Kafka Apicurio Registry: Use the Quarkus extension as dependency so the Kamelets will work well in Camel K too

### DIFF
--- a/kamelets/kafka-apicurio-registry-not-secured-source.kamelet.yaml
+++ b/kamelets/kafka-apicurio-registry-not-secured-source.kamelet.yaml
@@ -113,7 +113,7 @@ spec:
     - "camel:kafka"
     - "camel:core"
     - "camel:kamelet"
-    - "mvn:io.apicurio:apicurio-registry-serdes-avro-serde:2.4.14.Final"
+    - "mvn:io.quarkus:quarkus-apicurio-registry-avro:3.6.3"
   template:
     beans:
       - name: kafkaHeaderDeserializer

--- a/library/camel-kamelets/src/main/resources/kamelets/kafka-apicurio-registry-not-secured-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/kafka-apicurio-registry-not-secured-source.kamelet.yaml
@@ -113,7 +113,7 @@ spec:
     - "camel:kafka"
     - "camel:core"
     - "camel:kamelet"
-    - "mvn:io.apicurio:apicurio-registry-serdes-avro-serde:2.4.14.Final"
+    - "mvn:io.quarkus:quarkus-apicurio-registry-avro:3.6.3"
   template:
     beans:
       - name: kafkaHeaderDeserializer

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
         <version.com.amazon.redshift.redshift-jdbc42>2.1.0.24</version.com.amazon.redshift.redshift-jdbc42>
         <version.org.apache.activemq.artemis-jms-client-all>2.31.2</version.org.apache.activemq.artemis-jms-client-all>
 	<version.org.postgresql.postgresql>42.7.1</version.org.postgresql.postgresql>
-	<version.io.apicurio.apicurio-registry-serdes-avro-serde>2.4.14.Final</version.io.apicurio.apicurio-registry-serdes-avro-serde>
+	<version.io.quarkus.quarkus-apicurio-registry-avro>3.6.3</version.io.quarkus.quarkus-apicurio-registry-avro>
 	<!-- These versions should be taken from Azure SDK BOM used in the Camel version declared -->
 	<version.com.azure.azure-identity>1.10.4</version.com.azure.azure-identity>
         <version.com.azure.azure-data-schemaregistry-apacheavro>1.1.11</version.com.azure.azure-data-schemaregistry-apacheavro>
@@ -342,7 +342,7 @@
                         "version.com.amazon.redshift.redshift-jdbc42": "${version.com.amazon.redshift.redshift-jdbc42}",
                         "version.org.apache.activemq.artemis-jms-client-all": "${version.org.apache.activemq.artemis-jms-client-all}",
 			"version.org.postgresql.postgresql": "${version.org.postgresql.postgresql}",
-                        "version.io.apicurio.apicurio-registry-serdes-avro-serde": "${version.io.apicurio.apicurio-registry-serdes-avro-serde}",
+                        "version.io.quarkus.quarkus-apicurio-registry-avro": "${version.io.quarkus.quarkus-apicurio-registry-avro}",
                         "version.com.azure.azure-identity": "${version.com.azure.azure-identity}",
                         "version.com.azure.azure-data-schemaregistry-apacheavro": "${version.com.azure.azure-data-schemaregistry-apacheavro}",
                         "version.com.microsoft.azure.azure-schemaregistry-kafka-avro": "${version.com.microsoft.azure.azure-schemaregistry-kafka-avro}"


### PR DESCRIPTION
Fixes #1798 