### PR TITLE
AWS Kamelets: Support profile and session credentials provider out of the box 

### DIFF
--- a/kamelets/aws-sqs-source.kamelet.yaml
+++ b/kamelets/aws-sqs-source.kamelet.yaml
@@ -108,6 +108,27 @@ spec:
         description: If true, the SQS client loads credentials through a default credentials provider. If false, it uses the basic authentication method (access key and secret key).
         type: boolean
         default: false
+      useProfileCredentialsProvider:
+        title: Profile Credentials Provider
+        description: Set whether the SQS client should expect to load credentials through a profile credentials provider.
+        type: boolean
+        default: false
+      useSessionCredentials:
+        title: Session Credentials
+        description: Set whether the SQS client should expect to use Session Credentials. This is useful in situation in which the user needs to assume a IAM role for doing operations in SQS.
+        type: boolean
+        default: false
+      profileCredentialsName:
+        title: Profile Credentials Name
+        description: If using a profile credentials provider this parameter will set the profile name.
+        type: string
+      sessionToken:
+        title: Session Token
+        description: Amazon AWS Session Token used when the user needs to assume a IAM role.
+        type: string
+        format: password
+        x-descriptors:
+        - urn:camel:group:credentials
       uriEndpointOverride:
         title: Overwrite Endpoint URI
         description: The overriding endpoint URI. To use this option, you must also select the `overrideEndpoint` option.
@@ -220,7 +241,11 @@ spec:
         amazonAWSHost: "{{?amazonAWSHost}}"
         protocol: "{{?protocol}}"
         useDefaultCredentialsProvider: "{{useDefaultCredentialsProvider}}"
+        useProfileCredentialsProvider: "{{useProfileCredentialsProvider}}"
+        useSessionCredentials: "{{useSessionCredentials}}"
         uriEndpointOverride: "{{?uriEndpointOverride}}"
+        profileCredentialsName: "{{?profileCredentialsName}}"
+        sessionToken: "{{?sessionToken}}"
         overrideEndpoint: "{{overrideEndpoint}}"
         delay: "{{delay}}"
         greedy: "{{greedy}}"

--- a/kamelets/aws-sts-assume-role-action.kamelet.yaml
+++ b/kamelets/aws-sts-assume-role-action.kamelet.yaml
@@ -69,8 +69,28 @@ spec:
         description: Set whether the STS client should expect to load credentials through a default credentials provider or to expect static credentials to be passed in.
         type: boolean
         default: false
+      useProfileCredentialsProvider:
+        title: Profile Credentials Provider
+        description: Set whether the STS client should expect to load credentials through a profile credentials provider.
+        type: boolean
+        default: false
+      useSessionCredentials:
+        title: Session Credentials
+        description: Set whether the STS client should expect to use Session Credentials. This is useful in situation in which the user needs to assume a IAM role for doing operations in STS.
+        type: boolean
+        default: false
+      profileCredentialsName:
+        title: Profile Credentials Name
+        description: If using a profile credentials provider this parameter will set the profile name.
+        type: string
+      sessionToken:
+        title: Session Token
+        description: Amazon AWS Session Token used when the user needs to assume a IAM role.
+        type: string
+        format: password
+        x-descriptors:
+        - urn:camel:group:credentials
   dependencies:
-    - "camel:dns"
     - "camel:kamelet"
     - "camel:core"
     - "camel:aws2-sts"
@@ -110,3 +130,7 @@ spec:
             region: "{{region}}"
             operation: "assumeRole"
             useDefaultCredentialsProvider: "{{useDefaultCredentialsProvider}}"
+            useProfileCredentialsProvider: "{{useProfileCredentialsProvider}}"
+            useSessionCredentials: "{{useSessionCredentials}}"
+            profileCredentialsName: "{{?profileCredentialsName}}"
+            sessionToken: "{{?sessionToken}}"            

--- a/kamelets/aws-timestream-query-sink.kamelet.yaml
+++ b/kamelets/aws-timestream-query-sink.kamelet.yaml
@@ -69,6 +69,27 @@ spec:
         description: If true, the CloudWatch client loads credentials through a default credentials provider. If false, it uses the basic authentication method (access key and secret key).
         type: boolean
         default: false
+      useProfileCredentialsProvider:
+        title: Profile Credentials Provider
+        description: Set whether the Timestream client should expect to load credentials through a profile credentials provider.
+        type: boolean
+        default: false
+      useSessionCredentials:
+        title: Session Credentials
+        description: Set whether the Timestream client should expect to use Session Credentials. This is useful in situation in which the user needs to assume a IAM role for doing operations in Timestream.
+        type: boolean
+        default: false
+      profileCredentialsName:
+        title: Profile Credentials Name
+        description: If using a profile credentials provider this parameter will set the profile name.
+        type: string
+      sessionToken:
+        title: Session Token
+        description: Amazon AWS Session Token used when the user needs to assume a IAM role.
+        type: string
+        format: password
+        x-descriptors:
+        - urn:camel:group:credentials
       uriEndpointOverride:
         title: Overwrite Endpoint URI
         description: The overriding endpoint URI. To use this option, you must also select the `overrideEndpoint` option.
@@ -106,5 +127,9 @@ spec:
             region: "{{region}}"
             operation: "query"
             useDefaultCredentialsProvider: "{{useDefaultCredentialsProvider}}"
+            useProfileCredentialsProvider: "{{useProfileCredentialsProvider}}"
+            useSessionCredentials: "{{useSessionCredentials}}"  
             uriEndpointOverride: "{{?uriEndpointOverride}}"
+            profileCredentialsName: "{{?profileCredentialsName}}"
+            sessionToken: "{{?sessionToken}}"
             overrideEndpoint: "{{overrideEndpoint}}"

--- a/kamelets/aws-translate-action.kamelet.yaml
+++ b/kamelets/aws-translate-action.kamelet.yaml
@@ -79,6 +79,27 @@ spec:
         description: Set whether the Translate client should expect to load credentials through a default credentials provider or to expect static credentials to be passed in.
         type: boolean
         default: false
+      useProfileCredentialsProvider:
+        title: Profile Credentials Provider
+        description: Set whether the Translate client should expect to load credentials through a profile credentials provider.
+        type: boolean
+        default: false
+      useSessionCredentials:
+        title: Session Credentials
+        description: Set whether the Translate client should expect to use Session Credentials. This is useful in situation in which the user needs to assume a IAM role for doing operations in Translate.
+        type: boolean
+        default: false
+      profileCredentialsName:
+        title: Profile Credentials Name
+        description: If using a profile credentials provider this parameter will set the profile name.
+        type: string
+      sessionToken:
+        title: Session Token
+        description: Amazon AWS Session Token used when the user needs to assume a IAM role.
+        type: string
+        format: password
+        x-descriptors:
+        - urn:camel:group:credentials
   dependencies:
     - "camel:dns"
     - "camel:kamelet"
@@ -96,3 +117,7 @@ spec:
             sourceLanguage: "{{sourceLanguage}}"
             targetLanguage: "{{targetLanguage}}"
             useDefaultCredentialsProvider: "{{useDefaultCredentialsProvider}}"
+            useProfileCredentialsProvider: "{{useProfileCredentialsProvider}}"
+            useSessionCredentials: "{{useSessionCredentials}}"
+            profileCredentialsName: "{{?profileCredentialsName}}"
+            sessionToken: "{{?sessionToken}}"

--- a/library/camel-kamelets-catalog/src/test/java/org/apache/camel/kamelets/catalog/KameletsCatalogTest.java
+++ b/library/camel-kamelets-catalog/src/test/java/org/apache/camel/kamelets/catalog/KameletsCatalogTest.java
@@ -55,7 +55,7 @@ public class KameletsCatalogTest {
     @Test
     void testGetKameletsDefinition() throws Exception {
         Definition props = catalog.getKameletDefinition("aws-sqs-source");
-        assertEquals(17, props.getProperties().keySet().size());
+        assertEquals(21, props.getProperties().keySet().size());
         assertTrue(props.getProperties().containsKey("queueNameOrArn"));
         assertTrue(props.getProperties().containsKey("deleteAfterRead"));
         assertTrue(props.getProperties().containsKey("accessKey"));

--- a/library/camel-kamelets/src/main/resources/kamelets/aws-sqs-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/aws-sqs-source.kamelet.yaml
@@ -108,6 +108,27 @@ spec:
         description: If true, the SQS client loads credentials through a default credentials provider. If false, it uses the basic authentication method (access key and secret key).
         type: boolean
         default: false
+      useProfileCredentialsProvider:
+        title: Profile Credentials Provider
+        description: Set whether the SQS client should expect to load credentials through a profile credentials provider.
+        type: boolean
+        default: false
+      useSessionCredentials:
+        title: Session Credentials
+        description: Set whether the SQS client should expect to use Session Credentials. This is useful in situation in which the user needs to assume a IAM role for doing operations in SQS.
+        type: boolean
+        default: false
+      profileCredentialsName:
+        title: Profile Credentials Name
+        description: If using a profile credentials provider this parameter will set the profile name.
+        type: string
+      sessionToken:
+        title: Session Token
+        description: Amazon AWS Session Token used when the user needs to assume a IAM role.
+        type: string
+        format: password
+        x-descriptors:
+        - urn:camel:group:credentials
       uriEndpointOverride:
         title: Overwrite Endpoint URI
         description: The overriding endpoint URI. To use this option, you must also select the `overrideEndpoint` option.
@@ -220,7 +241,11 @@ spec:
         amazonAWSHost: "{{?amazonAWSHost}}"
         protocol: "{{?protocol}}"
         useDefaultCredentialsProvider: "{{useDefaultCredentialsProvider}}"
+        useProfileCredentialsProvider: "{{useProfileCredentialsProvider}}"
+        useSessionCredentials: "{{useSessionCredentials}}"
         uriEndpointOverride: "{{?uriEndpointOverride}}"
+        profileCredentialsName: "{{?profileCredentialsName}}"
+        sessionToken: "{{?sessionToken}}"
         overrideEndpoint: "{{overrideEndpoint}}"
         delay: "{{delay}}"
         greedy: "{{greedy}}"

--- a/library/camel-kamelets/src/main/resources/kamelets/aws-sts-assume-role-action.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/aws-sts-assume-role-action.kamelet.yaml
@@ -69,8 +69,28 @@ spec:
         description: Set whether the STS client should expect to load credentials through a default credentials provider or to expect static credentials to be passed in.
         type: boolean
         default: false
+      useProfileCredentialsProvider:
+        title: Profile Credentials Provider
+        description: Set whether the STS client should expect to load credentials through a profile credentials provider.
+        type: boolean
+        default: false
+      useSessionCredentials:
+        title: Session Credentials
+        description: Set whether the STS client should expect to use Session Credentials. This is useful in situation in which the user needs to assume a IAM role for doing operations in STS.
+        type: boolean
+        default: false
+      profileCredentialsName:
+        title: Profile Credentials Name
+        description: If using a profile credentials provider this parameter will set the profile name.
+        type: string
+      sessionToken:
+        title: Session Token
+        description: Amazon AWS Session Token used when the user needs to assume a IAM role.
+        type: string
+        format: password
+        x-descriptors:
+        - urn:camel:group:credentials
   dependencies:
-    - "camel:dns"
     - "camel:kamelet"
     - "camel:core"
     - "camel:aws2-sts"
@@ -110,3 +130,7 @@ spec:
             region: "{{region}}"
             operation: "assumeRole"
             useDefaultCredentialsProvider: "{{useDefaultCredentialsProvider}}"
+            useProfileCredentialsProvider: "{{useProfileCredentialsProvider}}"
+            useSessionCredentials: "{{useSessionCredentials}}"
+            profileCredentialsName: "{{?profileCredentialsName}}"
+            sessionToken: "{{?sessionToken}}"            

--- a/library/camel-kamelets/src/main/resources/kamelets/aws-timestream-query-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/aws-timestream-query-sink.kamelet.yaml
@@ -69,6 +69,27 @@ spec:
         description: If true, the CloudWatch client loads credentials through a default credentials provider. If false, it uses the basic authentication method (access key and secret key).
         type: boolean
         default: false
+      useProfileCredentialsProvider:
+        title: Profile Credentials Provider
+        description: Set whether the Timestream client should expect to load credentials through a profile credentials provider.
+        type: boolean
+        default: false
+      useSessionCredentials:
+        title: Session Credentials
+        description: Set whether the Timestream client should expect to use Session Credentials. This is useful in situation in which the user needs to assume a IAM role for doing operations in Timestream.
+        type: boolean
+        default: false
+      profileCredentialsName:
+        title: Profile Credentials Name
+        description: If using a profile credentials provider this parameter will set the profile name.
+        type: string
+      sessionToken:
+        title: Session Token
+        description: Amazon AWS Session Token used when the user needs to assume a IAM role.
+        type: string
+        format: password
+        x-descriptors:
+        - urn:camel:group:credentials
       uriEndpointOverride:
         title: Overwrite Endpoint URI
         description: The overriding endpoint URI. To use this option, you must also select the `overrideEndpoint` option.
@@ -106,5 +127,9 @@ spec:
             region: "{{region}}"
             operation: "query"
             useDefaultCredentialsProvider: "{{useDefaultCredentialsProvider}}"
+            useProfileCredentialsProvider: "{{useProfileCredentialsProvider}}"
+            useSessionCredentials: "{{useSessionCredentials}}"  
             uriEndpointOverride: "{{?uriEndpointOverride}}"
+            profileCredentialsName: "{{?profileCredentialsName}}"
+            sessionToken: "{{?sessionToken}}"
             overrideEndpoint: "{{overrideEndpoint}}"

--- a/library/camel-kamelets/src/main/resources/kamelets/aws-translate-action.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/aws-translate-action.kamelet.yaml
@@ -79,6 +79,27 @@ spec:
         description: Set whether the Translate client should expect to load credentials through a default credentials provider or to expect static credentials to be passed in.
         type: boolean
         default: false
+      useProfileCredentialsProvider:
+        title: Profile Credentials Provider
+        description: Set whether the Translate client should expect to load credentials through a profile credentials provider.
+        type: boolean
+        default: false
+      useSessionCredentials:
+        title: Session Credentials
+        description: Set whether the Translate client should expect to use Session Credentials. This is useful in situation in which the user needs to assume a IAM role for doing operations in Translate.
+        type: boolean
+        default: false
+      profileCredentialsName:
+        title: Profile Credentials Name
+        description: If using a profile credentials provider this parameter will set the profile name.
+        type: string
+      sessionToken:
+        title: Session Token
+        description: Amazon AWS Session Token used when the user needs to assume a IAM role.
+        type: string
+        format: password
+        x-descriptors:
+        - urn:camel:group:credentials
   dependencies:
     - "camel:dns"
     - "camel:kamelet"
@@ -96,3 +117,7 @@ spec:
             sourceLanguage: "{{sourceLanguage}}"
             targetLanguage: "{{targetLanguage}}"
             useDefaultCredentialsProvider: "{{useDefaultCredentialsProvider}}"
+            useProfileCredentialsProvider: "{{useProfileCredentialsProvider}}"
+            useSessionCredentials: "{{useSessionCredentials}}"
+            profileCredentialsName: "{{?profileCredentialsName}}"
+            sessionToken: "{{?sessionToken}}"


### PR DESCRIPTION
Related to #2131 

Part 5