### PR TITLE
AWS Kamelets: Support profile and session credentials provider out of the box 

### DIFF
--- a/kamelets/aws-eventbridge-sink.kamelet.yaml
+++ b/kamelets/aws-eventbridge-sink.kamelet.yaml
@@ -78,6 +78,27 @@ spec:
         description: If true, the Eventbridge client loads credentials through a default credentials provider. If false, it uses the basic authentication method (access key and secret key).
         type: boolean
         default: false
+      useProfileCredentialsProvider:
+        title: Profile Credentials Provider
+        description: Set whether the Eventbridge client should expect to load credentials through a profile credentials provider.
+        type: boolean
+        default: false
+      useSessionCredentials:
+        title: Session Credentials
+        description: Set whether the Eventbridge client should expect to use Session Credentials. This is useful in situation in which the user needs to assume a IAM role for doing operations in Eventbridge.
+        type: boolean
+        default: false
+      profileCredentialsName:
+        title: Profile Credentials Name
+        description: If using a profile credentials provider this parameter will set the profile name.
+        type: string
+      sessionToken:
+        title: Session Token
+        description: Amazon AWS Session Token used when the user needs to assume a IAM role.
+        type: string
+        format: password
+        x-descriptors:
+        - urn:camel:group:credentials
       uriEndpointOverride:
         title: Overwrite Endpoint URI
         description: The overriding endpoint URI. To use this option, you must also select the `overrideEndpoint` option.
@@ -138,6 +159,10 @@ spec:
             accessKey: "{{?accessKey}}"
             region: "{{region}}"
             useDefaultCredentialsProvider: "{{useDefaultCredentialsProvider}}"
+            useProfileCredentialsProvider: "{{useProfileCredentialsProvider}}"
+            useSessionCredentials: "{{useSessionCredentials}}"
             uriEndpointOverride: "{{?uriEndpointOverride}}"
+            profileCredentialsName: "{{?profileCredentialsName}}"
+            sessionToken: "{{?sessionToken}}"
             overrideEndpoint: "{{overrideEndpoint}}"
             operation: "putEvent"

--- a/kamelets/aws-kinesis-firehose-sink.kamelet.yaml
+++ b/kamelets/aws-kinesis-firehose-sink.kamelet.yaml
@@ -70,6 +70,27 @@ spec:
         description: Set whether the Kinesis Firehose client should expect to load credentials through a default credentials provider or to expect static credentials to be passed in.
         type: boolean
         default: false
+      useProfileCredentialsProvider:
+        title: Profile Credentials Provider
+        description: Set whether the Kinesis Firehose client should expect to load credentials through a profile credentials provider.
+        type: boolean
+        default: false
+      useSessionCredentials:
+        title: Session Credentials
+        description: Set whether the Kinesis Firehose client should expect to use Session Credentials. This is useful in situation in which the user needs to assume a IAM role for doing operations in Kinesis Firehose.
+        type: boolean
+        default: false
+      profileCredentialsName:
+        title: Profile Credentials Name
+        description: If using a profile credentials provider this parameter will set the profile name.
+        type: string
+      sessionToken:
+        title: Session Token
+        description: Amazon AWS Session Token used when the user needs to assume a IAM role.
+        type: string
+        format: password
+        x-descriptors:
+        - urn:camel:group:credentials
       uriEndpointOverride:
         title: Overwrite Endpoint URI
         description: The overriding endpoint URI. To use this option, you must also select the `overrideEndpoint` option.
@@ -93,5 +114,9 @@ spec:
             secretKey: "{{?secretKey}}"
             region: "{{region}}"
             useDefaultCredentialsProvider: "{{useDefaultCredentialsProvider}}"
+            useProfileCredentialsProvider: "{{useProfileCredentialsProvider}}"
+            useSessionCredentials: "{{useSessionCredentials}}"
             uriEndpointOverride: "{{?uriEndpointOverride}}"
+            profileCredentialsName: "{{?profileCredentialsName}}"
+            sessionToken: "{{?sessionToken}}"
             overrideEndpoint: "{{overrideEndpoint}}"

--- a/kamelets/aws-kinesis-sink.kamelet.yaml
+++ b/kamelets/aws-kinesis-sink.kamelet.yaml
@@ -77,6 +77,27 @@ spec:
         description: If true, the Kinesis client loads credentials through a default credentials provider. If false, it uses the basic authentication method (access key and secret key).
         type: boolean
         default: false
+      useProfileCredentialsProvider:
+        title: Profile Credentials Provider
+        description: Set whether the Kinesis client should expect to load credentials through a profile credentials provider.
+        type: boolean
+        default: false
+      useSessionCredentials:
+        title: Session Credentials
+        description: Set whether the Kinesis client should expect to use Session Credentials. This is useful in situation in which the user needs to assume a IAM role for doing operations in Kinesis.
+        type: boolean
+        default: false
+      profileCredentialsName:
+        title: Profile Credentials Name
+        description: If using a profile credentials provider this parameter will set the profile name.
+        type: string
+      sessionToken:
+        title: Session Token
+        description: Amazon AWS Session Token used when the user needs to assume a IAM role.
+        type: string
+        format: password
+        x-descriptors:
+        - urn:camel:group:credentials
       uriEndpointOverride:
         title: Overwrite Endpoint URI
         description: The overriding endpoint URI. To use this option, you must also select the `overrideEndpoint` option.
@@ -133,5 +154,9 @@ spec:
             accessKey: "{{?accessKey}}"
             region: "{{region}}"
             useDefaultCredentialsProvider: "{{useDefaultCredentialsProvider}}"
+            useProfileCredentialsProvider: "{{useProfileCredentialsProvider}}"
+            useSessionCredentials: "{{useSessionCredentials}}"
             uriEndpointOverride: "{{?uriEndpointOverride}}"
+            profileCredentialsName: "{{?profileCredentialsName}}"
+            sessionToken: "{{?sessionToken}}"
             overrideEndpoint: "{{overrideEndpoint}}"

--- a/kamelets/aws-kinesis-source.kamelet.yaml
+++ b/kamelets/aws-kinesis-source.kamelet.yaml
@@ -72,6 +72,27 @@ spec:
         description: If true, the Kinesis client loads credentials through a default credentials provider. If false, it uses the basic authentication method (access key and secret key).
         type: boolean
         default: false
+      useProfileCredentialsProvider:
+        title: Profile Credentials Provider
+        description: Set whether the Kinesis client should expect to load credentials through a profile credentials provider.
+        type: boolean
+        default: false
+      useSessionCredentials:
+        title: Session Credentials
+        description: Set whether the Kinesis client should expect to use Session Credentials. This is useful in situation in which the user needs to assume a IAM role for doing operations in Kinesis.
+        type: boolean
+        default: false
+      profileCredentialsName:
+        title: Profile Credentials Name
+        description: If using a profile credentials provider this parameter will set the profile name.
+        type: string
+      sessionToken:
+        title: Session Token
+        description: Amazon AWS Session Token used when the user needs to assume a IAM role.
+        type: string
+        format: password
+        x-descriptors:
+        - urn:camel:group:credentials
       uriEndpointOverride:
         title: Overwrite Endpoint URI
         description: The overriding endpoint URI. To use this option, you must also select the `overrideEndpoint` option.
@@ -112,7 +133,11 @@ spec:
         accessKey: "{{?accessKey}}"
         region: "{{region}}"
         useDefaultCredentialsProvider: "{{useDefaultCredentialsProvider}}"
+        useProfileCredentialsProvider: "{{useProfileCredentialsProvider}}"
+        useSessionCredentials: "{{useSessionCredentials}}"
         uriEndpointOverride: "{{?uriEndpointOverride}}"
+        profileCredentialsName: "{{?profileCredentialsName}}"
+        sessionToken: "{{?sessionToken}}"
         overrideEndpoint: "{{overrideEndpoint}}"
         delay: "{{delay}}"
         useKclConsumers: "{{useKclConsumers}}"

--- a/kamelets/aws-lambda-sink.kamelet.yaml
+++ b/kamelets/aws-lambda-sink.kamelet.yaml
@@ -70,6 +70,27 @@ spec:
         description: If true, the Lambda client loads credentials through a default credentials provider. If false, it uses the basic authentication method (access key and secret key).
         type: boolean
         default: false
+      useProfileCredentialsProvider:
+        title: Profile Credentials Provider
+        description: Set whether the Lambda client should expect to load credentials through a profile credentials provider.
+        type: boolean
+        default: false
+      useSessionCredentials:
+        title: Session Credentials
+        description: Set whether the Lambda client should expect to use Session Credentials. This is useful in situation in which the user needs to assume a IAM role for doing operations in Lambda.
+        type: boolean
+        default: false
+      profileCredentialsName:
+        title: Profile Credentials Name
+        description: If using a profile credentials provider this parameter will set the profile name.
+        type: string
+      sessionToken:
+        title: Session Token
+        description: Amazon AWS Session Token used when the user needs to assume a IAM role.
+        type: string
+        format: password
+        x-descriptors:
+        - urn:camel:group:credentials
   dependencies:
     - "camel:aws2-lambda"
     - "camel:kamelet"
@@ -84,3 +105,7 @@ spec:
             secretKey: "{{?secretKey}}"
             region: "{{region}}"
             useDefaultCredentialsProvider: "{{useDefaultCredentialsProvider}}"
+            useProfileCredentialsProvider: "{{useProfileCredentialsProvider}}"
+            useSessionCredentials: "{{useSessionCredentials}}"
+            profileCredentialsName: "{{?profileCredentialsName}}"
+            sessionToken: "{{?sessionToken}}"

--- a/library/camel-kamelets/src/main/resources/kamelets/aws-eventbridge-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/aws-eventbridge-sink.kamelet.yaml
@@ -78,6 +78,27 @@ spec:
         description: If true, the Eventbridge client loads credentials through a default credentials provider. If false, it uses the basic authentication method (access key and secret key).
         type: boolean
         default: false
+      useProfileCredentialsProvider:
+        title: Profile Credentials Provider
+        description: Set whether the Eventbridge client should expect to load credentials through a profile credentials provider.
+        type: boolean
+        default: false
+      useSessionCredentials:
+        title: Session Credentials
+        description: Set whether the Eventbridge client should expect to use Session Credentials. This is useful in situation in which the user needs to assume a IAM role for doing operations in Eventbridge.
+        type: boolean
+        default: false
+      profileCredentialsName:
+        title: Profile Credentials Name
+        description: If using a profile credentials provider this parameter will set the profile name.
+        type: string
+      sessionToken:
+        title: Session Token
+        description: Amazon AWS Session Token used when the user needs to assume a IAM role.
+        type: string
+        format: password
+        x-descriptors:
+        - urn:camel:group:credentials
       uriEndpointOverride:
         title: Overwrite Endpoint URI
         description: The overriding endpoint URI. To use this option, you must also select the `overrideEndpoint` option.
@@ -138,6 +159,10 @@ spec:
             accessKey: "{{?accessKey}}"
             region: "{{region}}"
             useDefaultCredentialsProvider: "{{useDefaultCredentialsProvider}}"
+            useProfileCredentialsProvider: "{{useProfileCredentialsProvider}}"
+            useSessionCredentials: "{{useSessionCredentials}}"
             uriEndpointOverride: "{{?uriEndpointOverride}}"
+            profileCredentialsName: "{{?profileCredentialsName}}"
+            sessionToken: "{{?sessionToken}}"
             overrideEndpoint: "{{overrideEndpoint}}"
             operation: "putEvent"

--- a/library/camel-kamelets/src/main/resources/kamelets/aws-kinesis-firehose-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/aws-kinesis-firehose-sink.kamelet.yaml
@@ -70,6 +70,27 @@ spec:
         description: Set whether the Kinesis Firehose client should expect to load credentials through a default credentials provider or to expect static credentials to be passed in.
         type: boolean
         default: false
+      useProfileCredentialsProvider:
+        title: Profile Credentials Provider
+        description: Set whether the Kinesis Firehose client should expect to load credentials through a profile credentials provider.
+        type: boolean
+        default: false
+      useSessionCredentials:
+        title: Session Credentials
+        description: Set whether the Kinesis Firehose client should expect to use Session Credentials. This is useful in situation in which the user needs to assume a IAM role for doing operations in Kinesis Firehose.
+        type: boolean
+        default: false
+      profileCredentialsName:
+        title: Profile Credentials Name
+        description: If using a profile credentials provider this parameter will set the profile name.
+        type: string
+      sessionToken:
+        title: Session Token
+        description: Amazon AWS Session Token used when the user needs to assume a IAM role.
+        type: string
+        format: password
+        x-descriptors:
+        - urn:camel:group:credentials
       uriEndpointOverride:
         title: Overwrite Endpoint URI
         description: The overriding endpoint URI. To use this option, you must also select the `overrideEndpoint` option.
@@ -93,5 +114,9 @@ spec:
             secretKey: "{{?secretKey}}"
             region: "{{region}}"
             useDefaultCredentialsProvider: "{{useDefaultCredentialsProvider}}"
+            useProfileCredentialsProvider: "{{useProfileCredentialsProvider}}"
+            useSessionCredentials: "{{useSessionCredentials}}"
             uriEndpointOverride: "{{?uriEndpointOverride}}"
+            profileCredentialsName: "{{?profileCredentialsName}}"
+            sessionToken: "{{?sessionToken}}"
             overrideEndpoint: "{{overrideEndpoint}}"

--- a/library/camel-kamelets/src/main/resources/kamelets/aws-kinesis-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/aws-kinesis-sink.kamelet.yaml
@@ -77,6 +77,27 @@ spec:
         description: If true, the Kinesis client loads credentials through a default credentials provider. If false, it uses the basic authentication method (access key and secret key).
         type: boolean
         default: false
+      useProfileCredentialsProvider:
+        title: Profile Credentials Provider
+        description: Set whether the Kinesis client should expect to load credentials through a profile credentials provider.
+        type: boolean
+        default: false
+      useSessionCredentials:
+        title: Session Credentials
+        description: Set whether the Kinesis client should expect to use Session Credentials. This is useful in situation in which the user needs to assume a IAM role for doing operations in Kinesis.
+        type: boolean
+        default: false
+      profileCredentialsName:
+        title: Profile Credentials Name
+        description: If using a profile credentials provider this parameter will set the profile name.
+        type: string
+      sessionToken:
+        title: Session Token
+        description: Amazon AWS Session Token used when the user needs to assume a IAM role.
+        type: string
+        format: password
+        x-descriptors:
+        - urn:camel:group:credentials
       uriEndpointOverride:
         title: Overwrite Endpoint URI
         description: The overriding endpoint URI. To use this option, you must also select the `overrideEndpoint` option.
@@ -133,5 +154,9 @@ spec:
             accessKey: "{{?accessKey}}"
             region: "{{region}}"
             useDefaultCredentialsProvider: "{{useDefaultCredentialsProvider}}"
+            useProfileCredentialsProvider: "{{useProfileCredentialsProvider}}"
+            useSessionCredentials: "{{useSessionCredentials}}"
             uriEndpointOverride: "{{?uriEndpointOverride}}"
+            profileCredentialsName: "{{?profileCredentialsName}}"
+            sessionToken: "{{?sessionToken}}"
             overrideEndpoint: "{{overrideEndpoint}}"

--- a/library/camel-kamelets/src/main/resources/kamelets/aws-kinesis-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/aws-kinesis-source.kamelet.yaml
@@ -72,6 +72,27 @@ spec:
         description: If true, the Kinesis client loads credentials through a default credentials provider. If false, it uses the basic authentication method (access key and secret key).
         type: boolean
         default: false
+      useProfileCredentialsProvider:
+        title: Profile Credentials Provider
+        description: Set whether the Kinesis client should expect to load credentials through a profile credentials provider.
+        type: boolean
+        default: false
+      useSessionCredentials:
+        title: Session Credentials
+        description: Set whether the Kinesis client should expect to use Session Credentials. This is useful in situation in which the user needs to assume a IAM role for doing operations in Kinesis.
+        type: boolean
+        default: false
+      profileCredentialsName:
+        title: Profile Credentials Name
+        description: If using a profile credentials provider this parameter will set the profile name.
+        type: string
+      sessionToken:
+        title: Session Token
+        description: Amazon AWS Session Token used when the user needs to assume a IAM role.
+        type: string
+        format: password
+        x-descriptors:
+        - urn:camel:group:credentials
       uriEndpointOverride:
         title: Overwrite Endpoint URI
         description: The overriding endpoint URI. To use this option, you must also select the `overrideEndpoint` option.
@@ -112,7 +133,11 @@ spec:
         accessKey: "{{?accessKey}}"
         region: "{{region}}"
         useDefaultCredentialsProvider: "{{useDefaultCredentialsProvider}}"
+        useProfileCredentialsProvider: "{{useProfileCredentialsProvider}}"
+        useSessionCredentials: "{{useSessionCredentials}}"
         uriEndpointOverride: "{{?uriEndpointOverride}}"
+        profileCredentialsName: "{{?profileCredentialsName}}"
+        sessionToken: "{{?sessionToken}}"
         overrideEndpoint: "{{overrideEndpoint}}"
         delay: "{{delay}}"
         useKclConsumers: "{{useKclConsumers}}"

--- a/library/camel-kamelets/src/main/resources/kamelets/aws-lambda-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/aws-lambda-sink.kamelet.yaml
@@ -70,6 +70,27 @@ spec:
         description: If true, the Lambda client loads credentials through a default credentials provider. If false, it uses the basic authentication method (access key and secret key).
         type: boolean
         default: false
+      useProfileCredentialsProvider:
+        title: Profile Credentials Provider
+        description: Set whether the Lambda client should expect to load credentials through a profile credentials provider.
+        type: boolean
+        default: false
+      useSessionCredentials:
+        title: Session Credentials
+        description: Set whether the Lambda client should expect to use Session Credentials. This is useful in situation in which the user needs to assume a IAM role for doing operations in Lambda.
+        type: boolean
+        default: false
+      profileCredentialsName:
+        title: Profile Credentials Name
+        description: If using a profile credentials provider this parameter will set the profile name.
+        type: string
+      sessionToken:
+        title: Session Token
+        description: Amazon AWS Session Token used when the user needs to assume a IAM role.
+        type: string
+        format: password
+        x-descriptors:
+        - urn:camel:group:credentials
   dependencies:
     - "camel:aws2-lambda"
     - "camel:kamelet"
@@ -84,3 +105,7 @@ spec:
             secretKey: "{{?secretKey}}"
             region: "{{region}}"
             useDefaultCredentialsProvider: "{{useDefaultCredentialsProvider}}"
+            useProfileCredentialsProvider: "{{useProfileCredentialsProvider}}"
+            useSessionCredentials: "{{useSessionCredentials}}"
+            profileCredentialsName: "{{?profileCredentialsName}}"
+            sessionToken: "{{?sessionToken}}"


### PR DESCRIPTION
Related to #2131 

Part 2