### PR TITLE
Github Actions Security Best practices: Pin Actions to Full lenght Co…

### DIFF
--- a/.github/workflows/automatic-changelog-update.yml
+++ b/.github/workflows/automatic-changelog-update.yml
@@ -30,7 +30,7 @@ jobs:
     name: Generate changelog for main branch
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v4
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           persist-credentials: false
           submodules: recursive


### PR DESCRIPTION
…mmit SHA - Automatic Changelog Update Action

for reference on the security best practice https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions