### PR TITLE
Enhance AWS EventBridge Sink Kamelet

### DIFF
--- a/kamelets/aws-eventbridge-sink.kamelet.yaml
+++ b/kamelets/aws-eventbridge-sink.kamelet.yaml
@@ -33,13 +33,13 @@ spec:
     title: "AWS Eventbridge Sink"
     description: Send events to an Amazon Eventbridge Eventbus.
 
-      In the headers, you need to set the `resources-arn` / `ce-resources-arn` property to specify the ARN of resources related to the event.
+      In the headers, you can set the `resources-arn` / `ce-resources-arn` property to specify the ARN of resources related to the event.
 
-      In the headers, you need to set the `detail-type` / `ce-detail-type` property to specify the detail type related to the event.
+      In the headers, you can set the `detail-type` / `ce-detail-type` property to specify the detail type related to the event.
 
-      In the headers, you need to set the `event-source` / `ce-event-source` property to specify the event source related to the event.
+      In the headers, you can set the `event-source` / `ce-event-source` property to specify the event source related to the event.
 
-      If you do not set the property in the header, the Kamelet uses the exchange ID for the file name.
+      If you do not set the property in the header, the Kamelet uses the given Kamelet properties as a default.
     required:
       - eventbusNameOrArn
       - region
@@ -48,6 +48,23 @@ spec:
       eventbusNameOrArn:
         title: Eventbus Name
         description: The Eventbridge Eventbus name or Amazon Resource Name (ARN).
+        type: string
+      resourcesArn:
+        title: Event Resource ARN
+        description: The ARN of resources related to the AWS event (e.g. `arn:aws:s3:eu-east-1:000000000001:test`).
+        type: string
+      eventSourcePrefix:
+        title: Event Source Prefix
+        description: The event source prefix set for all events sent to the eventbus.
+        type: string
+        default: ""
+      eventSource:
+        title: Event Source
+        description: The event source related to the AWS event (e.g. `aws.s3`).
+        type: string
+      detailType:
+        title: Event Detail Type
+        description: The event detail type related to the AWS event.
         type: string
       accessKey:
         title: Access Key
@@ -123,6 +140,11 @@ spec:
             - setHeader:
                 name: CamelAwsEventbridgeResourcesArn
                 simple: "${header[ce-resources-arn]}"
+          otherwise:
+            steps:
+            - setHeader:
+                name: CamelAwsEventbridgeResourcesArn
+                simple: "{{?resourcesArn}}"
       - choice:
           when:
           - simple: "${header[detail-type]}"
@@ -135,18 +157,33 @@ spec:
             - setHeader:
                 name: CamelAwsEventbridgeDetailType
                 simple: "${header[ce-detail-type]}"
+          otherwise:
+            steps:
+            - setHeader:
+                name: CamelAwsEventbridgeDetailType
+                simple: "{{?detailType}}"
       - choice:
           when:
           - simple: "${header[event-source]}"
             steps:
             - setHeader:
                 name: CamelAwsEventbridgeSource
-                simple: "${header[event-source]}"
+                simple: "{{?eventSourcePrefix}}${header[event-source]}"
           - simple: "${header[ce-event-source]}"
             steps:
             - setHeader:
                 name: CamelAwsEventbridgeSource
-                simple: "${header[ce-event-source]}"            
+                simple: "{{?eventSourcePrefix}}${header[ce-event-source]}"
+          - simple: "${header[ce-source]}"
+            steps:
+            - setHeader:
+                name: CamelAwsEventbridgeSource
+                simple: "{{?eventSourcePrefix}}${header[ce-source]}"
+          otherwise:
+            steps:
+            - setHeader:
+                name: CamelAwsEventbridgeSource
+                simple: "{{?eventSourcePrefix}}{{?eventSource}}"
       - to:
           uri: "aws2-eventbridge:{{eventbusNameOrArn}}"
           parameters:

--- a/library/camel-kamelets/src/main/resources/kamelets/aws-eventbridge-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/aws-eventbridge-sink.kamelet.yaml
@@ -33,13 +33,13 @@ spec:
     title: "AWS Eventbridge Sink"
     description: Send events to an Amazon Eventbridge Eventbus.
 
-      In the headers, you need to set the `resources-arn` / `ce-resources-arn` property to specify the ARN of resources related to the event.
+      In the headers, you can set the `resources-arn` / `ce-resources-arn` property to specify the ARN of resources related to the event.
 
-      In the headers, you need to set the `detail-type` / `ce-detail-type` property to specify the detail type related to the event.
+      In the headers, you can set the `detail-type` / `ce-detail-type` property to specify the detail type related to the event.
 
-      In the headers, you need to set the `event-source` / `ce-event-source` property to specify the event source related to the event.
+      In the headers, you can set the `event-source` / `ce-event-source` property to specify the event source related to the event.
 
-      If you do not set the property in the header, the Kamelet uses the exchange ID for the file name.
+      If you do not set the property in the header, the Kamelet uses the given Kamelet properties as a default.
     required:
       - eventbusNameOrArn
       - region
@@ -48,6 +48,23 @@ spec:
       eventbusNameOrArn:
         title: Eventbus Name
         description: The Eventbridge Eventbus name or Amazon Resource Name (ARN).
+        type: string
+      resourcesArn:
+        title: Event Resource ARN
+        description: The ARN of resources related to the AWS event (e.g. `arn:aws:s3:eu-east-1:000000000001:test`).
+        type: string
+      eventSourcePrefix:
+        title: Event Source Prefix
+        description: The event source prefix set for all events sent to the eventbus.
+        type: string
+        default: ""
+      eventSource:
+        title: Event Source
+        description: The event source related to the AWS event (e.g. `aws.s3`).
+        type: string
+      detailType:
+        title: Event Detail Type
+        description: The event detail type related to the AWS event.
         type: string
       accessKey:
         title: Access Key
@@ -123,6 +140,11 @@ spec:
             - setHeader:
                 name: CamelAwsEventbridgeResourcesArn
                 simple: "${header[ce-resources-arn]}"
+          otherwise:
+            steps:
+            - setHeader:
+                name: CamelAwsEventbridgeResourcesArn
+                simple: "{{?resourcesArn}}"
       - choice:
           when:
           - simple: "${header[detail-type]}"
@@ -135,18 +157,33 @@ spec:
             - setHeader:
                 name: CamelAwsEventbridgeDetailType
                 simple: "${header[ce-detail-type]}"
+          otherwise:
+            steps:
+            - setHeader:
+                name: CamelAwsEventbridgeDetailType
+                simple: "{{?detailType}}"
       - choice:
           when:
           - simple: "${header[event-source]}"
             steps:
             - setHeader:
                 name: CamelAwsEventbridgeSource
-                simple: "${header[event-source]}"
+                simple: "{{?eventSourcePrefix}}${header[event-source]}"
           - simple: "${header[ce-event-source]}"
             steps:
             - setHeader:
                 name: CamelAwsEventbridgeSource
-                simple: "${header[ce-event-source]}"            
+                simple: "{{?eventSourcePrefix}}${header[ce-event-source]}"
+          - simple: "${header[ce-source]}"
+            steps:
+            - setHeader:
+                name: CamelAwsEventbridgeSource
+                simple: "{{?eventSourcePrefix}}${header[ce-source]}"
+          otherwise:
+            steps:
+            - setHeader:
+                name: CamelAwsEventbridgeSource
+                simple: "{{?eventSourcePrefix}}{{?eventSource}}"
       - to:
           uri: "aws2-eventbridge:{{eventbusNameOrArn}}"
           parameters:

--- a/tests/camel-kamelets-itest/pom.xml
+++ b/tests/camel-kamelets-itest/pom.xml
@@ -87,6 +87,12 @@
             <version>${camel.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-aws2-eventbridge</artifactId>
+            <version>${camel.version}</version>
+            <scope>test</scope>
+        </dependency>
 
         <!-- Citrus -->
         <dependency>

--- a/tests/camel-kamelets-itest/src/test/resources/aws/eventbridge/application.properties
+++ b/tests/camel-kamelets-itest/src/test/resources/aws/eventbridge/application.properties
@@ -1,0 +1,28 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+aws.eventbridge.eventbusName=${aws.eventbridge.eventbusName}
+aws.eventbridge.resourcesArn=${aws.eventbridge.resourcesArn}
+aws.eventbridge.eventSource=${aws.eventbridge.eventSource}
+aws.eventbridge.eventSourcePrefix=${aws.eventbridge.eventSourcePrefix}
+aws.eventbridge.detailType=${aws.eventbridge.detailType}
+
+aws.eventbridge.uriEndpointOverride=${CITRUS_TESTCONTAINERS_LOCALSTACK_SERVICE_URL}
+aws.eventbridge.secretKey=${CITRUS_TESTCONTAINERS_LOCALSTACK_SECRET_KEY}
+aws.eventbridge.accessKey=${CITRUS_TESTCONTAINERS_LOCALSTACK_ACCESS_KEY}
+aws.eventbridge.region=${CITRUS_TESTCONTAINERS_LOCALSTACK_REGION}
+aws.eventbridge.overrideEndpoint=true

--- a/tests/camel-kamelets-itest/src/test/resources/aws/eventbridge/aws-eventbridge-sink-pipe.yaml
+++ b/tests/camel-kamelets-itest/src/test/resources/aws/eventbridge/aws-eventbridge-sink-pipe.yaml
@@ -1,0 +1,51 @@
+# ---------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ---------------------------------------------------------------------------
+
+apiVersion: camel.apache.org/v1
+kind: Pipe
+metadata:
+  name: aws-eventbridge-sink-pipe
+spec:
+  source:
+    ref:
+      kind: Kamelet
+      apiVersion: camel.apache.org/v1
+      name: timer-source
+    properties:
+      period: '{{timer.source.period}}'
+      message: '{{aws.eventbridge.json.data}}'
+  steps:
+    - ref:
+        kind: Kamelet
+        apiVersion: camel.apache.org/v1
+        name: log-action
+  sink:
+    ref:
+      kind: Kamelet
+      apiVersion: camel.apache.org/v1
+      name: aws-eventbridge-sink
+    properties:
+      eventbusNameOrArn: '{{aws.eventbridge.eventbusName}}'
+      overrideEndpoint: '{{aws.eventbridge.overrideEndpoint}}'
+      uriEndpointOverride: '{{aws.eventbridge.uriEndpointOverride}}'
+      accessKey: '{{aws.eventbridge.accessKey}}'
+      secretKey: '{{aws.eventbridge.secretKey}}'
+      region: '{{aws.eventbridge.region}}'
+      resourcesArn: '{{aws.eventbridge.resourcesArn}}'
+      eventSource: '{{aws.eventbridge.eventSource}}'
+      eventSourcePrefix: '{{aws.eventbridge.eventSourcePrefix}}'
+      detailType: '{{aws.eventbridge.detailType}}'

--- a/tests/camel-kamelets-itest/src/test/resources/aws/eventbridge/aws-eventbridge-sink.it.yaml
+++ b/tests/camel-kamelets-itest/src/test/resources/aws/eventbridge/aws-eventbridge-sink.it.yaml
@@ -1,0 +1,89 @@
+# ---------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ---------------------------------------------------------------------------
+
+name: aws-eventbridge-sink-test
+variables:
+  - name: "maxRetryAttempts"
+    value: "20"
+  - name: "aws.sqs.queueName"
+    value: "event-queue"
+  - name: "aws.eventbridge.eventbusName"
+    value: "default"
+  - name: "aws.eventbridge.resourcesArn"
+    value: "arn:aws:s3:us-east-1:000000000000:my-bucket"
+  - name: "aws.eventbridge.eventSource"
+    value: "aws.s3"
+  - name: "aws.eventbridge.eventSourcePrefix"
+    value: "kamelet-connect."
+  - name: "aws.eventbridge.detailType"
+    value: "Object Created"
+  - name: "aws.eventbridge.json.data"
+    value: |
+      { \"message\": \"Hello AWS EventBridge!\" }
+  - name: "timer.source.period"
+    value: "10000"
+actions:
+  # Create LocalStack infrastructure
+  - testcontainers:
+      start:
+        localstack:
+          services:
+            - "SQS"
+            - "EVENT_BRIDGE"
+
+  - waitFor:
+      http:
+        url: "${CITRUS_TESTCONTAINERS_LOCALSTACK_SERVICE_URL}"
+
+  # Create AWS EventBridge and SQS queue
+  - groovy:
+      script:
+        file: "aws/eventbridge/setupEventBridge.groovy"
+
+  # Create Camel JBang integration
+  - camel:
+      jbang:
+        run:
+          integration:
+            file: "aws/eventbridge/aws-eventbridge-sink-pipe.yaml"
+            systemProperties:
+              properties:
+                - name: "timer.source.period"
+                  value: "${timer.source.period}"
+                - name: "aws.eventbridge.json.data"
+                  value: "${aws.eventbridge.json.data}"
+              file: "aws/eventbridge/application.properties"
+
+  # Create event listener
+  - camel:
+      jbang:
+        run:
+          integration:
+            file: "aws/eventbridge/aws-sqs-event-listener-pipe.yaml"
+            systemProperties:
+              properties:
+                - name: "aws.sqs.queueName"
+                  value: "${aws.sqs.queueName}"
+              file: "aws/eventbridge/application.properties"
+
+  # Verify event received
+  - camel:
+      jbang:
+        verify:
+          integration: "aws-sqs-event-listener-pipe"
+          logMessage: |
+            "detail":{"message":"Hello AWS EventBridge!"}

--- a/tests/camel-kamelets-itest/src/test/resources/aws/eventbridge/aws-sqs-event-listener-pipe.yaml
+++ b/tests/camel-kamelets-itest/src/test/resources/aws/eventbridge/aws-sqs-event-listener-pipe.yaml
@@ -1,0 +1,41 @@
+# ---------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ---------------------------------------------------------------------------
+
+apiVersion: camel.apache.org/v1
+kind: Pipe
+metadata:
+  name: aws-sqs-event-listener-pipe
+spec:
+  source:
+    ref:
+      kind: Kamelet
+      apiVersion: camel.apache.org/v1
+      name: aws-sqs-source
+    properties:
+      queueNameOrArn: "{{aws.sqs.queueName}}"
+      uriEndpointOverride: "{{aws.eventbridge.uriEndpointOverride}}"
+      overrideEndpoint: "{{aws.eventbridge.overrideEndpoint}}"
+      accessKey: "{{aws.eventbridge.accessKey}}"
+      secretKey: "{{aws.eventbridge.secretKey}}"
+      region: "{{aws.eventbridge.region}}"
+  sink:
+    ref:
+      kind: Kamelet
+      apiVersion: camel.apache.org/v1
+      name: log-sink
+    properties:
+      showHeaders: true

--- a/tests/camel-kamelets-itest/src/test/resources/aws/eventbridge/setupEventBridge.groovy
+++ b/tests/camel-kamelets-itest/src/test/resources/aws/eventbridge/setupEventBridge.groovy
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import org.citrusframework.actions.testcontainers.aws2.AwsService
+import org.citrusframework.testcontainers.aws2.LocalStackContainer
+import software.amazon.awssdk.services.eventbridge.EventBridgeClient
+import software.amazon.awssdk.services.eventbridge.model.PutRuleResponse
+import software.amazon.awssdk.services.eventbridge.model.Target
+import software.amazon.awssdk.services.sqs.SqsClient
+import software.amazon.awssdk.services.sqs.model.CreateQueueResponse
+import software.amazon.awssdk.services.sqs.model.QueueAttributeName
+
+LocalStackContainer container = context.getReferenceResolver().resolve(LocalStackContainer.class)
+container.withServices(AwsService.EVENT_BRIDGE, AwsService.S3, AwsService.SQS)
+
+EventBridgeClient eventBridgeClient = container.getClient(AwsService.EVENT_BRIDGE)
+
+// Add an EventBridge rule on the event
+PutRuleResponse putRuleResponse = eventBridgeClient.putRule(b -> b.name("events-cdc")
+        .eventBusName('${aws.eventbridge.eventbusName}')
+        .eventPattern('''
+                    {
+                        "source": ["${aws.eventbridge.eventSourcePrefix}${aws.eventbridge.eventSource}"],
+                        "detail-type": ["${aws.eventbridge.detailType}"]
+                    }
+                    '''))
+
+// Create SQS queue acting as an EventBridge notification endpoint
+SqsClient sqsClient = container.getClient(AwsService.SQS);
+CreateQueueResponse createQueueResponse = sqsClient.createQueue(b -> b.queueName('${aws.sqs.queueName}'))
+
+// Modify access policy for the queue just created, so EventBridge rule is allowed to send messages
+String queueUrl = createQueueResponse.queueUrl();
+String queueArn = 'arn:aws:sqs:%s:000000000000:${aws.sqs.queueName}'.formatted(container.getRegion())
+
+sqsClient.setQueueAttributes(b -> b.queueUrl(queueUrl).attributes(Collections.singletonMap(QueueAttributeName.POLICY, """
+                {
+                    "Version": "2012-10-17",
+                    "Id": "%s/SQSDefaultPolicy",
+                    "Statement":
+                    [
+                        {
+                            "Sid": "EventsToMyQueue",
+                            "Effect": "Allow",
+                            "Principal": {
+                                "Service": "events.amazonaws.com"
+                            },
+                            "Action": "sqs:SendMessage",
+                            "Resource": "%s",
+                            "Condition": {
+                                "ArnEquals": {
+                                    "aws:SourceArn": "%s"
+                                }
+                            }
+                        }
+                    ]
+                }
+                """.formatted(queueArn, queueArn, putRuleResponse.ruleArn()))))
+
+// Add a target for EventBridge rule which will be the SQS Queue just created
+eventBridgeClient.putTargets(b -> b.rule("events-cdc")
+        .eventBusName('${aws.eventbridge.eventbusName}')
+        .targets(Target.builder().id("sqs-sub").arn(queueArn).build()))


### PR DESCRIPTION
Users may need to set the AWS EventBridge details via Kamelet properties instead of sending special Http/CloudEvents headers (e.g. in Knative EventMesh).

- Add option to set detailType, eventSource and resourcesArn via Kamelet properties
- Add option to add an eventSource prefix that is added to all events sent to AWS via this Kamelet sink
- Users are still able to overwrite the settings via Http/CloudEvent headers
- Add automated tests for aws-eventbridge-sink