### PR TITLE
chore(ci): use internal CRDs spec

### DIFF
--- a/library/camel-kamelets-catalog/pom.xml
+++ b/library/camel-kamelets-catalog/pom.xml
@@ -57,16 +57,15 @@
             <artifactId>camel-kamelets</artifactId>
             <version>${project.version}</version>
         </dependency>
-
+        <dependency>
+            <groupId>org.apache.camel.kamelets</groupId>
+            <artifactId>camel-kamelets-crds</artifactId>
+            <version>${project.version}</version>
+        </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-yaml</artifactId>
             <version>${jackson2-version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.camel.k</groupId>
-            <artifactId>camel-k-crds</artifactId>
-            <version>${camel.k.crds.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>

--- a/library/camel-kamelets-catalog/src/test/java/org/apache/camel/kamelets/catalog/KameletsCatalogTest.java
+++ b/library/camel-kamelets-catalog/src/test/java/org/apache/camel/kamelets/catalog/KameletsCatalogTest.java
@@ -154,8 +154,8 @@ public class KameletsCatalogTest {
 
     @Test
     void testSupportedHeaders() throws Exception {
-        verifyHeaders("aws-s3-source", 24);
-        verifyHeaders("aws-s3-sink", 33);
+        verifyHeaders("aws-s3-source", 25);
+        verifyHeaders("aws-s3-sink", 34);
         verifyHeaders("aws-cloudtrail-source", 4);
         verifyHeaders("aws-redshift-source", 0);
         verifyHeaders("aws-not-exists", 0);
@@ -278,7 +278,7 @@ public class KameletsCatalogTest {
 
     void verifyHeaders(String name, int expected) {
         List<ComponentModel.EndpointHeaderModel> headers = catalog.getKameletSupportedHeaders(name);
-        assertEquals(expected, headers.size());
+        assertEquals(expected, headers.size(), "Failure checking " + name);
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,6 @@
         <cyclonedx-maven-plugin-version>2.9.0</cyclonedx-maven-plugin-version>
 
         <camel.version>4.9.0-SNAPSHOT</camel.version>
-        <camel.k.crds.version>2.4.0</camel.k.crds.version>
 
         <citrus.version>4.3.2</citrus.version>
         <cucumber.version>7.18.1</cucumber.version>


### PR DESCRIPTION
With this we move the dependency from Camel K CRDs to internal one.