### PR TITLE
Github Actions Security Best practices: Pin Actions to Full lenght Co…

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -44,15 +44,18 @@ on:
       - 'NOTICE'
       - 'Jenkinsfile'
   workflow_dispatch:
+permissions:  # added using https://github.com/step-security/secure-repo
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       with:
         persist-credentials: false
     - name: Set up JDK
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@6a0805fcefea3d4657a47ac4c165951e33482018 # v4.2.2
       with:
         distribution: 'temurin'
         java-version: 17
@@ -63,7 +66,7 @@ jobs:
       shell: bash
       run: tar -czf maven-repo-${{ github.run_id }}-${{ github.run_number }}.tgz -C ~ .m2/repository
     - name: Persist Maven Repo
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a # v4.3.6
       with:
         name: maven-repo-${{ github.run_id }}-${{ github.run_number }}
         path: maven-repo-${{ github.run_id }}-${{ github.run_number }}.tgz
@@ -75,11 +78,11 @@ jobs:
       NEXUS_DEPLOY_USERNAME: ${{ secrets.NEXUS_USER }}
       NEXUS_DEPLOY_PASSWORD: ${{ secrets.NEXUS_PW }}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       with:
         persist-credentials: false
     - name: Set up JDK
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@6a0805fcefea3d4657a47ac4c165951e33482018 # v4.2.2
       with:
         distribution: 'temurin'
         java-version: 17


### PR DESCRIPTION
…mmit SHA - CI Build Action

for reference on the security best practice https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions