### PR TITLE
add VEX file with vulnerabilities information to SBOM

### DIFF
--- a/camel-kamelets-sbom/camel-kamelets-sbom.vex.json
+++ b/camel-kamelets-sbom/camel-kamelets-sbom.vex.json
@@ -1,0 +1,145 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-1825a239e56e9f5a1a6096a98c5f1d3a426a0eb6d4574e602b4a62c0101bbad1",
+  "author": "Davide Fucci (davide.fucci@bth.se)",
+  "timestamp": "2024-06-19T09:27:02.736293+02:00",
+  "last_updated": "2024-06-19T09:42:01.034645+02:00",
+  "version": 11,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2023-3635"
+      },
+      "timestamp": "2024-06-19T09:27:02.736294+02:00",
+      "products": [
+        {
+          "@id": "pkg:maven/com.squareup.okio/okio@1.15.0?type=jar"
+        }
+      ],
+      "status": "under_investigation"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2023-39410"
+      },
+      "timestamp": "2024-06-19T09:29:01.449532+02:00",
+      "products": [
+        {
+          "@id": "pkg:maven/org.apache.avro/avro@1.8.2?type=jar"
+        }
+      ],
+      "status": "under_investigation"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2019-10202"
+      },
+      "timestamp": "2024-06-19T09:33:14.931683+02:00",
+      "products": [
+        {
+          "@id": "pkg:maven/org.codehaus.jackson/jackson-mapper-asl@1.9.13?type=jar"
+        }
+      ],
+      "status": "under_investigation"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2019-10172"
+      },
+      "timestamp": "2024-06-19T09:34:26.033861+02:00",
+      "products": [
+        {
+          "@id": "pkg:maven/org.codehaus.jackson/jackson-mapper-asl@1.9.13?type=jar"
+        }
+      ],
+      "status": "under_investigation"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2024-25710"
+      },
+      "timestamp": "2024-06-19T09:35:44.392635+02:00",
+      "products": [
+        {
+          "@id": "pkg:maven/org.apache.commons/commons-compress@1.8.1?type=jar"
+        }
+      ],
+      "status": "under_investigation"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2021-35515"
+      },
+      "timestamp": "2024-06-19T09:36:23.804341+02:00",
+      "products": [
+        {
+          "@id": "pkg:maven/org.apache.commons/commons-compress@1.8.1?type=jar"
+        }
+      ],
+      "status": "under_investigation"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2021-35565"
+      },
+      "timestamp": "2024-06-19T09:36:45.465007+02:00",
+      "products": [
+        {
+          "@id": "pkg:maven/org.apache.commons/commons-compress@1.8.1?type=jar"
+        }
+      ],
+      "status": "under_investigation"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2018-11771"
+      },
+      "timestamp": "2024-06-19T09:37:11.953898+02:00",
+      "products": [
+        {
+          "@id": "pkg:maven/org.apache.commons/commons-compress@1.8.1?type=jar"
+        }
+      ],
+      "status": "under_investigation"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2021-36090"
+      },
+      "timestamp": "2024-06-19T09:37:37.997898+02:00",
+      "products": [
+        {
+          "@id": "pkg:maven/org.apache.commons/commons-compress@1.8.1?type=jar"
+        }
+      ],
+      "status": "under_investigation"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2021-35517"
+      },
+      "timestamp": "2024-06-19T09:38:00.592205+02:00",
+      "products": [
+        {
+          "@id": "pkg:maven/org.apache.commons/commons-compress@1.8.1?type=jar"
+        }
+      ],
+      "status": "under_investigation"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2024-35255"
+      },
+      "timestamp": "2024-06-19T09:42:01.034646+02:00",
+      "products": [
+        {
+          "@id": "pkg:maven/com.microsoft.azure/msal4j@1.15.0?type=jar"
+        },
+        {
+          @id: "pkg:maven/com.azure/azure-identity@1.12.0?type=jar"
+        }
+      ],
+      "status": "under_investigation"
+    }
+  ]
+}


### PR DESCRIPTION
Dear project owners,
We are a group of researchers investigating the usefulness of augmenting Software Bills of Materials (SBOMs) with information about known vulnerabilities of third-party dependencies.

As claimed in previous interview-based studies, a major limitation—according to software practitioners—of existing SBOMs is the lack of information about known vulnerabilities.  For this reason, we would like to investigate how augmented SBOMs are received in open-source projects.

To this aim, we have identified popular open-source repositories on GitHub that provided SBOMs, statically detected vulnerabilities on their dependencies in the OSV database, and, based on its output, we have augmented your repository’s SBOM by leveraging the OpenVEX implementation of the Vulnerability Exploitability eXchange (VEX). 

The JSON file in this pull request consists of statements, each indicating i) the software products (i.e., dependencies) that may be affected by a vulnerability. These are linked to the SBOM components through the @id field in their Persistent uniform resource locator (pURL); ii) a CVE affecting the product; iii) an impact status defined by VEX. By default, all statements have the status `under_investigation` as it is not yet known whether these product versions are actually affected by the vulnerability. After investigating the vulnerability, further statuses can be `affected`, `not_affected`, `fixed`. It is possible to motivate the new status in a `justification` field (see https://www.cisa.gov/sites/default/files/publications/VEX_Status_Justification_Jun22.pdf for more information). 
 
We open this pull request containing a VEX file related to the SBOM of your project and hope it will be considered. 
We would also like to hear your opinion on the usefulness (or not) of this information by answering a 3-minute anonymous survey:
https://ww2.unipark.de/uc/sbom/

Thanks in advance, and regards,
Davide Fucci (Blekinge Institute of Technology, Sweden) 
Simone Romano and Giuseppe Scaniello (University of Salerno, Italy),
Massimiliano Di Penta (University of Sannio, Italy)
