### PR TITLE
Spring RabbitMQ Sink Kamelet: Support autoDeclareProducer as parameter

### DIFF
--- a/kamelets/spring-rabbitmq-sink.kamelet.yaml
+++ b/kamelets/spring-rabbitmq-sink.kamelet.yaml
@@ -74,6 +74,11 @@ spec:
         title: Queue name
         description: The queue to receive messages from
         type: string
+      autoDeclareProducer:
+        title: Auto Declare Producer
+        description: Specifies whether the producer should auto declare binding between exchange, queue and routing key when starting
+        type: boolean
+        default: false
   dependencies:
     - "camel:spring-rabbitmq"
     - "camel:kamelet"
@@ -95,3 +100,4 @@ spec:
             connectionFactory: "#bean:{{connectionFactory}}"
             routingKey: "{{?routingKey}}"
             queues: "{{?queues}}"
+            autoDeclareProducer: "{{autoDeclareProducer}}"

--- a/library/camel-kamelets/src/main/resources/kamelets/spring-rabbitmq-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/spring-rabbitmq-sink.kamelet.yaml
@@ -74,6 +74,11 @@ spec:
         title: Queue name
         description: The queue to receive messages from
         type: string
+      autoDeclareProducer:
+        title: Auto Declare Producer
+        description: Specifies whether the producer should auto declare binding between exchange, queue and routing key when starting
+        type: boolean
+        default: false
   dependencies:
     - "camel:spring-rabbitmq"
     - "camel:kamelet"
@@ -95,3 +100,4 @@ spec:
             connectionFactory: "#bean:{{connectionFactory}}"
             routingKey: "{{?routingKey}}"
             queues: "{{?queues}}"
+            autoDeclareProducer: "{{autoDeclareProducer}}"


### PR DESCRIPTION
Fixes #1943 