### PR TITLE
AWS Kamelets: Support profile and session credentials provider out of the box

### DIFF
--- a/kamelets/aws-s3-sink.kamelet.yaml
+++ b/kamelets/aws-s3-sink.kamelet.yaml
@@ -81,12 +81,12 @@ spec:
         default: false
       useProfileCredentialsProvider:
         title: Profile Credentials Provider
-        description: Set whether the Eventbridge client should expect to load credentials through a profile credentials provider.
+        description: Set whether the S3 client should expect to load credentials through a profile credentials provider.
         type: boolean
         default: false
       useSessionCredentials:
         title: Session Credentials
-        description: Set whether the Eventbridge client should expect to use Session Credentials. This is useful in situation in which the user needs to assume a IAM role for doing operations in Eventbridge.
+        description: Set whether the S3 client should expect to use Session Credentials. This is useful in situation in which the user needs to assume a IAM role for doing operations in S3.
         type: boolean
         default: false
       profileCredentialsName:

--- a/kamelets/aws-s3-sink.kamelet.yaml
+++ b/kamelets/aws-s3-sink.kamelet.yaml
@@ -79,6 +79,27 @@ spec:
         description: If true, the S3 client loads credentials through a default credentials provider. If false, it uses the basic authentication method (access key and secret key).
         type: boolean
         default: false
+      useProfileCredentialsProvider:
+        title: Profile Credentials Provider
+        description: Set whether the Eventbridge client should expect to load credentials through a profile credentials provider.
+        type: boolean
+        default: false
+      useSessionCredentials:
+        title: Session Credentials
+        description: Set whether the Eventbridge client should expect to use Session Credentials. This is useful in situation in which the user needs to assume a IAM role for doing operations in Eventbridge.
+        type: boolean
+        default: false
+      profileCredentialsName:
+        title: Profile Credentials Name
+        description: If using a profile credentials provider this parameter will set the profile name.
+        type: string
+      sessionToken:
+        title: Session Token
+        description: Amazon AWS Session Token used when the user needs to assume a IAM role.
+        type: string
+        format: password
+        x-descriptors:
+        - urn:camel:group:credentials
       uriEndpointOverride:
         title: Overwrite Endpoint URI
         description: The overriding endpoint URI. To use this option, you must also select the `overrideEndpoint` option.
@@ -135,7 +156,11 @@ spec:
             region: "{{region}}"
             autoCreateBucket: "{{autoCreateBucket}}"
             useDefaultCredentialsProvider: "{{useDefaultCredentialsProvider}}"
+            useProfileCredentialsProvider: "{{useProfileCredentialsProvider}}"
+            useSessionCredentials: "{{useSessionCredentials}}"
             uriEndpointOverride: "{{?uriEndpointOverride}}"
+            profileCredentialsName: "{{?profileCredentialsName}}"
+            sessionToken: "{{?sessionToken}}"
             overrideEndpoint: "{{overrideEndpoint}}"
             forcePathStyle: "{{forcePathStyle}}"
             keyName: "{{?keyName}}"

--- a/kamelets/aws-s3-source.kamelet.yaml
+++ b/kamelets/aws-s3-source.kamelet.yaml
@@ -92,6 +92,27 @@ spec:
         description: If true, the S3 client loads credentials through a default credentials provider. If false, it uses the basic authentication method (access key and secret key).
         type: boolean
         default: false
+      useProfileCredentialsProvider:
+        title: Profile Credentials Provider
+        description: Set whether the S3 client should expect to load credentials through a profile credentials provider.
+        type: boolean
+        default: false
+      useSessionCredentials:
+        title: Session Credentials
+        description: Set whether the S3 client should expect to use Session Credentials. This is useful in situation in which the user needs to assume a IAM role for doing operations in S3.
+        type: boolean
+        default: false
+      profileCredentialsName:
+        title: Profile Credentials Name
+        description: If using a profile credentials provider this parameter will set the profile name.
+        type: string
+      sessionToken:
+        title: Session Token
+        description: Amazon AWS Session Token used when the user needs to assume a IAM role.
+        type: string
+        format: password
+        x-descriptors:
+        - urn:camel:group:credentials
       uriEndpointOverride:
         title: Overwrite Endpoint URI
         description: The overriding endpoint URI. To use this option, you must also select the `overrideEndpoint` option.
@@ -188,7 +209,11 @@ spec:
         deleteAfterRead: "{{deleteAfterRead}}"
         prefix: "{{?prefix}}"
         useDefaultCredentialsProvider: "{{useDefaultCredentialsProvider}}"
+        useProfileCredentialsProvider: "{{useProfileCredentialsProvider}}"
+        useSessionCredentials: "{{useSessionCredentials}}"
         uriEndpointOverride: "{{?uriEndpointOverride}}"
+        profileCredentialsName: "{{?profileCredentialsName}}"
+        sessionToken: "{{?sessionToken}}"
         overrideEndpoint: "{{overrideEndpoint}}"
         forcePathStyle: "{{forcePathStyle}}"
         delay: "{{delay}}"

--- a/kamelets/aws-s3-streaming-upload-sink.kamelet.yaml
+++ b/kamelets/aws-s3-streaming-upload-sink.kamelet.yaml
@@ -104,6 +104,27 @@ spec:
         description: Set whether the S3 client should expect to load credentials through a default credentials provider or to expect static credentials to be passed in.
         type: boolean
         default: false
+      useProfileCredentialsProvider:
+        title: Profile Credentials Provider
+        description: Set whether the S3 client should expect to load credentials through a profile credentials provider.
+        type: boolean
+        default: false
+      useSessionCredentials:
+        title: Session Credentials
+        description: Set whether the S3 client should expect to use Session Credentials. This is useful in situation in which the user needs to assume a IAM role for doing operations in S3.
+        type: boolean
+        default: false
+      profileCredentialsName:
+        title: Profile Credentials Name
+        description: If using a profile credentials provider this parameter will set the profile name.
+        type: string
+      sessionToken:
+        title: Session Token
+        description: Amazon AWS Session Token used when the user needs to assume a IAM role.
+        type: string
+        format: password
+        x-descriptors:
+        - urn:camel:group:credentials
       uriEndpointOverride:
         title: Overwrite Endpoint URI
         description: The overriding endpoint URI. To use this option, you must also select the `overrideEndpoint` option.
@@ -140,6 +161,10 @@ spec:
             keyName: "{{keyName}}"
             streamingUploadTimeout: "{{?streamingUploadTimeout}}"
             useDefaultCredentialsProvider: "{{useDefaultCredentialsProvider}}"
+            useProfileCredentialsProvider: "{{useProfileCredentialsProvider}}"
+            useSessionCredentials: "{{useSessionCredentials}}"
             uriEndpointOverride: "{{?uriEndpointOverride}}"
+            profileCredentialsName: "{{?profileCredentialsName}}"
+            sessionToken: "{{?sessionToken}}"
             overrideEndpoint: "{{overrideEndpoint}}"
             forcePathStyle: "{{forcePathStyle}}"

--- a/kamelets/aws-secrets-manager-sink.kamelet.yaml
+++ b/kamelets/aws-secrets-manager-sink.kamelet.yaml
@@ -71,6 +71,27 @@ spec:
         description: Set whether the Secrets Manager client should expect to load credentials through a default credentials provider or to expect static credentials to be passed in.
         type: boolean
         default: false
+      useProfileCredentialsProvider:
+        title: Profile Credentials Provider
+        description: Set whether the Secrets Manager client should expect to load credentials through a profile credentials provider.
+        type: boolean
+        default: false
+      useSessionCredentials:
+        title: Session Credentials
+        description: Set whether the Secrets Manager client should expect to use Session Credentials. This is useful in situation in which the user needs to assume a IAM role for doing operations in Secrets Manager.
+        type: boolean
+        default: false
+      profileCredentialsName:
+        title: Profile Credentials Name
+        description: If using a profile credentials provider this parameter will set the profile name.
+        type: string
+      sessionToken:
+        title: Session Token
+        description: Amazon AWS Session Token used when the user needs to assume a IAM role.
+        type: string
+        format: password
+        x-descriptors:
+        - urn:camel:group:credentials
   dependencies:
     - "camel:core"
     - "camel:aws-secrets-manager"
@@ -103,4 +124,8 @@ spec:
             accessKey: "{{?accessKey}}"
             region: "{{region}}"
             useDefaultCredentialsProvider: "{{useDefaultCredentialsProvider}}"
+            useProfileCredentialsProvider: "{{useProfileCredentialsProvider}}"
+            useSessionCredentials: "{{useSessionCredentials}}"
             operation: "createSecret"
+            profileCredentialsName: "{{?profileCredentialsName}}"
+            sessionToken: "{{?sessionToken}}"            

--- a/library/camel-kamelets/src/main/resources/kamelets/aws-s3-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/aws-s3-sink.kamelet.yaml
@@ -81,12 +81,12 @@ spec:
         default: false
       useProfileCredentialsProvider:
         title: Profile Credentials Provider
-        description: Set whether the Eventbridge client should expect to load credentials through a profile credentials provider.
+        description: Set whether the S3 client should expect to load credentials through a profile credentials provider.
         type: boolean
         default: false
       useSessionCredentials:
         title: Session Credentials
-        description: Set whether the Eventbridge client should expect to use Session Credentials. This is useful in situation in which the user needs to assume a IAM role for doing operations in Eventbridge.
+        description: Set whether the S3 client should expect to use Session Credentials. This is useful in situation in which the user needs to assume a IAM role for doing operations in S3.
         type: boolean
         default: false
       profileCredentialsName:

--- a/library/camel-kamelets/src/main/resources/kamelets/aws-s3-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/aws-s3-sink.kamelet.yaml
@@ -79,6 +79,27 @@ spec:
         description: If true, the S3 client loads credentials through a default credentials provider. If false, it uses the basic authentication method (access key and secret key).
         type: boolean
         default: false
+      useProfileCredentialsProvider:
+        title: Profile Credentials Provider
+        description: Set whether the Eventbridge client should expect to load credentials through a profile credentials provider.
+        type: boolean
+        default: false
+      useSessionCredentials:
+        title: Session Credentials
+        description: Set whether the Eventbridge client should expect to use Session Credentials. This is useful in situation in which the user needs to assume a IAM role for doing operations in Eventbridge.
+        type: boolean
+        default: false
+      profileCredentialsName:
+        title: Profile Credentials Name
+        description: If using a profile credentials provider this parameter will set the profile name.
+        type: string
+      sessionToken:
+        title: Session Token
+        description: Amazon AWS Session Token used when the user needs to assume a IAM role.
+        type: string
+        format: password
+        x-descriptors:
+        - urn:camel:group:credentials
       uriEndpointOverride:
         title: Overwrite Endpoint URI
         description: The overriding endpoint URI. To use this option, you must also select the `overrideEndpoint` option.
@@ -135,7 +156,11 @@ spec:
             region: "{{region}}"
             autoCreateBucket: "{{autoCreateBucket}}"
             useDefaultCredentialsProvider: "{{useDefaultCredentialsProvider}}"
+            useProfileCredentialsProvider: "{{useProfileCredentialsProvider}}"
+            useSessionCredentials: "{{useSessionCredentials}}"
             uriEndpointOverride: "{{?uriEndpointOverride}}"
+            profileCredentialsName: "{{?profileCredentialsName}}"
+            sessionToken: "{{?sessionToken}}"
             overrideEndpoint: "{{overrideEndpoint}}"
             forcePathStyle: "{{forcePathStyle}}"
             keyName: "{{?keyName}}"

--- a/library/camel-kamelets/src/main/resources/kamelets/aws-s3-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/aws-s3-source.kamelet.yaml
@@ -92,6 +92,27 @@ spec:
         description: If true, the S3 client loads credentials through a default credentials provider. If false, it uses the basic authentication method (access key and secret key).
         type: boolean
         default: false
+      useProfileCredentialsProvider:
+        title: Profile Credentials Provider
+        description: Set whether the S3 client should expect to load credentials through a profile credentials provider.
+        type: boolean
+        default: false
+      useSessionCredentials:
+        title: Session Credentials
+        description: Set whether the S3 client should expect to use Session Credentials. This is useful in situation in which the user needs to assume a IAM role for doing operations in S3.
+        type: boolean
+        default: false
+      profileCredentialsName:
+        title: Profile Credentials Name
+        description: If using a profile credentials provider this parameter will set the profile name.
+        type: string
+      sessionToken:
+        title: Session Token
+        description: Amazon AWS Session Token used when the user needs to assume a IAM role.
+        type: string
+        format: password
+        x-descriptors:
+        - urn:camel:group:credentials
       uriEndpointOverride:
         title: Overwrite Endpoint URI
         description: The overriding endpoint URI. To use this option, you must also select the `overrideEndpoint` option.
@@ -188,7 +209,11 @@ spec:
         deleteAfterRead: "{{deleteAfterRead}}"
         prefix: "{{?prefix}}"
         useDefaultCredentialsProvider: "{{useDefaultCredentialsProvider}}"
+        useProfileCredentialsProvider: "{{useProfileCredentialsProvider}}"
+        useSessionCredentials: "{{useSessionCredentials}}"
         uriEndpointOverride: "{{?uriEndpointOverride}}"
+        profileCredentialsName: "{{?profileCredentialsName}}"
+        sessionToken: "{{?sessionToken}}"
         overrideEndpoint: "{{overrideEndpoint}}"
         forcePathStyle: "{{forcePathStyle}}"
         delay: "{{delay}}"

--- a/library/camel-kamelets/src/main/resources/kamelets/aws-s3-streaming-upload-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/aws-s3-streaming-upload-sink.kamelet.yaml
@@ -104,6 +104,27 @@ spec:
         description: Set whether the S3 client should expect to load credentials through a default credentials provider or to expect static credentials to be passed in.
         type: boolean
         default: false
+      useProfileCredentialsProvider:
+        title: Profile Credentials Provider
+        description: Set whether the S3 client should expect to load credentials through a profile credentials provider.
+        type: boolean
+        default: false
+      useSessionCredentials:
+        title: Session Credentials
+        description: Set whether the S3 client should expect to use Session Credentials. This is useful in situation in which the user needs to assume a IAM role for doing operations in S3.
+        type: boolean
+        default: false
+      profileCredentialsName:
+        title: Profile Credentials Name
+        description: If using a profile credentials provider this parameter will set the profile name.
+        type: string
+      sessionToken:
+        title: Session Token
+        description: Amazon AWS Session Token used when the user needs to assume a IAM role.
+        type: string
+        format: password
+        x-descriptors:
+        - urn:camel:group:credentials
       uriEndpointOverride:
         title: Overwrite Endpoint URI
         description: The overriding endpoint URI. To use this option, you must also select the `overrideEndpoint` option.
@@ -140,6 +161,10 @@ spec:
             keyName: "{{keyName}}"
             streamingUploadTimeout: "{{?streamingUploadTimeout}}"
             useDefaultCredentialsProvider: "{{useDefaultCredentialsProvider}}"
+            useProfileCredentialsProvider: "{{useProfileCredentialsProvider}}"
+            useSessionCredentials: "{{useSessionCredentials}}"
             uriEndpointOverride: "{{?uriEndpointOverride}}"
+            profileCredentialsName: "{{?profileCredentialsName}}"
+            sessionToken: "{{?sessionToken}}"
             overrideEndpoint: "{{overrideEndpoint}}"
             forcePathStyle: "{{forcePathStyle}}"

--- a/library/camel-kamelets/src/main/resources/kamelets/aws-secrets-manager-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/aws-secrets-manager-sink.kamelet.yaml
@@ -71,6 +71,27 @@ spec:
         description: Set whether the Secrets Manager client should expect to load credentials through a default credentials provider or to expect static credentials to be passed in.
         type: boolean
         default: false
+      useProfileCredentialsProvider:
+        title: Profile Credentials Provider
+        description: Set whether the Secrets Manager client should expect to load credentials through a profile credentials provider.
+        type: boolean
+        default: false
+      useSessionCredentials:
+        title: Session Credentials
+        description: Set whether the Secrets Manager client should expect to use Session Credentials. This is useful in situation in which the user needs to assume a IAM role for doing operations in Secrets Manager.
+        type: boolean
+        default: false
+      profileCredentialsName:
+        title: Profile Credentials Name
+        description: If using a profile credentials provider this parameter will set the profile name.
+        type: string
+      sessionToken:
+        title: Session Token
+        description: Amazon AWS Session Token used when the user needs to assume a IAM role.
+        type: string
+        format: password
+        x-descriptors:
+        - urn:camel:group:credentials
   dependencies:
     - "camel:core"
     - "camel:aws-secrets-manager"
@@ -103,4 +124,8 @@ spec:
             accessKey: "{{?accessKey}}"
             region: "{{region}}"
             useDefaultCredentialsProvider: "{{useDefaultCredentialsProvider}}"
+            useProfileCredentialsProvider: "{{useProfileCredentialsProvider}}"
+            useSessionCredentials: "{{useSessionCredentials}}"
             operation: "createSecret"
+            profileCredentialsName: "{{?profileCredentialsName}}"
+            sessionToken: "{{?sessionToken}}"            


### PR DESCRIPTION
Related to #2131 

Part 3