### PR TITLE
chore: Improve integration tests

### DIFF
--- a/tests/camel-kamelets-itest/src/test/java/EndpointAutoConfiguration.java
+++ b/tests/camel-kamelets-itest/src/test/java/EndpointAutoConfiguration.java
@@ -17,21 +17,52 @@
 
 import org.citrusframework.annotations.CitrusConfiguration;
 import org.citrusframework.container.SequenceAfterTest;
+import org.citrusframework.container.SequenceBeforeTest;
 import org.citrusframework.http.server.HttpServer;
 import org.citrusframework.spi.BindToRegistry;
+import org.citrusframework.util.SocketUtils;
 import org.springframework.http.HttpStatus;
 
+import static org.citrusframework.actions.CreateVariablesAction.Builder.createVariables;
 import static org.citrusframework.actions.PurgeEndpointAction.Builder.purgeEndpoints;
 import static org.citrusframework.http.endpoint.builder.HttpEndpoints.http;
 
 @CitrusConfiguration
 public class EndpointAutoConfiguration {
 
+    private static final long SERVER_TIMEOUT = 60000L;
+
+    private static final int HTTP_SERVER_PORT = SocketUtils.findAvailableTcpPort(8801);
+    private static final int SLACK_SERVER_PORT = SocketUtils.findAvailableTcpPort(8802);
+    private static final int PETSTORE_SERVER_PORT = SocketUtils.findAvailableTcpPort(8803);
+    private static final int JIRA_SERVER_PORT = SocketUtils.findAvailableTcpPort(8804);
+
     private final HttpServer httpServer = http()
             .server()
-            .port(8081)
+            .port(HTTP_SERVER_PORT)
+            .timeout(SERVER_TIMEOUT)
+            .autoStart(true)
+            .build();
+
+    private final HttpServer slackServer = http()
+            .server()
+            .port(SLACK_SERVER_PORT)
+            .timeout(SERVER_TIMEOUT)
+            .autoStart(true)
+            .build();
+
+    private final HttpServer petstoreServer = http()
+            .server()
+            .port(PETSTORE_SERVER_PORT)
+            .timeout(SERVER_TIMEOUT)
             .defaultStatus(HttpStatus.CREATED)
-            .timeout(60000L)
+            .autoStart(true)
+            .build();
+
+    private final HttpServer jiraServer = http()
+            .server()
+            .port(JIRA_SERVER_PORT)
+            .timeout(SERVER_TIMEOUT)
             .autoStart(true)
             .build();
 
@@ -41,11 +72,44 @@ public class EndpointAutoConfiguration {
     }
 
     @BindToRegistry
+    public HttpServer slackServer() {
+        return slackServer;
+    }
+
+    @BindToRegistry
+    public HttpServer petstoreServer() {
+        return petstoreServer;
+    }
+
+    @BindToRegistry
+    public HttpServer jiraServer() {
+        return jiraServer;
+    }
+
+    @BindToRegistry
+    public SequenceBeforeTest beforeTest() {
+        return SequenceBeforeTest.Builder.beforeTest()
+                .actions(
+                    // Set server ports as test variables
+                    createVariables()
+                            .variable("http.server.port", String.valueOf(HTTP_SERVER_PORT))
+                            .variable("slack.server.port", String.valueOf(SLACK_SERVER_PORT))
+                            .variable("petstore.server.port", String.valueOf(PETSTORE_SERVER_PORT))
+                            .variable("jira.server.port", String.valueOf(JIRA_SERVER_PORT))
+                )
+                .build();
+    }
+
+    @BindToRegistry
     public SequenceAfterTest afterTest() {
         return SequenceAfterTest.Builder.afterTest()
                 .actions(
                     // Auto purge Http server endpoint
-                    purgeEndpoints().endpoint(httpServer)
+                    purgeEndpoints()
+                            .endpoint(httpServer)
+                            .endpoint(slackServer)
+                            .endpoint(petstoreServer)
+                            .endpoint(jiraServer)
                 )
                 .build();
     }

--- a/tests/camel-kamelets-itest/src/test/java/EndpointAutoConfiguration.java
+++ b/tests/camel-kamelets-itest/src/test/java/EndpointAutoConfiguration.java
@@ -23,7 +23,6 @@ import org.springframework.http.HttpStatus;
 
 import static org.citrusframework.actions.PurgeEndpointAction.Builder.purgeEndpoints;
 import static org.citrusframework.http.endpoint.builder.HttpEndpoints.http;
-import static org.citrusframework.jbang.actions.JBangAction.Builder.jbang;
 
 @CitrusConfiguration
 public class EndpointAutoConfiguration {
@@ -45,8 +44,6 @@ public class EndpointAutoConfiguration {
     public SequenceAfterTest afterTest() {
         return SequenceAfterTest.Builder.afterTest()
                 .actions(
-                    // Workaround to stop all Camel JBang integrations after test - remove when Citrus 4.5.2 is released
-                    jbang().app("camel@apache/camel").command("stop"),
                     // Auto purge Http server endpoint
                     purgeEndpoints().endpoint(httpServer)
                 )

--- a/tests/camel-kamelets-itest/src/test/resources/aws/s3/aws-s3-to-http.it.yaml
+++ b/tests/camel-kamelets-itest/src/test/resources/aws/s3/aws-s3-to-http.it.yaml
@@ -48,6 +48,9 @@ actions:
             file: "aws/s3/aws-s3-to-http.yaml"
             systemProperties:
               file: "aws/s3/application.properties"
+              properties:
+                - name: http.sink.url
+                  value: "http://localhost:${http.server.port}/incoming"
 
   # Publish event
   - send:

--- a/tests/camel-kamelets-itest/src/test/resources/aws/s3/aws-s3-to-http.yaml
+++ b/tests/camel-kamelets-itest/src/test/resources/aws/s3/aws-s3-to-http.yaml
@@ -76,4 +76,4 @@ spec:
       apiVersion: camel.apache.org/v1
       name: http-sink
     properties:
-      url: http://localhost:8081/incoming
+      url: "{{http.sink.url}}"

--- a/tests/camel-kamelets-itest/src/test/resources/citrus-application.properties
+++ b/tests/camel-kamelets-itest/src/test/resources/citrus-application.properties
@@ -21,9 +21,6 @@ citrus.camel.jbang.kamelets.local.dir=../../../kamelets
 # Enable dump of Camel JBang integration output
 citrus.camel.jbang.dump.integration.output=true
 
-# Workaround to stop all Camel JBang integrations after test - remove when Citrus 4.5.2 is released
-citrus.camel.jbang.auto.remove.resources=false
-
 # Use general registry mirror for Docker images (e.g. Testcontainers)
 citrus.testcontainers.registry.mirror=mirror.gcr.io
 citrus.testcontainers.registry.mirror.enabled=true

--- a/tests/camel-kamelets-itest/src/test/resources/earthquake/earthquake-to-http.it.yaml
+++ b/tests/camel-kamelets-itest/src/test/resources/earthquake/earthquake-to-http.it.yaml
@@ -23,6 +23,10 @@ actions:
         run:
           integration:
             file: "earthquake/earthquake-to-http.yaml"
+            systemProperties:
+              properties:
+                - name: http.sink.url
+                  value: "http://localhost:${http.server.port}/test"
 
   # Verify Http request
   - http:

--- a/tests/camel-kamelets-itest/src/test/resources/earthquake/earthquake-to-http.yaml
+++ b/tests/camel-kamelets-itest/src/test/resources/earthquake/earthquake-to-http.yaml
@@ -26,4 +26,4 @@ spec:
       apiVersion: camel.apache.org/v1
       name: earthquake-source
   sink:
-    uri: http://localhost:8081/test
+    uri: "{{http.sink.url}}"

--- a/tests/camel-kamelets-itest/src/test/resources/jira/jira-add-comment-sink-pipe.it.yaml
+++ b/tests/camel-kamelets-itest/src/test/resources/jira/jira-add-comment-sink-pipe.it.yaml
@@ -19,8 +19,6 @@ name: jira-add-comment-sink-pipe-test
 variables:
   - name: "timer.source.period"
     value: "10000"
-  - name: "jira.url"
-    value: "http://localhost:8081"
   - name: "jira.project.key"
     value: "CAMEL"
   - name: "jira.issue.assignee"
@@ -46,6 +44,10 @@ variables:
   - name: "jira.password"
     value: "secr3t"
 actions:
+  - createVariables:
+      variables:
+        - name: "jira.url"
+          value: "http://localhost:${jira.server.port}"
   # Create Camel JBang integration
   - camel:
       jbang:
@@ -70,7 +72,7 @@ actions:
 
   # Verify get issue request
   - http:
-      server: "httpServer"
+      server: "jiraServer"
       receiveRequest:
         GET:
           path: "/rest/api/latest/issue/${jira.issue.key}"
@@ -79,7 +81,7 @@ actions:
               value: "Basic citrus:encodeBase64(${jira.username}:${jira.password})"
 
   - http:
-      server: "httpServer"
+      server: "jiraServer"
       sendResponse:
         response:
           status: 200
@@ -126,7 +128,7 @@ actions:
 
   # Verify server info request
   - http:
-      server: "httpServer"
+      server: "jiraServer"
       receiveRequest:
         GET:
           path: "/rest/api/latest/serverInfo"
@@ -135,7 +137,7 @@ actions:
               value: "Basic citrus:encodeBase64(${jira.username}:${jira.password})"
 
   - http:
-      server: "httpServer"
+      server: "jiraServer"
       sendResponse:
         response:
           status: 200
@@ -162,7 +164,7 @@ actions:
 
   # Verify add comment request
   - http:
-      server: "httpServer"
+      server: "jiraServer"
       receiveRequest:
         POST:
           path: "/rest/api/latest/issue/${jira.issue.key}/comment"
@@ -176,7 +178,7 @@ actions:
               }
 
   - http:
-      server: "httpServer"
+      server: "jiraServer"
       sendResponse:
         response:
           status: 200

--- a/tests/camel-kamelets-itest/src/test/resources/jira/jira-add-issue-sink-pipe.it.yaml
+++ b/tests/camel-kamelets-itest/src/test/resources/jira/jira-add-issue-sink-pipe.it.yaml
@@ -19,8 +19,6 @@ name: jira-add-issue-sink-pipe-test
 variables:
   - name: "timer.source.period"
     value: "10000"
-  - name: "jira.url"
-    value: "http://localhost:8081"
   - name: "jira.project.key"
     value: "CAMEL"
   - name: "jira.issue.assignee"
@@ -42,6 +40,10 @@ variables:
   - name: "jira.password"
     value: "secr3t"
 actions:
+  - createVariables:
+      variables:
+        - name: "jira.url"
+          value: "http://localhost:${jira.server.port}"
   # Create Camel JBang integration
   - camel:
       jbang:
@@ -74,7 +76,7 @@ actions:
 
   # Verify issue type request
   - http:
-      server: "httpServer"
+      server: "jiraServer"
       receiveRequest:
         GET:
           path: "/rest/api/latest/issuetype"
@@ -83,7 +85,7 @@ actions:
               value: "Basic citrus:encodeBase64(${jira.username}:${jira.password})"
 
   - http:
-      server: "httpServer"
+      server: "jiraServer"
       sendResponse:
         response:
           status: 200
@@ -115,7 +117,7 @@ actions:
 
   # Verify add issue request
   - http:
-      server: "httpServer"
+      server: "jiraServer"
       receiveRequest:
         POST:
           path: "/rest/api/latest/issue"
@@ -142,7 +144,7 @@ actions:
               }
 
   - http:
-      server: "httpServer"
+      server: "jiraServer"
       sendResponse:
         response:
           status: 200

--- a/tests/camel-kamelets-itest/src/test/resources/jira/jira-source-pipe.it.yaml
+++ b/tests/camel-kamelets-itest/src/test/resources/jira/jira-source-pipe.it.yaml
@@ -17,8 +17,6 @@
 
 name: jira-source-pipe-test
 variables:
-  - name: "jira.url"
-    value: "http://localhost:8081"
   - name: "jira.project.id"
     value: "10001"
   - name: "jira.issue.id"
@@ -34,6 +32,10 @@ variables:
   - name: "jira.jql"
     value: "assignee=citrus"
 actions:
+  - createVariables:
+      variables:
+        - name: "jira.url"
+          value: "http://localhost:${jira.server.port}"
   # Create Camel JBang integration
   - camel:
       jbang:
@@ -54,7 +56,7 @@ actions:
 
   # Verify latest issue request
   - http:
-      server: "httpServer"
+      server: "jiraServer"
       receiveRequest:
         GET:
           path: "/rest/api/latest/search"
@@ -68,7 +70,7 @@ actions:
               value: "Basic citrus:encodeBase64(${jira.username}:${jira.password})"
 
   - http:
-      server: "httpServer"
+      server: "jiraServer"
       sendResponse:
         response:
           status: 200
@@ -95,7 +97,7 @@ actions:
 
   # Verify search request
   - http:
-      server: "httpServer"
+      server: "jiraServer"
       receiveRequest:
         GET:
           path: "/rest/api/latest/search"
@@ -111,7 +113,7 @@ actions:
               value: "Basic citrus:encodeBase64(${jira.username}:${jira.password})"
 
   - http:
-      server: "httpServer"
+      server: "jiraServer"
       sendResponse:
         response:
           status: 200

--- a/tests/camel-kamelets-itest/src/test/resources/kafka/kafka-source-pipe.it.yaml
+++ b/tests/camel-kamelets-itest/src/test/resources/kafka/kafka-source-pipe.it.yaml
@@ -47,6 +47,9 @@ actions:
             file: "kafka/kafka-source-pipe.yaml"
             systemProperties:
               file: "kafka/application.properties"
+              properties:
+                - name: http.sink.url
+                  value: "http://localhost:${http.server.port}/result"
 
   # Verify topic subscription
   - camel:

--- a/tests/camel-kamelets-itest/src/test/resources/kafka/kafka-source-pipe.yaml
+++ b/tests/camel-kamelets-itest/src/test/resources/kafka/kafka-source-pipe.yaml
@@ -33,5 +33,5 @@ spec:
       securityProtocol: '{{kafka.securityProtocol}}'
       deserializeHeaders: '{{kafka.deserializeHeaders}}'
   sink:
-    uri: http://localhost:8081/result
+    uri: "{{http.sink.url}}"
 

--- a/tests/camel-kamelets-itest/src/test/resources/openapi/rest-openapi-sink-add-pet.it.yaml
+++ b/tests/camel-kamelets-itest/src/test/resources/openapi/rest-openapi-sink-add-pet.it.yaml
@@ -35,6 +35,8 @@ actions:
             file: "openapi/rest-openapi-sink-pipe.yaml"
             systemProperties:
               properties:
+                - name: "petstore.server.url"
+                  value: "http://localhost:${petstore.server.port}"
                 - name: "petId"
                   value: "${petId}"
                 - name: "pet"
@@ -45,13 +47,13 @@ actions:
 
   # Verify OpenAPI spec request
   - http:
-      server: "httpServer"
+      server: "petstoreServer"
       receiveRequest:
         GET:
           path: "/petstore/openapi.json"
 
   - http:
-      server: "httpServer"
+      server: "petstoreServer"
       sendResponse:
         response:
           status: 200
@@ -63,7 +65,7 @@ actions:
 
   # Verify add pet request
   - http:
-      server: "httpServer"
+      server: "petstoreServer"
       receiveRequest:
         POST:
           path: "/petstore/pet"
@@ -71,7 +73,7 @@ actions:
             data: "${pet}"
 
   - http:
-      server: "httpServer"
+      server: "petstoreServer"
       sendResponse:
         response:
           status: 201

--- a/tests/camel-kamelets-itest/src/test/resources/openapi/rest-openapi-sink-delete-pet.it.yaml
+++ b/tests/camel-kamelets-itest/src/test/resources/openapi/rest-openapi-sink-delete-pet.it.yaml
@@ -35,6 +35,8 @@ actions:
             file: "openapi/rest-openapi-sink-pipe.yaml"
             systemProperties:
               properties:
+                - name: "petstore.server.url"
+                  value: "http://localhost:${petstore.server.port}"
                 - name: "petId"
                   value: "${petId}"
                 - name: "pet"
@@ -44,13 +46,13 @@ actions:
 
   # Verify OpenAPI spec request
   - http:
-      server: "httpServer"
+      server: "petstoreServer"
       receiveRequest:
         GET:
           path: "/petstore/openapi.json"
 
   - http:
-      server: "httpServer"
+      server: "petstoreServer"
       sendResponse:
         response:
           status: 200
@@ -62,13 +64,13 @@ actions:
 
   # Verify add pet request
   - http:
-      server: "httpServer"
+      server: "petstoreServer"
       receiveRequest:
         DELETE:
           path: "/petstore/pet/${petId}"
 
   - http:
-      server: "httpServer"
+      server: "petstoreServer"
       sendResponse:
         response:
           status: 204

--- a/tests/camel-kamelets-itest/src/test/resources/openapi/rest-openapi-sink-pipe.yaml
+++ b/tests/camel-kamelets-itest/src/test/resources/openapi/rest-openapi-sink-pipe.yaml
@@ -42,5 +42,5 @@ spec:
       apiVersion: camel.apache.org/v1
       name: rest-openapi-sink
     properties:
-      specification: http://localhost:8081/petstore/openapi.json
+      specification: "{{petstore.server.url}}/petstore/openapi.json"
       operation: "{{spec.operation}}"

--- a/tests/camel-kamelets-itest/src/test/resources/slack/application.properties
+++ b/tests/camel-kamelets-itest/src/test/resources/slack/application.properties
@@ -15,6 +15,6 @@
 # limitations under the License.
 #
 
-slack.server.url=http://localhost:8081
+slack.server.url=http://localhost:${slack.server.port}
 slack.channel=${slack.channel}
 slack.token=${slack.token}

--- a/tests/camel-kamelets-itest/src/test/resources/slack/slack-sink-pipe.it.yaml
+++ b/tests/camel-kamelets-itest/src/test/resources/slack/slack-sink-pipe.it.yaml
@@ -17,8 +17,6 @@
 
 name: slack-sink-pipe-test
 variables:
-  - name: "slack.server.url"
-    value: "http://localhost:8081"
   - name: "slack.token"
     value: "xoxb-citrus:randomNumber(10)-citrus:randomNumber(13)-citrus:randomString(34)"
   - name: "slack.channel"
@@ -32,6 +30,10 @@ variables:
   - name: "timer.source.period"
     value: "10000"
 actions:
+  - createVariables:
+      variables:
+        - name: "slack.server.url"
+          value: "http://localhost:${slack.server.port}"
   # Create Camel JBang integration
   - camel:
       jbang:
@@ -49,7 +51,7 @@ actions:
 
   # Verify message post request
   - http:
-      server: "httpServer"
+      server: "slackServer"
       receiveRequest:
         POST:
           path: "/"
@@ -62,7 +64,7 @@ actions:
               }
 
   - http:
-      server: "httpServer"
+      server: "slackServer"
       sendResponse:
         response:
           status: 200

--- a/tests/camel-kamelets-itest/src/test/resources/slack/slack-source-pipe.it.yaml
+++ b/tests/camel-kamelets-itest/src/test/resources/slack/slack-source-pipe.it.yaml
@@ -17,8 +17,6 @@
 
 name: slack-source-pipe-test
 variables:
-  - name: "slack.server.url"
-    value: "http://localhost:8081"
   - name: "slack.token"
     value: "xoxb-citrus:randomNumber(10)-citrus:randomNumber(13)-citrus:randomString(34)"
   - name: "slack.channel"
@@ -30,6 +28,10 @@ variables:
   - name: "slack.message"
     value: "Camel rocks!"
 actions:
+  - createVariables:
+      variables:
+        - name: "slack.server.url"
+          value: "http://localhost:${slack.server.port}"
   # Create Camel JBang integration
   - camel:
       jbang:
@@ -45,7 +47,7 @@ actions:
 
   # Verify auth test request
   - http:
-      server: "httpServer"
+      server: "slackServer"
       receiveRequest:
         POST:
           path: "/api/auth.test"
@@ -55,7 +57,7 @@ actions:
               value: "Bearer ${slack.token}"
 
   - http:
-      server: "httpServer"
+      server: "slackServer"
       sendResponse:
         response:
           status: 200
@@ -68,7 +70,7 @@ actions:
 
   # Verify conversations list request
   - http:
-      server: "httpServer"
+      server: "slackServer"
       receiveRequest:
         POST:
           path: "/api/conversations.list"
@@ -78,7 +80,7 @@ actions:
               value: "Bearer ${slack.token}"
 
   - http:
-      server: "httpServer"
+      server: "slackServer"
       sendResponse:
         response:
           status: 200
@@ -91,7 +93,7 @@ actions:
 
   # Verify conversations history request
   - http:
-      server: "httpServer"
+      server: "slackServer"
       receiveRequest:
         POST:
           path: "/api/conversations.history"
@@ -101,7 +103,7 @@ actions:
               value: "Bearer ${slack.token}"
 
   - http:
-      server: "httpServer"
+      server: "slackServer"
       sendResponse:
         response:
           status: 200

--- a/tests/camel-kamelets-itest/src/test/resources/timer/timer-to-http-pipe.it.yaml
+++ b/tests/camel-kamelets-itest/src/test/resources/timer/timer-to-http-pipe.it.yaml
@@ -17,11 +17,13 @@
 
 name: timer-to-http-pipe-test
 variables:
-  - name: "server.url"
-    value: "http://localhost:8081"
   - name: "timer.message"
     value: "Camel rocks!"
 actions:
+  - createVariables:
+      variables:
+        - name: "http.server.url"
+          value: "http://localhost:${http.server.port}"
   # Create Camel JBang integration
   - camel:
       jbang:
@@ -31,8 +33,8 @@ actions:
             file: "timer/timer-to-http-pipe.yaml"
             systemProperties:
               properties:
-                - name: "server.url"
-                  value: "${server.url}"
+                - name: "http.sink.url"
+                  value: "${http.server.url}"
                 - name: "timer.message"
                   value: "${timer.message}"
 

--- a/tests/camel-kamelets-itest/src/test/resources/timer/timer-to-http-pipe.yaml
+++ b/tests/camel-kamelets-itest/src/test/resources/timer/timer-to-http-pipe.yaml
@@ -29,4 +29,4 @@ spec:
       period: 10000
       message: "{{timer.message}}"
   sink:
-    uri: "{{server.url}}/events"
+    uri: "{{http.sink.url}}/events"

--- a/tests/camel-kamelets-itest/src/test/resources/timer/timer-to-http.it.yaml
+++ b/tests/camel-kamelets-itest/src/test/resources/timer/timer-to-http.it.yaml
@@ -17,11 +17,13 @@
 
 name: timer-to-http-test
 variables:
-  - name: "server.url"
-    value: "http://localhost:8081"
   - name: "timer.message"
     value: "Camel rocks!"
 actions:
+  - createVariables:
+      variables:
+        - name: "http.server.url"
+          value: "http://localhost:${http.server.port}"
   # Create Camel JBang integration
   - camel:
       jbang:
@@ -31,8 +33,8 @@ actions:
             file: "timer/timer-to-http.yaml"
             systemProperties:
               properties:
-                - name: "server.url"
-                  value: "${server.url}"
+                - name: "http.sink.url"
+                  value: "${http.server.url}"
                 - name: "timer.message"
                   value: "${timer.message}"
 

--- a/tests/camel-kamelets-itest/src/test/resources/timer/timer-to-http.yaml
+++ b/tests/camel-kamelets-itest/src/test/resources/timer/timer-to-http.yaml
@@ -28,7 +28,7 @@
           expression:
             constant: '{{timer.message}}'
       - to:
-          uri: '{{server.url}}/events'
+          uri: '{{http.sink.url}}/events'
       - to:
           uri: 'log:info'
           parameters:

--- a/tests/camel-kamelets-itest/src/test/resources/transformation/data-type-action-pipe.it.yaml
+++ b/tests/camel-kamelets-itest/src/test/resources/transformation/data-type-action-pipe.it.yaml
@@ -17,11 +17,13 @@
 
 name: data-type-action-pipe-test
 variables:
-  - name: "server.url"
-    value: "http://localhost:8081"
   - name: "uuid"
     value: "citrus:randomUUID()"
 actions:
+  - createVariables:
+      variables:
+        - name: "http.server.url"
+          value: "http://localhost:${http.server.port}"
   # Create Camel JBang integration
   - camel:
       jbang:
@@ -31,8 +33,8 @@ actions:
             file: "transformation/data-type-action-pipe.yaml"
             systemProperties:
               properties:
-                - name: "server.url"
-                  value: "${server.url}"
+                - name: "http.sink.url"
+                  value: "${http.server.url}"
                 - name: "input"
                   value: |
                     { \"id\": \"${uuid}\" }

--- a/tests/camel-kamelets-itest/src/test/resources/transformation/data-type-action-pipe.yaml
+++ b/tests/camel-kamelets-itest/src/test/resources/transformation/data-type-action-pipe.yaml
@@ -48,4 +48,4 @@ spec:
       properties:
         showHeaders: true
   sink:
-    uri: "{{server.url}}/result"
+    uri: "{{http.sink.url}}/result"

--- a/tests/camel-kamelets-itest/src/test/resources/transformation/extract-field-action-pipe.it.yaml
+++ b/tests/camel-kamelets-itest/src/test/resources/transformation/extract-field-action-pipe.it.yaml
@@ -17,13 +17,15 @@
 
 name: extract-field-action-pipe-test
 variables:
-  - name: "server.url"
-    value: "http://localhost:8081"
   - name: "field.name"
     value: "subject"
   - name: "field.value"
     value: "Camel rocks!"
 actions:
+  - createVariables:
+      variables:
+        - name: "http.server.url"
+          value: "http://localhost:${http.server.port}"
   # Create Camel JBang integration
   - camel:
       jbang:
@@ -33,8 +35,8 @@ actions:
             file: "transformation/extract-field-action-pipe.yaml"
             systemProperties:
               properties:
-                - name: "server.url"
-                  value: "${server.url}"
+                - name: "http.sink.url"
+                  value: "${http.server.url}"
                 - name: "field.name"
                   value: "${field.name}"
                 - name: "input"

--- a/tests/camel-kamelets-itest/src/test/resources/transformation/extract-field-action-pipe.yaml
+++ b/tests/camel-kamelets-itest/src/test/resources/transformation/extract-field-action-pipe.yaml
@@ -38,4 +38,4 @@ spec:
       properties:
         field: "{{field.name}}"
   sink:
-    uri: "{{server.url}}/result"
+    uri: "{{http.sink.url}}/result"

--- a/tests/camel-kamelets-itest/src/test/resources/transformation/insert-field-action-pipe.it.yaml
+++ b/tests/camel-kamelets-itest/src/test/resources/transformation/insert-field-action-pipe.it.yaml
@@ -17,8 +17,6 @@
 
 name: insert-field-action-pipe-test
 variables:
-  - name: "server.url"
-    value: "http://localhost:8081"
   - name: "id"
     value: "citrus:randomUUID()"
   - name: "field.value"
@@ -26,6 +24,10 @@ variables:
   - name: "field.name"
     value: "subject"
 actions:
+  - createVariables:
+      variables:
+        - name: "http.server.url"
+          value: "http://localhost:${http.server.port}"
   # Create Camel JBang integration
   - camel:
       jbang:
@@ -35,8 +37,8 @@ actions:
             file: "transformation/insert-field-action-pipe.yaml"
             systemProperties:
               properties:
-                - name: "server.url"
-                  value: "${server.url}"
+                - name: "http.sink.url"
+                  value: "${http.server.url}"
                 - name: "field.name"
                   value: "${field.name}"
                 - name: "field.value"

--- a/tests/camel-kamelets-itest/src/test/resources/transformation/insert-field-action-pipe.yaml
+++ b/tests/camel-kamelets-itest/src/test/resources/transformation/insert-field-action-pipe.yaml
@@ -39,4 +39,4 @@ spec:
         field: "{{field.name}}"
         value: "{{field.value}}"
   sink:
-    uri: "{{server.url}}/result"
+    uri: "{{http.sink.url}}/result"


### PR DESCRIPTION
Since Citrus 4.5.2 Camel JBang integrations should be stopped properly on all operating systems so the workaround is not needed anymore

Make tests more stable with separate Http server instances