### PR TITLE
fix #2236: Wrong artifact id in kafka-apicurio-registry-not-secured-source.kamelet.yaml dependencies

### DIFF
--- a/kamelets/kafka-apicurio-registry-not-secured-source.kamelet.yaml
+++ b/kamelets/kafka-apicurio-registry-not-secured-source.kamelet.yaml
@@ -110,7 +110,7 @@ spec:
     - "camel:kafka"
     - "camel:core"
     - "camel:kamelet"
-    - "mvn:io.quarkus:io.quarkus:quarkus-apicurio-registry-json-schema:3.15.1"
+    - "mvn:io.quarkus:quarkus-apicurio-registry-json-schema:3.15.1"
   template:
     beans:
       - name: kafkaHeaderDeserializer


### PR DESCRIPTION
see https://github.com/apache/camel-kamelets/issues/2236