### PR TITLE
chore: Add Slack Kamelets E2E tests

### DIFF
--- a/kamelets/slack-source.kamelet.yaml
+++ b/kamelets/slack-source.kamelet.yaml
@@ -37,6 +37,12 @@ spec:
       - token
     type: object
     properties:
+      serverUrl:
+        title: Server URL
+        description: The Slack API server endpoint URL.
+        type: string
+        default: "https://slack.com"
+        example: "https://slack.com"
       channel:
         title: Channel
         description: The Slack channel to receive messages from.
@@ -51,7 +57,7 @@ spec:
         - urn:camel:group:credentials
       delay:
         title: Delay
-        description: The delay between polls. If no unit provided, miliseconds is the default.
+        description: The delay between polls. If no unit provided, milliseconds is the default.
         type: string
         default: "60000"
         example: "60s or 6000 or 1m"
@@ -107,6 +113,7 @@ spec:
     from:
       uri: "slack:{{channel}}"
       parameters:
+        serverUrl: "{{serverUrl}}"
         token: "{{token}}"
         delay: "{{delay}}"
         naturalOrder: "{{naturalOrder}}"

--- a/library/camel-kamelets/src/main/resources/kamelets/slack-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/slack-source.kamelet.yaml
@@ -37,6 +37,12 @@ spec:
       - token
     type: object
     properties:
+      serverUrl:
+        title: Server URL
+        description: The Slack API server endpoint URL.
+        type: string
+        default: "https://slack.com"
+        example: "https://slack.com"
       channel:
         title: Channel
         description: The Slack channel to receive messages from.
@@ -51,7 +57,7 @@ spec:
         - urn:camel:group:credentials
       delay:
         title: Delay
-        description: The delay between polls. If no unit provided, miliseconds is the default.
+        description: The delay between polls. If no unit provided, milliseconds is the default.
         type: string
         default: "60000"
         example: "60s or 6000 or 1m"
@@ -107,6 +113,7 @@ spec:
     from:
       uri: "slack:{{channel}}"
       parameters:
+        serverUrl: "{{serverUrl}}"
         token: "{{token}}"
         delay: "{{delay}}"
         naturalOrder: "{{naturalOrder}}"

--- a/tests/camel-kamelets-itest/src/test/resources/avro/README.md
+++ b/tests/camel-kamelets-itest/src/test/resources/avro/README.md
@@ -36,7 +36,7 @@ You can review the installation steps for the tooling in the documentation:
 To run tests with URI based configuration: 
 
 ```shell script
-$ yaks run --local test/avro/avro-serdes-action.feature
+$ yaks run --local src/test/resources/avro/avro-serdes-action.feature
 ```
 
 You will be provided with the test log output and the test results.

--- a/tests/camel-kamelets-itest/src/test/resources/aws/s3/README.md
+++ b/tests/camel-kamelets-itest/src/test/resources/aws/s3/README.md
@@ -46,31 +46,31 @@ You can review the installation steps for the operators in the documentation:
 To run tests with URI based configuration: 
 
 ```shell script
-$ yaks test aws-s3-source-uri-conf.feature
+$ yaks run --local src/test/resources/aws-s3-source-uri-conf.feature
 ```
 
 To run tests with secret based configuration:
 
 ```shell script
-$ yaks test aws-s3-source-secret-conf.feature
+$ yaks run --local src/test/resources/aws/s3/aws-s3-source-secret-conf.feature
 ```
 
 To run tests with property based configuration:
 
 ```shell script
-$ yaks test aws-s3-source-property-conf.feature
+$ yaks run --local src/test/resources/aws/s3/aws-s3-source-property-conf.feature
 ```
 
 To run tests with URI binding:
 
 ```shell script
-$ yaks test aws-s3-uri-pipe.feature
+$ yaks run --local src/test/resources/aws/s3/aws-s3-uri-pipe.feature
 ```
 
 To run tests with binding to Knative channel:
 
 ```shell script
-$ yaks test aws-s3-knative-channel.feature
+$ yaks run --local src/test/resources/aws/s3/aws-s3-knative-channel.feature
 ```
 
 You will be provided with the test log output and the test results.

--- a/tests/camel-kamelets-itest/src/test/resources/aws/sqs/README.md
+++ b/tests/camel-kamelets-itest/src/test/resources/aws/sqs/README.md
@@ -52,25 +52,25 @@ $ yaks test aws-sqs-source-uri-conf.feature
 To run tests with secret based configuration:
 
 ```shell script
-$ yaks test aws-sqs-source-secret-conf.feature
+$ yaks run --local src/test/resources/aws/sqs/aws-sqs-source-secret-conf.feature
 ```
 
 To run tests with property based configuration:
 
 ```shell script
-$ yaks test aws-sqs-source-property-conf.feature
+$ yaks run --local src/test/resources/aws/sqs/aws-sqs-source-property-conf.feature
 ```
 
 To run tests with URI binding:
 
 ```shell script
-$ yaks test aws-sqs-uri-pipe.feature
+$ yaks run --local src/test/resources/aws/sqs/aws-sqs-uri-pipe.feature
 ```
 
 To run tests with binding to Knative channel:
 
 ```shell script
-$ yaks test aws-sqs-knative-channel.feature
+$ yaks run --local src/test/resources/aws/sqs/aws-sqs-knative-channel.feature
 ```
 
 You will be provided with the test log output and the test results.

--- a/tests/camel-kamelets-itest/src/test/resources/protobuf/README.md
+++ b/tests/camel-kamelets-itest/src/test/resources/protobuf/README.md
@@ -36,7 +36,7 @@ You can review the installation steps for the tooling in the documentation:
 To run tests with URI based configuration: 
 
 ```shell script
-$ yaks run --local test/protobuf/protobuf-serdes-action.feature
+$ yaks run --local src/test/resources/protobuf/protobuf-serdes-action.feature
 ```
 
 You will be provided with the test log output and the test results.

--- a/tests/camel-kamelets-itest/src/test/resources/slack/README.md
+++ b/tests/camel-kamelets-itest/src/test/resources/slack/README.md
@@ -1,0 +1,43 @@
+# Slack Kamelet test
+
+This test verifies the Slack Kamelets defined in [slack-source.kamelet.yaml](slack-source.kamelet.yaml)
+
+## Objectives
+
+The test verifies the Slack Kamelets by creating a Camel K integration that uses the Kamelet to listen for messages on a
+Slack channel using the Slack bot API.
+
+### Test Kamelets
+
+The test performs the following high level steps:
+
+*Preparation*
+- Create a Slack API server that will simulate the Slack API (e.g. providing a webhook URL or verifying the Slack API channel history calls)
+
+*Scenario* 
+- Create the Camel K integration that uses the Slack Kamelets
+- Wait for the Camel K integration to start and listen for Slack messages
+- Create a new message on the Slack channel
+- Verify that the integration has received the message event
+
+*Cleanup*
+- Delete the Camel K integration
+
+## Installation
+
+The test assumes that you have access to a Kubernetes cluster and that the Camel K operator as well as the YAKS operator is installed
+and running.
+
+You can review the installation steps for the operators in the documentation:
+
+- [Install Camel K operator](https://camel.apache.org/camel-k/latest/installation/installation.html)
+- [Install YAKS operator](https://github.com/citrusframework/yaks#installation)
+
+## Run the test
+
+```shell script
+$ yaks run --local src/test/resources/slack/slack-source.feature
+$ yaks run --local src/test/resources/slack/slack-sink.feature
+```
+
+You will be provided with the test log output and the test results.

--- a/tests/camel-kamelets-itest/src/test/resources/slack/slack-sink-pipe.yaml
+++ b/tests/camel-kamelets-itest/src/test/resources/slack/slack-sink-pipe.yaml
@@ -1,0 +1,46 @@
+# ---------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ---------------------------------------------------------------------------
+
+apiVersion: camel.apache.org/v1
+kind: Pipe
+metadata:
+  name: slack-sink-pipe
+spec:
+  source:
+    ref:
+      kind: Kamelet
+      apiVersion: camel.apache.org/v1
+      name: timer-source
+    properties:
+      period: ${timer.source.period}
+      message: '${slack.message}'
+  steps:
+    - ref:
+        kind: Kamelet
+        apiVersion: camel.apache.org/v1
+        name: log-action
+      properties:
+        showHeaders: true
+  sink:
+    ref:
+      kind: Kamelet
+      apiVersion: camel.apache.org/v1
+      name: slack-sink
+    properties:
+      webhookUrl: yaks:resolveURL('slack-service')
+      channel: ${slack.channel}
+      token: ${slack.token}

--- a/tests/camel-kamelets-itest/src/test/resources/slack/slack-sink.feature
+++ b/tests/camel-kamelets-itest/src/test/resources/slack/slack-sink.feature
@@ -1,0 +1,56 @@
+# ---------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ---------------------------------------------------------------------------
+
+Feature: Slack Kamelet - Sink
+
+  Background:
+    Given variables
+      | timer.source.period | 10000 |
+      | slack.channel | announcements |
+      | slack.message | Camel rocks! |
+      | slack.user.id | W12345678    |
+      | slack.team.id | T12345678    |
+    Given HTTP server timeout is 15000 ms
+    Given HTTP server "slack-service"
+
+  Scenario: Create Http server
+    Given create Kubernetes service slack-service
+
+  Scenario: Verify Slack events
+    Given variables
+      | slack.token   | xoxb-yaks:randomNumber(10)-yaks:randomNumber(13)-yaks:randomString(34) |
+    # Create binding
+    Given load Pipe slack-sink-pipe.yaml
+    # Verify authentication test
+    Given expect HTTP request header: Content-Type="application/json; charset=UTF-8"
+    Then expect HTTP request body
+    """
+    {
+        "channel": "${slack.channel}",
+        "text": "${slack.message}",
+    }
+    """
+    When receive POST /
+    Then send HTTP 200 OK
+    # Verify event
+    And Camel K integration slack-sink-pipe should print ${slack.message}
+
+  Scenario: Remove resources
+    # Remove Camel K binding
+    Given delete Pipe slack-sink-pipe
+    Given delete Kubernetes service slack-service
+    And stop server component slack-service

--- a/tests/camel-kamelets-itest/src/test/resources/slack/slack-source-pipe.yaml
+++ b/tests/camel-kamelets-itest/src/test/resources/slack/slack-source-pipe.yaml
@@ -1,0 +1,38 @@
+# ---------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ---------------------------------------------------------------------------
+
+apiVersion: camel.apache.org/v1
+kind: Pipe
+metadata:
+  name: slack-source-pipe
+spec:
+  source:
+    ref:
+      kind: Kamelet
+      apiVersion: camel.apache.org/v1
+      name: slack-source
+    properties:
+      serverUrl: yaks:resolveURL('slack-service')
+      channel: ${slack.channel}
+      token: ${slack.token}
+  sink:
+    ref:
+      kind: Kamelet
+      apiVersion: camel.apache.org/v1
+      name: log-sink
+      properties:
+        showHeaders: true

--- a/tests/camel-kamelets-itest/src/test/resources/slack/slack-source.feature
+++ b/tests/camel-kamelets-itest/src/test/resources/slack/slack-source.feature
@@ -1,0 +1,132 @@
+# ---------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ---------------------------------------------------------------------------
+
+Feature: Slack Kamelet - Source
+
+  Background:
+    Given variables
+      | slack.channel | announcements |
+      | slack.message | Camel rocks! |
+      | slack.user.id | W12345678    |
+      | slack.team.id | T12345678    |
+    Given HTTP server timeout is 15000 ms
+    Given HTTP server "slack-service"
+
+  Scenario: Create Http server
+    Given create Kubernetes service slack-service
+
+  Scenario: Verify Slack events
+    Given variables
+      | slack.token   | xoxb-yaks:randomNumber(10)-yaks:randomNumber(13)-yaks:randomString(34) |
+    # Create binding
+    Given load Pipe slack-source-pipe.yaml
+    # Verify authentication test
+    Given expect HTTP request header: Authorization="Bearer ${slack.token}"
+    Given expect HTTP request header: Content-Type="application/x-www-form-urlencoded"
+    When receive POST /api/auth.test
+    Then HTTP response body
+    """
+    {
+        "ok": true,
+        "url": "yaks:resolveURL('slack-service')",
+        "team": "Camel Workspace",
+        "user": "yaks",
+        "team_id": "${slack.team.id}",
+        "user_id": "${slack.user.id}"
+    }
+    """
+    Then send HTTP 200 OK
+    # Verify conversations list
+    Given expect HTTP request header: Authorization="Bearer ${slack.token}"
+    When receive POST /api/conversations.list
+    Then HTTP response body
+    """
+    {
+        "ok": true,
+        "channels": [
+            {
+                "id": "yaks:randomString(9, UPPERCASE)",
+                "name": "${slack.channel}",
+                "is_channel": true,
+                "is_group": false,
+                "is_im": false,
+                "created": 1449252889,
+                "creator": "U012A3CDE",
+                "is_archived": false,
+                "is_general": true,
+                "unlinked": 0,
+                "name_normalized": "${slack.channel}",
+                "is_shared": false,
+                "is_ext_shared": false,
+                "is_org_shared": false,
+                "pending_shared": [],
+                "is_pending_ext_shared": false,
+                "is_member": true,
+                "is_private": false,
+                "is_mpim": false,
+                "updated": 1678229664302,
+                "topic": {
+                    "value": "Company-wide announcements and work-based matters",
+                    "creator": "",
+                    "last_set": 0
+                },
+                "purpose": {
+                    "value": "This channel is for team-wide communication and announcements. All team members are in this channel.",
+                    "creator": "",
+                    "last_set": 0
+                },
+                "previous_names": [],
+                "num_members": 2
+            }
+        ],
+        "response_metadata": {
+            "next_cursor": "yaks:randomString(32)"
+        }
+    }
+    """
+    Then send HTTP 200 OK
+    # Verify conversations history
+    Given expect HTTP request header: Authorization="Bearer ${slack.token}"
+    When receive POST /api/conversations.history
+    Then HTTP response body
+    """
+    {
+        "ok": true,
+        "messages": [
+            {
+                "type": "message",
+                "user": "${slack.user.id}",
+                "text": "${slack.message}",
+                "ts": "1512085950.000216"
+            }
+        ],
+        "has_more": true,
+        "pin_count": 0,
+        "response_metadata": {
+            "next_cursor": "yaks:randomString(32)"
+        }
+    }
+    """
+    Then send HTTP 200 OK
+    # Verify event
+    And Camel K integration slack-source-pipe should print ${slack.message}
+
+  Scenario: Remove resources
+    # Remove Camel K binding
+    Given delete Pipe slack-source-pipe
+    Given delete Kubernetes service slack-service
+    And stop server component slack-service

--- a/tests/camel-kamelets-itest/src/test/resources/slack/yaks-config.yaml
+++ b/tests/camel-kamelets-itest/src/test/resources/slack/yaks-config.yaml
@@ -1,0 +1,55 @@
+# ---------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ---------------------------------------------------------------------------
+
+config:
+  namespace:
+    temporary: false
+  runtime:
+    env:
+      - name: YAKS_CAMEL_AUTO_REMOVE_RESOURCES
+        value: false
+      - name: YAKS_CAMELK_AUTO_REMOVE_RESOURCES
+        value: false
+      - name: YAKS_KAMELETS_AUTO_REMOVE_RESOURCES
+        value: false
+      - name: YAKS_KUBERNETES_AUTO_REMOVE_RESOURCES
+        value: false
+      - name: YAKS_KNATIVE_AUTO_REMOVE_RESOURCES
+        value: false
+      - name: YAKS_JBANG_CAMEL_DUMP_INTEGRATION_OUTPUT
+        value: true
+      - name: YAKS_TESTCONTAINERS_AUTO_REMOVE_RESOURCES
+        value: false
+      - name: CITRUS_TYPE_CONVERTER
+        value: camel
+    resources:
+      - slack-source-pipe.yaml
+      - slack-sink-pipe.yaml
+    cucumber:
+      tags:
+        - "not @ignored"
+    settings:
+      loggers:
+        - name: INTEGRATION_STATUS
+          level: INFO
+        - name: INTEGRATION_LOGS
+          level: INFO
+  dump:
+    enabled: true
+    failedOnly: true
+    includes:
+      - app=camel-k

--- a/tests/camel-kamelets-itest/src/test/resources/transformation/README.md
+++ b/tests/camel-kamelets-itest/src/test/resources/transformation/README.md
@@ -36,7 +36,7 @@ You can review the installation steps for the tooling in the documentation:
 To run tests with URI based configuration: 
 
 ```shell script
-$ yaks run --local test/avro-data-type/avro-serdes-action.feature
+$ yaks run --local src/test/resources/transformation/data-type-action.feature
 ```
 
 You will be provided with the test log output and the test results.


### PR DESCRIPTION
- Add serverUrl property to slack-source.kamelet for better testability reasons
- Use local Slack Http server in tests to verify Slack API calls