### PR TITLE
Github Actions Security Best practices: Pin Actions to Full lenght Co…

### DIFF
--- a/.github/workflows/generate-sbom-main.yml
+++ b/.github/workflows/generate-sbom-main.yml
@@ -35,11 +35,11 @@ jobs:
       matrix:
         java: [ '17' ]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           persist-credentials: false
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@6a0805fcefea3d4657a47ac4c165951e33482018 # v4.2.2
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
@@ -47,7 +47,7 @@ jobs:
       - name: mvn build and sbom generation
         run: mvn -V -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 --no-transfer-progress -e -Psbom -DskipTests verify
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6.1.0
         with:
           base: main
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
…mmit SHA - Generate SBOM main action

for reference on the security best practice https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions