### PR TITLE
Fix #1808: empty x-descriptors field and dataTypes empty default

### DIFF
--- a/kamelets/aws-timestream-query-sink.kamelet.yaml
+++ b/kamelets/aws-timestream-query-sink.kamelet.yaml
@@ -68,7 +68,6 @@ spec:
         title: Default Credentials Provider
         description: If true, the CloudWatch client loads credentials through a default credentials provider. If false, it uses the basic authentication method (access key and secret key).
         type: boolean
-        x-descriptors:
         default: false
       uriEndpointOverride:
         title: Overwrite Endpoint URI
@@ -78,7 +77,6 @@ spec:
         title: Endpoint Overwrite
         description: Select this option to override the endpoint URI. To use this option, you must also provide a URI for the `uriEndpointOverride` option.
         type: boolean
-        x-descriptors:
         default: false
   dependencies:
     - "camel:core"

--- a/kamelets/google-sheets-source.kamelet.yaml
+++ b/kamelets/google-sheets-source.kamelet.yaml
@@ -108,7 +108,6 @@ spec:
         type: string
         default: "A"
   dataTypes:
-    default:
     out:
       default: json
       headers:

--- a/library/camel-kamelets/src/main/resources/kamelets/aws-timestream-query-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/aws-timestream-query-sink.kamelet.yaml
@@ -68,7 +68,6 @@ spec:
         title: Default Credentials Provider
         description: If true, the CloudWatch client loads credentials through a default credentials provider. If false, it uses the basic authentication method (access key and secret key).
         type: boolean
-        x-descriptors:
         default: false
       uriEndpointOverride:
         title: Overwrite Endpoint URI
@@ -78,7 +77,6 @@ spec:
         title: Endpoint Overwrite
         description: Select this option to override the endpoint URI. To use this option, you must also provide a URI for the `uriEndpointOverride` option.
         type: boolean
-        x-descriptors:
         default: false
   dependencies:
     - "camel:core"

--- a/library/camel-kamelets/src/main/resources/kamelets/google-sheets-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/google-sheets-source.kamelet.yaml
@@ -108,7 +108,6 @@ spec:
         type: string
         default: "A"
   dataTypes:
-    default:
     out:
       default: json
       headers:


### PR DESCRIPTION
Ref #1814 
Ref #1808 

Some leftover errors on main branch:

```
amel-k-operator-77bf96b5b6-k9xc5 camel-k-operator {"level":"error","ts":"2023-12-21T16:20:42Z","msg":"Error occurred whilst applying bundled kamelet","error":"Kamelet.camel.apache.org \"aws-timestream-query-sink\" is invalid: [spec.definition.properties.useDefaultCredentialsProvider.x-descriptors: Invalid value: \"null\": spec.definition.properties.useDefaultCredentialsProvider.x-descriptors in body must be of type array: \"null\", spec.definition.properties.overrideEndpoint.x-descriptors: Invalid value: \"null\": spec.definition.properties.overrideEndpoint.x-descriptors in body must be of type array: \"null\"]","stacktrace":"github.com/apache/camel-k/v2/pkg/install.KameletCatalog.func1.1\n\tgithub.com/apache/camel-k/v2/pkg/install/kamelets.go:127\ngolang.org/x/sync/errgroup.(*Group).Go.func1\n\tgolang.org/x/sync@v0.5.0/errgroup/errgroup.go:75"}
camel-k-operator-77bf96b5b6-k9xc5 camel-k-operator {"level":"error","ts":"2023-12-21T16:20:43Z","msg":"Error occurred whilst applying bundled kamelet","error":"Kamelet.camel.apache.org \"google-sheets-source\" is invalid: spec.dataTypes.default: Invalid value: \"null\": spec.dataTypes.default in body must be of type object: \"null\"","stacktrace":"github.com/apache/camel-k/v2/pkg/install.KameletCatalog.func1.1\n\tgithub.com/apache/camel-k/v2/pkg/install/kamelets.go:127\ngolang.org/x/sync/errgroup.(*Group).Go.func1\n\tgolang.org/x/sync@v0.5.0/errgroup/errgroup.go:75"}
```

@christophd Please don't hesitate to indicate if dataTypes `default:` should be some other value.