### PR TITLE
SQL Kamelets: Disable autowiring by default - AWS Redshift

### DIFF
--- a/kamelets/aws-redshift-sink.kamelet.yaml
+++ b/kamelets/aws-redshift-sink.kamelet.yaml
@@ -91,6 +91,10 @@ spec:
   - "mvn:org.apache.commons:commons-dbcp2:2.12.0"
   template:
     beans:
+      - name: local-sql-redshift-sink
+        type: "#class:org.apache.camel.component.sql.SqlComponent"
+        properties:
+          autowiredEnabled: "false"
       - name: dsBean
         type: "#class:org.apache.commons.dbcp2.BasicDataSource"
         properties:
@@ -105,6 +109,6 @@ spec:
           json: 
             library: Jackson
       - to: 
-          uri: "sql:{{query}}"
+          uri: "{{local-sql-redshift-sink}}:{{query}}"
           parameters:
             dataSource: "#bean:{{dsBean}}"

--- a/kamelets/aws-redshift-source.kamelet.yaml
+++ b/kamelets/aws-redshift-source.kamelet.yaml
@@ -93,6 +93,10 @@ spec:
   - "mvn:org.apache.commons:commons-dbcp2:2.12.0"
   template:
     beans:
+      - name: local-sql-redshift-source
+        type: "#class:org.apache.camel.component.sql.SqlComponent"
+        properties:
+          autowiredEnabled: "false"
       - name: dsBean
         type: "#class:org.apache.commons.dbcp2.BasicDataSource"
         properties:
@@ -101,7 +105,7 @@ spec:
           url: 'jdbc:redshift://{{serverName}}:{{serverPort}}/{{databaseName}}'
           driverClassName: 'com.amazon.redshift.jdbc.Driver'
     from:
-      uri: "sql:{{query}}"
+      uri: "{{local-sql-redshift-source}}:{{query}}"
       parameters:
         dataSource: "#bean:{{dsBean}}"
         onConsume: "{{?consumedQuery}}"

--- a/library/camel-kamelets/src/main/resources/kamelets/aws-redshift-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/aws-redshift-sink.kamelet.yaml
@@ -91,6 +91,10 @@ spec:
   - "mvn:org.apache.commons:commons-dbcp2:2.12.0"
   template:
     beans:
+      - name: local-sql-redshift-sink
+        type: "#class:org.apache.camel.component.sql.SqlComponent"
+        properties:
+          autowiredEnabled: "false"
       - name: dsBean
         type: "#class:org.apache.commons.dbcp2.BasicDataSource"
         properties:
@@ -105,6 +109,6 @@ spec:
           json: 
             library: Jackson
       - to: 
-          uri: "sql:{{query}}"
+          uri: "{{local-sql-redshift-sink}}:{{query}}"
           parameters:
             dataSource: "#bean:{{dsBean}}"

--- a/library/camel-kamelets/src/main/resources/kamelets/aws-redshift-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/aws-redshift-source.kamelet.yaml
@@ -93,6 +93,10 @@ spec:
   - "mvn:org.apache.commons:commons-dbcp2:2.12.0"
   template:
     beans:
+      - name: local-sql-redshift-source
+        type: "#class:org.apache.camel.component.sql.SqlComponent"
+        properties:
+          autowiredEnabled: "false"
       - name: dsBean
         type: "#class:org.apache.commons.dbcp2.BasicDataSource"
         properties:
@@ -101,7 +105,7 @@ spec:
           url: 'jdbc:redshift://{{serverName}}:{{serverPort}}/{{databaseName}}'
           driverClassName: 'com.amazon.redshift.jdbc.Driver'
     from:
-      uri: "sql:{{query}}"
+      uri: "{{local-sql-redshift-source}}:{{query}}"
       parameters:
         dataSource: "#bean:{{dsBean}}"
         onConsume: "{{?consumedQuery}}"


### PR DESCRIPTION
Related to #2278 for Redshift on 4.8.x