### PR TITLE
Fix tests with next SNAPSHOT and Camel 4.14.0

### DIFF
--- a/tests/camel-kamelets-itest/README.md
+++ b/tests/camel-kamelets-itest/README.md
@@ -10,7 +10,7 @@ You need the following tools to run the tests:
 
 Once everything is set you just need to run
 
-```console
+```shell
   mvn verify -Denable.integration.tests
 ```
 
@@ -18,7 +18,7 @@ This runs all available Citrus tests.
 
 You can run individual tests when specifying its folder name on the class `CommonIT` (e.g. `timer`).
 
-```console
+```shell
   mvn verify -Dtest=CommonIT#timer
 ```
 

--- a/tests/camel-kamelets-itest/jbang.properties
+++ b/tests/camel-kamelets-itest/jbang.properties
@@ -16,5 +16,5 @@
 #
 
 # Declare required additional dependencies
-run.deps=org.apache.camel:camel-jackson-avro:4.9.0,\
-org.apache.camel:camel-jackson-protobuf:4.9.0
+run.deps=org.apache.camel:camel-jackson-avro:4.14.0,\
+org.apache.camel:camel-jackson-protobuf:4.14.0

--- a/tests/camel-kamelets-itest/src/test/java/AvroIT.java
+++ b/tests/camel-kamelets-itest/src/test/java/AvroIT.java
@@ -23,7 +23,6 @@ import org.citrusframework.junit.jupiter.CitrusSupport;
 import org.citrusframework.junit.jupiter.CitrusTestFactory;
 import org.citrusframework.junit.jupiter.CitrusTestFactorySupport;
 import org.citrusframework.spi.BindToRegistry;
-import org.citrusframework.util.SocketUtils;
 import org.junit.jupiter.api.DynamicTest;
 
 import static org.citrusframework.actions.CreateVariablesAction.Builder.createVariables;
@@ -31,7 +30,7 @@ import static org.citrusframework.actions.CreateVariablesAction.Builder.createVa
 @CitrusSupport
 public class AvroIT {
 
-    private final int avroWebhookPort = SocketUtils.findAvailableTcpPort();
+    private final int avroWebhookPort = 8080;
 
     @BindToRegistry
     public SequenceBeforeTest beforeAvro() {

--- a/tests/camel-kamelets-itest/src/test/java/KafkaIT.java
+++ b/tests/camel-kamelets-itest/src/test/java/KafkaIT.java
@@ -36,7 +36,7 @@ import static org.citrusframework.http.endpoint.builder.HttpEndpoints.http;
 public class KafkaIT {
 
     private final int kafkaSinkServerPort = SocketUtils.findAvailableTcpPort();
-    private final int kafkaWebhookPort = SocketUtils.findAvailableTcpPort();
+    private final int kafkaWebhookPort = 8080;
 
     @BindToRegistry
     HttpServer kafkaSinkServer = http()

--- a/tests/camel-kamelets-itest/src/test/java/ProtobufIT.java
+++ b/tests/camel-kamelets-itest/src/test/java/ProtobufIT.java
@@ -23,7 +23,6 @@ import org.citrusframework.junit.jupiter.CitrusSupport;
 import org.citrusframework.junit.jupiter.CitrusTestFactory;
 import org.citrusframework.junit.jupiter.CitrusTestFactorySupport;
 import org.citrusframework.spi.BindToRegistry;
-import org.citrusframework.util.SocketUtils;
 import org.junit.jupiter.api.DynamicTest;
 
 import static org.citrusframework.actions.CreateVariablesAction.Builder.createVariables;
@@ -31,7 +30,7 @@ import static org.citrusframework.actions.CreateVariablesAction.Builder.createVa
 @CitrusSupport
 public class ProtobufIT {
 
-    private final int protobufWebhookPort = SocketUtils.findAvailableTcpPort();
+    private final int protobufWebhookPort = 8080;
 
     @BindToRegistry
     public SequenceBeforeTest beforeProtobuf() {

--- a/tests/camel-kamelets-itest/src/test/resources/citrus-application.properties
+++ b/tests/camel-kamelets-itest/src/test/resources/citrus-application.properties
@@ -25,9 +25,9 @@ citrus.cluster.type=local
 citrus.camel.jbang.max.attempts=10
 
 # Camel JBang version (should align with version used in pom.xml)
-citrus.camel.jbang.version=4.11.0
+citrus.camel.jbang.version=4.14.0
 # Kamelets version (should point to the current snapshot release version)
-citrus.camel.jbang.kamelets.version=4.12.0-SNAPSHOT
+citrus.camel.jbang.kamelets.version=4.15.0-SNAPSHOT
 
 # Enable dump of Camel JBang integration output
 citrus.camel.jbang.dump.integration.output=true

--- a/tests/camel-kamelets-itest/src/test/resources/junit-platform.properties
+++ b/tests/camel-kamelets-itest/src/test/resources/junit-platform.properties
@@ -15,5 +15,5 @@
 # limitations under the License.
 #
 
-junit.jupiter.execution.parallel.enabled = true
+junit.jupiter.execution.parallel.enabled = false
 junit.jupiter.execution.parallel.mode.classes.default = concurrent


### PR DESCRIPTION
Fixes automated integration tests

Had to disable parallel test execution because custom server port with `camel run --port <custom-server-port>` seems to be broken with Camel 4.14.0. Instead all tests are using default port `8080` until custom server port has been fixed.