### PR TITLE
SQL Kamelets: Disable autowiring by default - MariaDB

### DIFF
--- a/kamelets/mariadb-sink.kamelet.yaml
+++ b/kamelets/mariadb-sink.kamelet.yaml
@@ -94,6 +94,10 @@ spec:
   - "mvn:org.apache.commons:commons-dbcp2:2.12.0"
   template:
     beans:
+      - name: local-sql-mariadb-sink
+        type: "#class:org.apache.camel.component.sql.SqlComponent"
+        properties:
+          autowiredEnabled: "false"
       - name: dsBean
         type: "#class:org.apache.commons.dbcp2.BasicDataSource"
         properties:
@@ -108,6 +112,6 @@ spec:
           json: 
             library: Jackson
       - to: 
-          uri: "sql:{{query}}"
+          uri: "{{local-sql-mariadb-sink}}:{{query}}"
           parameters:
             dataSource: "#bean:{{dsBean}}"

--- a/kamelets/mariadb-source.kamelet.yaml
+++ b/kamelets/mariadb-source.kamelet.yaml
@@ -96,6 +96,10 @@ spec:
   - "mvn:org.apache.commons:commons-dbcp2:2.12.0"
   template:
     beans:
+      - name: local-sql-mariadb-source
+        type: "#class:org.apache.camel.component.sql.SqlComponent"
+        properties:
+          autowiredEnabled: "false"
       - name: dsBean
         type: "#class:org.apache.commons.dbcp2.BasicDataSource"
         properties:
@@ -104,7 +108,7 @@ spec:
           url: 'jdbc:mariadb://{{serverName}}:{{serverPort}}/{{databaseName}}'
           driverClassName: 'org.mariadb.jdbc.Driver'
     from:
-      uri: "sql:{{query}}"
+      uri: "{{local-sql-mariadb-source}}:{{query}}"
       parameters:
         dataSource: "#bean:{{dsBean}}"
         onConsume: "{{?consumedQuery}}"

--- a/library/camel-kamelets/src/main/resources/kamelets/mariadb-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/mariadb-sink.kamelet.yaml
@@ -94,6 +94,10 @@ spec:
   - "mvn:org.apache.commons:commons-dbcp2:2.12.0"
   template:
     beans:
+      - name: local-sql-mariadb-sink
+        type: "#class:org.apache.camel.component.sql.SqlComponent"
+        properties:
+          autowiredEnabled: "false"
       - name: dsBean
         type: "#class:org.apache.commons.dbcp2.BasicDataSource"
         properties:
@@ -108,6 +112,6 @@ spec:
           json: 
             library: Jackson
       - to: 
-          uri: "sql:{{query}}"
+          uri: "{{local-sql-mariadb-sink}}:{{query}}"
           parameters:
             dataSource: "#bean:{{dsBean}}"

--- a/library/camel-kamelets/src/main/resources/kamelets/mariadb-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/mariadb-source.kamelet.yaml
@@ -96,6 +96,10 @@ spec:
   - "mvn:org.apache.commons:commons-dbcp2:2.12.0"
   template:
     beans:
+      - name: local-sql-mariadb-source
+        type: "#class:org.apache.camel.component.sql.SqlComponent"
+        properties:
+          autowiredEnabled: "false"
       - name: dsBean
         type: "#class:org.apache.commons.dbcp2.BasicDataSource"
         properties:
@@ -104,7 +108,7 @@ spec:
           url: 'jdbc:mariadb://{{serverName}}:{{serverPort}}/{{databaseName}}'
           driverClassName: 'org.mariadb.jdbc.Driver'
     from:
-      uri: "sql:{{query}}"
+      uri: "{{local-sql-mariadb-source}}:{{query}}"
       parameters:
         dataSource: "#bean:{{dsBean}}"
         onConsume: "{{?consumedQuery}}"


### PR DESCRIPTION
Related to #2278 for MariaDB in 4.8.x