### PR TITLE
chore: Integration test improvements

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -62,7 +62,8 @@ jobs:
         ./mvnw clean install -DskipTests -DskipITs
     - name: Run Tests
       env:
-        CITRUS_TESTCONTAINERS_LOCALSTACK_IMAGE_NAME: "mirror.gcr.io/localstack/localstack"
+        CITRUS_TESTCONTAINERS_REGISTRY_MIRROR: "mirror.gcr.io"
+        CITRUS_TESTCONTAINERS_REGISTRY_MIRROR_ENABLED: "true"
       run: |
         echo "Install JBang via SDKMAN"
 

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
 
         <camel.version>4.9.0</camel.version>
 
-        <citrus.version>4.5.0</citrus.version>
+        <citrus.version>4.5.1</citrus.version>
         <cucumber.version>7.20.1</cucumber.version>
 
         <!-- Versions used inside Kamelets (add them also to the dependencyManagement section and the groovy script below) -->

--- a/tests/camel-kamelets-itest/src/test/resources/aws/kinesis/amazonKinesisClient.groovy
+++ b/tests/camel-kamelets-itest/src/test/resources/aws/kinesis/amazonKinesisClient.groovy
@@ -15,17 +15,10 @@
  * limitations under the License.
  */
 
-
-import org.apache.camel.CamelContext
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider
 import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.kinesis.KinesisClient
-
-if (context.getReferenceResolver().isResolvable(CamelContext.class)) {
-    println "Destroying former KINESIS client instance"
-    context.getReferenceResolver().resolve(CamelContext.class).getRegistry().unbind("amazonKinesisClient")
-}
 
 KinesisClient kinesisClient = KinesisClient
         .builder()

--- a/tests/camel-kamelets-itest/src/test/resources/aws/s3/amazonS3Client.groovy
+++ b/tests/camel-kamelets-itest/src/test/resources/aws/s3/amazonS3Client.groovy
@@ -15,18 +15,10 @@
  * limitations under the License.
  */
 
-
-
-import org.apache.camel.CamelContext
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider
 import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.s3.S3Client
-
-if (context.getReferenceResolver().isResolvable(CamelContext.class)) {
-    println "Destroying former S3 client instance"
-    context.getReferenceResolver().resolve(CamelContext.class).getRegistry().unbind("amazonS3Client")
-}
 
 S3Client s3 = S3Client
         .builder()

--- a/tests/camel-kamelets-itest/src/test/resources/aws/s3/aws-s3-to-http.it.yaml
+++ b/tests/camel-kamelets-itest/src/test/resources/aws/s3/aws-s3-to-http.it.yaml
@@ -34,11 +34,6 @@ actions:
       http:
         url: "${CITRUS_TESTCONTAINERS_LOCALSTACK_SERVICE_URL}"
 
-  # Purge Http service
-  - purge:
-      endpoints:
-        - name: "httpServer"
-
   # Create AWS-S3 client
   - camel:
       createComponent:

--- a/tests/camel-kamelets-itest/src/test/resources/aws/sqs/amazonSQSClient.groovy
+++ b/tests/camel-kamelets-itest/src/test/resources/aws/sqs/amazonSQSClient.groovy
@@ -15,17 +15,10 @@
  * limitations under the License.
  */
 
-
-import org.apache.camel.CamelContext
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider
 import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.sqs.SqsClient
-
-if (context.getReferenceResolver().isResolvable(CamelContext.class)) {
-        println "Destroying former SQS client instance"
-        context.getReferenceResolver().resolve(CamelContext.class).getRegistry().unbind("amazonSQSClient")
-}
 
 SqsClient sqsClient = SqsClient
         .builder()

--- a/tests/camel-kamelets-itest/src/test/resources/citrus-application.properties
+++ b/tests/camel-kamelets-itest/src/test/resources/citrus-application.properties
@@ -1,3 +1,4 @@
+# Configure endpoints used in tests (e.g. generic Http server)
 citrus.java.config=EndpointAutoConfiguration
 
 citrus.file.encoding=UTF-8
@@ -7,11 +8,22 @@ citrus.type.converter=camel
 citrus.mail.marshaller.type=JSON
 
 citrus.cluster.type=local
-citrus.camelk.max.attempts=10
 citrus.camel.jbang.max.attempts=10
 
+# Camel JBang version (should align with version used in pom.xml)
 citrus.camel.jbang.version=4.9.0
+# Kamelets version (should point to the next snapshot release version)
 citrus.camel.jbang.kamelets.version=4.10.0-SNAPSHOT
 
+# Tests should use local Kamelets
 citrus.camel.jbang.kamelets.local.dir=../../../kamelets
+
+# Enable dump of Camel JBang integration output
 citrus.camel.jbang.dump.integration.output=true
+
+# Workaround to stop all Camel JBang integrations after test - remove when Citrus 4.5.2 is released
+citrus.camel.jbang.auto.remove.resources=false
+
+# Use general registry mirror for Docker images (e.g. Testcontainers)
+citrus.testcontainers.registry.mirror=mirror.gcr.io
+citrus.testcontainers.registry.mirror.enabled=true

--- a/tests/camel-kamelets-itest/src/test/resources/earthquake/earthquake-to-http.it.yaml
+++ b/tests/camel-kamelets-itest/src/test/resources/earthquake/earthquake-to-http.it.yaml
@@ -17,11 +17,6 @@
 
 name: earthquake-to-http-test
 actions:
-  # Purge Http service
-  - purge:
-      endpoints:
-        - name: "httpServer"
-
   # Create Camel JBang integration
   - camel:
       jbang:

--- a/tests/camel-kamelets-itest/src/test/resources/jira/jira-add-comment-sink-pipe.it.yaml
+++ b/tests/camel-kamelets-itest/src/test/resources/jira/jira-add-comment-sink-pipe.it.yaml
@@ -46,11 +46,6 @@ variables:
   - name: "jira.password"
     value: "secr3t"
 actions:
-  # Purge Http service
-  - purge:
-      endpoints:
-        - name: "httpServer"
-
   # Create Camel JBang integration
   - camel:
       jbang:

--- a/tests/camel-kamelets-itest/src/test/resources/jira/jira-add-issue-sink-pipe.it.yaml
+++ b/tests/camel-kamelets-itest/src/test/resources/jira/jira-add-issue-sink-pipe.it.yaml
@@ -42,11 +42,6 @@ variables:
   - name: "jira.password"
     value: "secr3t"
 actions:
-  # Purge Http service
-  - purge:
-      endpoints:
-        - name: "httpServer"
-
   # Create Camel JBang integration
   - camel:
       jbang:

--- a/tests/camel-kamelets-itest/src/test/resources/jira/jira-source-pipe.it.yaml
+++ b/tests/camel-kamelets-itest/src/test/resources/jira/jira-source-pipe.it.yaml
@@ -34,11 +34,6 @@ variables:
   - name: "jira.jql"
     value: "assignee=citrus"
 actions:
-  # Purge Http service
-  - purge:
-      endpoints:
-        - name: "httpServer"
-
   # Create Camel JBang integration
   - camel:
       jbang:

--- a/tests/camel-kamelets-itest/src/test/resources/kafka/kafka-router-pipe.it.yaml
+++ b/tests/camel-kamelets-itest/src/test/resources/kafka/kafka-router-pipe.it.yaml
@@ -39,11 +39,6 @@ actions:
       start:
         redpanda: {}
 
-  # Purge Http service
-  - purge:
-      endpoints:
-        - name: "httpServer"
-
   # Create Camel JBang integration
   - camel:
       jbang:

--- a/tests/camel-kamelets-itest/src/test/resources/kafka/kafka-sink-pipe.it.yaml
+++ b/tests/camel-kamelets-itest/src/test/resources/kafka/kafka-sink-pipe.it.yaml
@@ -37,11 +37,6 @@ actions:
       start:
         redpanda: {}
 
-  # Purge Http service
-  - purge:
-      endpoints:
-        - name: "httpServer"
-
   # Create Camel JBang integration
   - camel:
       jbang:

--- a/tests/camel-kamelets-itest/src/test/resources/kafka/kafka-source-pipe.it.yaml
+++ b/tests/camel-kamelets-itest/src/test/resources/kafka/kafka-source-pipe.it.yaml
@@ -39,11 +39,6 @@ actions:
       start:
         redpanda: {}
 
-  # Purge Http service
-  - purge:
-      endpoints:
-        - name: "httpServer"
-
   # Create Camel JBang integration
   - camel:
       jbang:

--- a/tests/camel-kamelets-itest/src/test/resources/openapi/rest-openapi-sink-add-pet.it.yaml
+++ b/tests/camel-kamelets-itest/src/test/resources/openapi/rest-openapi-sink-add-pet.it.yaml
@@ -26,11 +26,6 @@ variables:
   - name: "openApiSpec"
     value: "citrus:readFile(openapi/openapi.json)"
 actions:
-  # Purge Http service
-  - purge:
-      endpoints:
-        - name: "httpServer"
-
   # Create Camel JBang integration
   - camel:
       jbang:

--- a/tests/camel-kamelets-itest/src/test/resources/openapi/rest-openapi-sink-delete-pet.it.yaml
+++ b/tests/camel-kamelets-itest/src/test/resources/openapi/rest-openapi-sink-delete-pet.it.yaml
@@ -26,11 +26,6 @@ variables:
   - name: "openApiSpec"
     value: "citrus:readFile(openapi/openapi.json)"
 actions:
-  # Purge Http service
-  - purge:
-      endpoints:
-        - name: "httpServer"
-
   # Create Camel JBang integration
   - camel:
       jbang:

--- a/tests/camel-kamelets-itest/src/test/resources/slack/slack-sink-pipe.it.yaml
+++ b/tests/camel-kamelets-itest/src/test/resources/slack/slack-sink-pipe.it.yaml
@@ -32,11 +32,6 @@ variables:
   - name: "timer.source.period"
     value: "10000"
 actions:
-  # Purge Http service
-  - purge:
-      endpoints:
-        - name: "httpServer"
-
   # Create Camel JBang integration
   - camel:
       jbang:

--- a/tests/camel-kamelets-itest/src/test/resources/slack/slack-source-pipe.it.yaml
+++ b/tests/camel-kamelets-itest/src/test/resources/slack/slack-source-pipe.it.yaml
@@ -30,11 +30,6 @@ variables:
   - name: "slack.message"
     value: "Camel rocks!"
 actions:
-  # Purge Http service
-  - purge:
-      endpoints:
-        - name: "httpServer"
-
   # Create Camel JBang integration
   - camel:
       jbang:

--- a/tests/camel-kamelets-itest/src/test/resources/timer/timer-to-http-pipe.it.yaml
+++ b/tests/camel-kamelets-itest/src/test/resources/timer/timer-to-http-pipe.it.yaml
@@ -22,11 +22,6 @@ variables:
   - name: "timer.message"
     value: "Camel rocks!"
 actions:
-  # Purge Http service
-  - purge:
-      endpoints:
-        - name: "httpServer"
-
   # Create Camel JBang integration
   - camel:
       jbang:

--- a/tests/camel-kamelets-itest/src/test/resources/timer/timer-to-http.it.yaml
+++ b/tests/camel-kamelets-itest/src/test/resources/timer/timer-to-http.it.yaml
@@ -22,11 +22,6 @@ variables:
   - name: "timer.message"
     value: "Camel rocks!"
 actions:
-  # Purge Http service
-  - purge:
-      endpoints:
-        - name: "httpServer"
-
   # Create Camel JBang integration
   - camel:
       jbang:

--- a/tests/camel-kamelets-itest/src/test/resources/transformation/data-type-action-pipe.it.yaml
+++ b/tests/camel-kamelets-itest/src/test/resources/transformation/data-type-action-pipe.it.yaml
@@ -22,11 +22,6 @@ variables:
   - name: "uuid"
     value: "citrus:randomUUID()"
 actions:
-  # Purge Http service
-  - purge:
-      endpoints:
-        - name: "httpServer"
-
   # Create Camel JBang integration
   - camel:
       jbang:

--- a/tests/camel-kamelets-itest/src/test/resources/transformation/extract-field-action-pipe.it.yaml
+++ b/tests/camel-kamelets-itest/src/test/resources/transformation/extract-field-action-pipe.it.yaml
@@ -24,11 +24,6 @@ variables:
   - name: "field.value"
     value: "Camel rocks!"
 actions:
-  # Purge Http service
-  - purge:
-      endpoints:
-        - name: "httpServer"
-
   # Create Camel JBang integration
   - camel:
       jbang:

--- a/tests/camel-kamelets-itest/src/test/resources/transformation/insert-field-action-pipe.it.yaml
+++ b/tests/camel-kamelets-itest/src/test/resources/transformation/insert-field-action-pipe.it.yaml
@@ -26,11 +26,6 @@ variables:
   - name: "field.name"
     value: "subject"
 actions:
-  # Purge Http service
-  - purge:
-      endpoints:
-        - name: "httpServer"
-
   # Create Camel JBang integration
   - camel:
       jbang:


### PR DESCRIPTION
- Update to Citrus 4.5.1
- Automatically purge Http server endpoint after each test
- Remove obsolete workaround to create dump output folders in before suite
- Use general Docker registry mirror