### PR TITLE
Support for RabbitMQ VirtualHost in Spring-RabbitMQ Source/Sink

### DIFF
--- a/kamelets/spring-rabbitmq-sink.kamelet.yaml
+++ b/kamelets/spring-rabbitmq-sink.kamelet.yaml
@@ -79,6 +79,11 @@ spec:
         description: Specifies whether the producer should auto declare binding between exchange, queue and routing key when starting
         type: boolean
         default: false
+      vhost:
+        title: Virtual Host
+        description: The virtual host
+        type: string
+        default: "/"
   dependencies:
     - "camel:spring-rabbitmq"
     - "camel:kamelet"
@@ -91,6 +96,7 @@ spec:
           password: '{{?password}}'
           host: '{{host}}'
           port: '{{port}}'
+          virtualHost: "{{vhost}}"
     from:
       uri: "kamelet:source"
       steps:

--- a/kamelets/spring-rabbitmq-source.kamelet.yaml
+++ b/kamelets/spring-rabbitmq-source.kamelet.yaml
@@ -79,6 +79,11 @@ spec:
         description: The routing key to use when binding a consumer queue to the exchange
         type: boolean
         default: false
+      vhost:
+        title: Virtual Host
+        description: The virtual host
+        type: string
+        default: "/"
   dependencies:
     - "camel:spring-rabbitmq"
     - "camel:kamelet"
@@ -91,6 +96,7 @@ spec:
           password: '{{?password}}'
           host: '{{host}}'
           port: '{{port}}'
+          virtualHost: "{{vhost}}"
     from:
       uri: "spring-rabbitmq://{{exchangeName}}"
       parameters:


### PR DESCRIPTION
Add support for vhost configuration in Spring-RabbitMQ Source/Sink, which was previously added to the deprecated RabbitMQ Source in #1068.

Refs #2114.