### PR TITLE
chore: remove keda descriptors

### DIFF
--- a/kamelets/aws-s3-event-based-source.kamelet.yaml
+++ b/kamelets/aws-s3-event-based-source.kamelet.yaml
@@ -27,7 +27,6 @@ metadata:
     camel.apache.org/provider: Apache Software Foundation
     camel.apache.org/kamelet.group: AWS S3 Event-Based
     camel.apache.org/kamelet.namespace: "AWS"
-    camel.apache.org/keda.type: aws-s3-event-based-queue
   labels:
     camel.apache.org/kamelet.type: "source"
 spec:
@@ -57,8 +56,6 @@ spec:
         format: password
         x-descriptors:
           - 'urn:camel:group:credentials'
-          - 'urn:keda:authentication:awsAccessKeyID'
-          - 'urn:keda:required'
       secretKey:
         title: Secret Key
         description: The secret key obtained from AWS.
@@ -66,15 +63,10 @@ spec:
         format: password
         x-descriptors:
           - 'urn:camel:group:credentials'
-          - 'urn:keda:authentication:awsSecretAccessKey'
-          - 'urn:keda:required'
       region:
         title: AWS Region
         description: The AWS region to access.
         type: string
-        x-descriptors:
-          - 'urn:keda:metadata:awsRegion'
-          - 'urn:keda:required'
         enum:
           - ap-south-1
           - eu-south-1
@@ -129,11 +121,8 @@ spec:
         default: https
       queueURL:
         title: Queue URL
-        description: The full SQS Queue URL (required if using KEDA)
+        description: The full SQS Queue URL
         type: string
-        x-descriptors:
-          - 'urn:keda:metadata:queueURL'
-          - 'urn:keda:required'
       uriEndpointOverride:
         title: Overwrite Endpoint URI
         description: >-

--- a/kamelets/aws-sqs-source.kamelet.yaml
+++ b/kamelets/aws-sqs-source.kamelet.yaml
@@ -25,7 +25,6 @@ metadata:
     camel.apache.org/kamelet.icon: "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9Im5vIj8+CjxzdmcKICAgeG1sbnM6ZGM9Imh0dHA6Ly9wdXJsLm9yZy9kYy9lbGVtZW50cy8xLjEvIgogICB4bWxuczpjYz0iaHR0cDovL2NyZWF0aXZlY29tbW9ucy5vcmcvbnMjIgogICB4bWxuczpyZGY9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkvMDIvMjItcmRmLXN5bnRheC1ucyMiCiAgIHhtbG5zOnN2Zz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciCiAgIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIKICAgeG1sbnM6c29kaXBvZGk9Imh0dHA6Ly9zb2RpcG9kaS5zb3VyY2Vmb3JnZS5uZXQvRFREL3NvZGlwb2RpLTAuZHRkIgogICB4bWxuczppbmtzY2FwZT0iaHR0cDovL3d3dy5pbmtzY2FwZS5vcmcvbmFtZXNwYWNlcy9pbmtzY2FwZSIKICAgZW5hYmxlLWJhY2tncm91bmQ9Im5ldyAwIDAgMTAwIDEwMCIKICAgaGVpZ2h0PSI3Mi4xOTk5OTciCiAgIHZlcnNpb249IjEuMSIKICAgdmlld0JveD0iMCAwIDU5Ljg0OTk5OCA3Mi4xOTk5OTciCiAgIHdpZHRoPSI1OS44NDk5OTgiCiAgIHhtbDpzcGFjZT0icHJlc2VydmUiCiAgIGlkPSJzdmcxNDUiCiAgIHNvZGlwb2RpOmRvY25hbWU9ImRvd25sb2FkLnN2ZyIKICAgaW5rc2NhcGU6dmVyc2lvbj0iMS4wLjIgKGU4NmM4NzA4NzksIDIwMjEtMDEtMTUpIj48bWV0YWRhdGEKICAgICBpZD0ibWV0YWRhdGExNTEiPjxyZGY6UkRGPjxjYzpXb3JrCiAgICAgICAgIHJkZjphYm91dD0iIj48ZGM6Zm9ybWF0PmltYWdlL3N2Zyt4bWw8L2RjOmZvcm1hdD48ZGM6dHlwZQogICAgICAgICAgIHJkZjpyZXNvdXJjZT0iaHR0cDovL3B1cmwub3JnL2RjL2RjbWl0eXBlL1N0aWxsSW1hZ2UiIC8+PGRjOnRpdGxlPjwvZGM6dGl0bGU+PC9jYzpXb3JrPjwvcmRmOlJERj48L21ldGFkYXRhPjxkZWZzCiAgICAgaWQ9ImRlZnMxNDkiIC8+PHNvZGlwb2RpOm5hbWVkdmlldwogICAgIHBhZ2Vjb2xvcj0iI2ZmZmZmZiIKICAgICBib3JkZXJjb2xvcj0iIzY2NjY2NiIKICAgICBib3JkZXJvcGFjaXR5PSIxIgogICAgIG9iamVjdHRvbGVyYW5jZT0iMTAiCiAgICAgZ3JpZHRvbGVyYW5jZT0iMTAiCiAgICAgZ3VpZGV0b2xlcmFuY2U9IjEwIgogICAgIGlua3NjYXBlOnBhZ2VvcGFjaXR5PSIwIgogICAgIGlua3NjYXBlOnBhZ2VzaGFkb3c9IjIiCiAgICAgaW5rc2NhcGU6d2luZG93LXdpZHRoPSIxOTIwIgogICAgIGlua3NjYXBlOndpbmRvdy1oZWlnaHQ9IjEwMTYiCiAgICAgaWQ9Im5hbWVkdmlldzE0NyIKICAgICBzaG93Z3JpZD0iZmFsc2UiCiAgICAgZml0LW1hcmdpbi10b3A9IjAuMSIKICAgICBmaXQtbWFyZ2luLWxlZnQ9IjAuMSIKICAgICBmaXQtbWFyZ2luLXJpZ2h0PSIwLjEiCiAgICAgZml0LW1hcmdpbi1ib3R0b209IjAuMSIKICAgICBpbmtzY2FwZTp6b29tPSI4LjE5IgogICAgIGlua3NjYXBlOmN4PSIyOS45MjUiCiAgICAgaW5rc2NhcGU6Y3k9IjM2LjEiCiAgICAgaW5rc2NhcGU6d2luZG93LXg9IjAiCiAgICAgaW5rc2NhcGU6d2luZG93LXk9IjI3IgogICAgIGlua3NjYXBlOndpbmRvdy1tYXhpbWl6ZWQ9IjEiCiAgICAgaW5rc2NhcGU6Y3VycmVudC1sYXllcj0ic3ZnMTQ1IiAvPjxnCiAgICAgaWQ9IkFtYXpvbl9DbG91ZFNlYXJjaCIKICAgICB0cmFuc2Zvcm09InRyYW5zbGF0ZSgtMjAuMDc1LC0xMy45KSI+PGcKICAgICAgIGlkPSJnMTQyIj48cG9seWdvbgogICAgICAgICBmaWxsPSIjZDlhNzQxIgogICAgICAgICBwb2ludHM9IjIzLjk4NywzNi4yMDEgNTQuNDYyLDQwLjQ5NCA1NC40Niw1OS41MDYgMjMuOTg1LDYzLjc5MyAiCiAgICAgICAgIGlkPSJwb2x5Z29uMTIwIiAvPjxwb2x5Z29uCiAgICAgICAgIGZpbGw9IiM4NzY5MjkiCiAgICAgICAgIHBvaW50cz0iNTAuMDAzLDE0IDIwLjE3OSwyOC45MDggMjAuMTc5LDM3LjM0NCA1MC4wMDMsMjguMzk5ICIKICAgICAgICAgaWQ9InBvbHlnb24xMjIiIC8+PHBvbHlnb24KICAgICAgICAgZmlsbD0iIzg3NjkyOSIKICAgICAgICAgcG9pbnRzPSI0OS45OTcsODYgMjAuMTksNzEuMDk0IDIwLjE5LDYyLjY1NCA0OS45OTksNzEuNiAiCiAgICAgICAgIGlkPSJwb2x5Z29uMTI0IiAvPjxwb2x5Z29uCiAgICAgICAgIGZpbGw9IiNkOWE3NDEiCiAgICAgICAgIHBvaW50cz0iNTAuMDAzLDE0IDc5LjgyNSwyOC45MTQgNzkuODIzLDM3LjM1IDUwLjAwMywyOC4zOTkgIgogICAgICAgICBpZD0icG9seWdvbjEyNiIgLz48cG9seWdvbgogICAgICAgICBmaWxsPSIjZDlhNzQxIgogICAgICAgICBwb2ludHM9IjQ5Ljk5Nyw4NiA3OS44MDYsNzEuMDk5IDc5LjgwNiw2Mi42NiA0OS45OTksNzEuNiAiCiAgICAgICAgIGlkPSJwb2x5Z29uMTI4IiAvPjxwb2x5Z29uCiAgICAgICAgIGZpbGw9IiM4NzY5MjkiCiAgICAgICAgIHBvaW50cz0iMjAuMTc5LDI4LjkwOCAyMy45ODksMjcuMDA0IDIzLjk4NSw3Mi45OSAyMC4xNzUsNzEuMDg2ICIKICAgICAgICAgaWQ9InBvbHlnb24xMzAiIC8+PHBvbHlnb24KICAgICAgICAgZmlsbD0iIzg3NjkyOSIKICAgICAgICAgcG9pbnRzPSI1MC4wMDEsNDAuODMyIDM5LjAxOSw0Mi4yMjkgMzkuMDE3LDU3Ljc2MiA0OS45OTksNTkuMTYgIgogICAgICAgICBpZD0icG9seWdvbjEzMiIgLz48cG9seWdvbgogICAgICAgICBmaWxsPSIjODc2OTI5IgogICAgICAgICBwb2ludHM9IjM1LjA4Myw0Mi43MjkgMjcuOTU0LDQzLjYzNyAyNy45NTQsNTYuMzU0IDM1LjA4MSw1Ny4yNiAiCiAgICAgICAgIGlkPSJwb2x5Z29uMTM0IiAvPjxwb2x5Z29uCiAgICAgICAgIGZpbGw9IiM2MjRhMWUiCiAgICAgICAgIHBvaW50cz0iNzkuODIzLDM3LjM1IDU0LjQ4MSw0MC40OTYgMjMuOTg3LDM2LjIwMSA1MC4wMDMsMjguMzk5ICIKICAgICAgICAgaWQ9InBvbHlnb24xMzYiIC8+PHBvbHlnb24KICAgICAgICAgZmlsbD0iI2ZhZDc5MSIKICAgICAgICAgcG9pbnRzPSI3OS44MDYsNjIuNjYgNTQuNDYsNTkuNTA2IDIzLjk4NSw2My43OTMgNDkuOTk5LDcxLjYgIgogICAgICAgICBpZD0icG9seWdvbjEzOCIgLz48cG9seWdvbgogICAgICAgICBmaWxsPSIjZDlhNzQxIgogICAgICAgICBwb2ludHM9IjUwLjAwMSw0MC44MzIgNzkuODA4LDQ0LjYyOSA3OS44MDgsNTUuMzMgNDkuOTk5LDU5LjA5MiAiCiAgICAgICAgIGlkPSJwb2x5Z29uMTQwIiAvPjwvZz48L2c+PC9zdmc+Cg=="
     camel.apache.org/provider: "Apache Software Foundation"
     camel.apache.org/kamelet.group: "AWS SQS"
-    camel.apache.org/keda.type: "aws-sqs-queue"
     camel.apache.org/kamelet.namespace: "AWS"
   labels:
     camel.apache.org/kamelet.type: "source"
@@ -54,8 +53,6 @@ spec:
         format: password
         x-descriptors:
         - urn:camel:group:credentials
-        - urn:keda:authentication:awsAccessKeyID
-        - urn:keda:required
       secretKey:
         title: Secret Key
         description: The secret key obtained from AWS.
@@ -63,15 +60,10 @@ spec:
         format: password
         x-descriptors:
         - urn:camel:group:credentials
-        - urn:keda:authentication:awsSecretAccessKey
-        - urn:keda:required
       region:
         title: AWS Region
         description: The AWS region to access.
         type: string
-        x-descriptors:
-        - urn:keda:metadata:awsRegion
-        - urn:keda:required
         enum: ["ap-south-1", "eu-south-1", "us-gov-east-1", "me-central-1", "ca-central-1", "eu-central-1", "us-iso-west-1", "us-west-1", "us-west-2", "af-south-1", "eu-north-1", "eu-west-3", "eu-west-2", "eu-west-1", "ap-northeast-3", "ap-northeast-2", "ap-northeast-1", "me-south-1", "sa-east-1", "ap-east-1", "cn-north-1", "us-gov-west-1", "ap-southeast-1", "ap-southeast-2", "us-iso-east-1", "ap-southeast-3", "us-east-1", "us-east-2", "cn-northwest-1", "us-isob-east-1", "aws-global", "aws-cn-global", "aws-us-gov-global", "aws-iso-global", "aws-iso-b-global"]
       autoCreateQueue:
         title: Autocreate Queue
@@ -91,11 +83,8 @@ spec:
         default: https
       queueURL:
         title: Queue URL
-        description: The full SQS Queue URL (required if using KEDA).
+        description: The full SQS Queue URL.
         type: string
-        x-descriptors:
-        - urn:keda:metadata:queueURL
-        - urn:keda:required
       useDefaultCredentialsProvider:
         title: Default Credentials Provider
         description: If true, the SQS client loads credentials through a default credentials provider. If false, it uses the basic authentication method (access key and secret key).

--- a/kamelets/jms-pooled-apache-artemis-sink.kamelet.yaml
+++ b/kamelets/jms-pooled-apache-artemis-sink.kamelet.yaml
@@ -58,21 +58,17 @@ spec:
         type: string
         x-descriptors:
         - urn:camel:group:credentials
-        - urn:keda:authentication:password
-        - urn:keda:required 
       password:
         title: "Broker Password"
         description: "The JMS Broker Password."
         type: string
         x-descriptors:
         - urn:camel:group:credentials
-        - urn:keda:authentication:password
-        - urn:keda:required
       maxSessionsPerConnection:
         title: "Max Sessions Per Connection"
         description: "The maximum number of pooled sessions per connection in the pool."
         type: integer
-        default: 500 
+        default: 500
       maxIdleSessionsPerConnection:
         title: "Max Idle Sessions Per Connection"
         description: "The number of idle sessions allowed per connection before they are closed."
@@ -82,7 +78,7 @@ spec:
         title: "Connection Idle Timeout"
         description: "The maximum time a pooled Connection can sit unused before it is eligible for removal (in milliseconds)."
         type: integer
-        default: 30000     
+        default: 30000
   dependencies:
   - "camel:jms"
   - "camel:kamelet"

--- a/kamelets/jms-pooled-apache-artemis-source.kamelet.yaml
+++ b/kamelets/jms-pooled-apache-artemis-source.kamelet.yaml
@@ -57,16 +57,12 @@ spec:
         type: string
         x-descriptors:
         - urn:camel:group:credentials
-        - urn:keda:authentication:password
-        - urn:keda:required 
       password:
         title: "Broker Password"
         description: "The JMS Broker Password."
         type: string
         x-descriptors:
         - urn:camel:group:credentials
-        - urn:keda:authentication:password
-        - urn:keda:required
       maxSessionsPerConnection:
         title: "Max Session Per Connection"
         description: "The maximum number of pooled sessions per connection in the pool."
@@ -81,7 +77,7 @@ spec:
         title: "Connection Idle Timeout"
         description: "The maximum time a pooled Connection can sit unused before it is eligible for removal (in milliseconds)."
         type: integer
-        default: 30000       
+        default: 30000
   dependencies:
   - "camel:jms"
   - "camel:kamelet"
@@ -101,7 +97,7 @@ spec:
           connectionFactory: '#bean:{{connectionFactoryBean}}'
           maxSessionsPerConnection: "{{maxSessionsPerConnection}}"
           maxIdleSessionsPerConnection: "{{maxIdleSessionsPerConnection}}"
-          connectionIdleTimeout: "{{connectionIdleTimeout}}"        
+          connectionIdleTimeout: "{{connectionIdleTimeout}}"
     from:
       uri: "jms:{{destinationType}}:{{destinationName}}"
       parameters:

--- a/kamelets/kafka-apicurio-registry-not-secured-sink.kamelet.yaml
+++ b/kamelets/kafka-apicurio-registry-not-secured-sink.kamelet.yaml
@@ -54,9 +54,6 @@ spec:
         title: Apicurio Registry URL
         description: The Apicurio Schema Registry URL.
         type: string
-        x-descriptors:
-        - urn:keda:metadata:apicurioRegistryUrl
-        - urn:keda:required
       avroDatumProvider:
         title: Avro Datum Provider
         description: How to write data with Avro.

--- a/kamelets/kafka-apicurio-registry-not-secured-source.kamelet.yaml
+++ b/kamelets/kafka-apicurio-registry-not-secured-source.kamelet.yaml
@@ -25,7 +25,6 @@ metadata:
     camel.apache.org/provider: "Apache Software Foundation"
     camel.apache.org/kamelet.group: "Kafka"
     camel.apache.org/kamelet.namespace: "Kafka"
-    camel.apache.org/keda.type: "kafka"
   labels:
     camel.apache.org/kamelet.type: "source"
 spec:
@@ -42,16 +41,10 @@ spec:
         title: Topic Names
         description: Comma separated list of Kafka topic names
         type: string
-        x-descriptors:
-        - urn:keda:metadata:topic
-        - urn:keda:required
       bootstrapServers:
         title: Bootstrap Servers
         description: Comma separated list of Kafka Broker URLs
         type: string
-        x-descriptors:
-        - urn:keda:metadata:bootstrapServers
-        - urn:keda:required
       autoCommitEnable:
         title: Auto Commit Enable
         description: If true, periodically commit to ZooKeeper the offset of messages already fetched by the consumer
@@ -72,16 +65,11 @@ spec:
         description: What to do when there is no initial offset. There are 3 enums and the value can be one of latest, earliest, none
         type: string
         default: "latest"
-        x-descriptors:
-        - urn:keda:metadata:offsetResetPolicy
       consumerGroup:
         title: Consumer Group
         description: A string that uniquely identifies the group of consumers to which this source belongs
         type: string
         example: "my-group-id"
-        x-descriptors:
-        - urn:keda:metadata:consumerGroup
-        - urn:keda:required
       deserializeHeaders:
         title: Automatically Deserialize Headers
         description: When enabled the Kamelet source will deserialize all message headers to String representation.
@@ -96,9 +84,6 @@ spec:
         title: Apicurio Registry URL
         description: The Apicurio Schema Registry URL
         type: string
-        x-descriptors:
-        - urn:keda:metadata:bootstrapServers
-        - urn:keda:required
       topicIsPattern:
         title: Topic Is Pattern
         description: Whether the topic is a pattern (regular expression). This can be used to subscribe to dynamic number of topics matching the pattern.

--- a/kamelets/kafka-azure-schema-registry-sink.kamelet.yaml
+++ b/kamelets/kafka-azure-schema-registry-sink.kamelet.yaml
@@ -53,7 +53,7 @@ spec:
         default: SASL_SSL
       saslMechanism:
         title: SASL Mechanism
-        description: The Simple Authentication and Security Layer (SASL) Mechanism used. 
+        description: The Simple Authentication and Security Layer (SASL) Mechanism used.
         type: string
         default: PLAIN
       password:
@@ -72,9 +72,6 @@ spec:
         title: Azure Schema Registry URL
         description: The Apicurio Schema Registry URL
         type: string
-        x-descriptors:
-        - urn:keda:metadata:bootstrapServers
-        - urn:keda:required
       specificAvroValueType:
         title: Specific Avro Value Type
         description: The Specific Type Avro will have to deal with

--- a/kamelets/kafka-azure-schema-registry-source.kamelet.yaml
+++ b/kamelets/kafka-azure-schema-registry-source.kamelet.yaml
@@ -25,7 +25,6 @@ metadata:
     camel.apache.org/provider: "Apache Software Foundation"
     camel.apache.org/kamelet.group: "Kafka"
     camel.apache.org/kamelet.namespace: "Kafka"
-    camel.apache.org/keda.type: "kafka"
   labels:
     camel.apache.org/kamelet.type: "source"
 spec:
@@ -43,16 +42,10 @@ spec:
         title: Topic Names
         description: Comma separated list of Kafka topic names
         type: string
-        x-descriptors:
-        - urn:keda:metadata:topic
-        - urn:keda:required
       bootstrapServers:
         title: Bootstrap Servers
         description: Comma separated list of Kafka Broker URLs
         type: string
-        x-descriptors:
-        - urn:keda:metadata:bootstrapServers
-        - urn:keda:required
       securityProtocol:
         title: Security Protocol
         description: Protocol used to communicate with brokers. SASL_PLAINTEXT, PLAINTEXT, SASL_SSL and SSL are supported
@@ -70,8 +63,6 @@ spec:
         format: password
         x-descriptors:
         - urn:camel:group:credentials
-        - urn:keda:authentication:password
-        - urn:keda:required
       autoCommitEnable:
         title: Auto Commit Enable
         description: If true, periodically commit to ZooKeeper the offset of messages already fetched by the consumer
@@ -92,16 +83,11 @@ spec:
         description: What to do when there is no initial offset. There are 3 enums and the value can be one of latest, earliest, none
         type: string
         default: "latest"
-        x-descriptors:
-        - urn:keda:metadata:offsetResetPolicy
       consumerGroup:
         title: Consumer Group
         description: A string that uniquely identifies the group of consumers to which this source belongs
         type: string
         example: "my-group-id"
-        x-descriptors:
-        - urn:keda:metadata:consumerGroup
-        - urn:keda:required
       deserializeHeaders:
         title: Automatically Deserialize Headers
         description: When enabled the Kamelet source will deserialize all message headers to String representation.
@@ -116,9 +102,6 @@ spec:
         title: Azure Schema Registry URL
         description: The Apicurio Schema Registry URL
         type: string
-        x-descriptors:
-        - urn:keda:metadata:bootstrapServers
-        - urn:keda:required
       specificAvroValueType:
         title: Specific Avro Value Type
         description: The Specific Type Avro will have to deal with

--- a/kamelets/kafka-batch-apicurio-registry-not-secured-source.kamelet.yaml
+++ b/kamelets/kafka-batch-apicurio-registry-not-secured-source.kamelet.yaml
@@ -25,7 +25,6 @@ metadata:
     camel.apache.org/provider: "Apache Software Foundation"
     camel.apache.org/kamelet.group: "Kafka"
     camel.apache.org/kamelet.namespace: "Kafka"
-    camel.apache.org/keda.type: "kafka"
   labels:
     camel.apache.org/kamelet.type: "source"
 spec:
@@ -42,16 +41,10 @@ spec:
         title: Topic Names
         description: Comma separated list of Kafka topic names.
         type: string
-        x-descriptors:
-        - urn:keda:metadata:topic
-        - urn:keda:required
       bootstrapServers:
         title: Bootstrap Servers
         description: Comma separated list of Kafka Broker URLs.
         type: string
-        x-descriptors:
-        - urn:keda:metadata:bootstrapServers
-        - urn:keda:required
       autoCommitEnable:
         title: Auto Commit Enable
         description: If true, periodically commit to ZooKeeper the offset of messages already fetched by the consumer.
@@ -72,16 +65,11 @@ spec:
         description: What to do when there is no initial offset. There are 3 enums and the value can be one of `latest`, `earliest`, `none`.
         type: string
         default: "latest"
-        x-descriptors:
-        - urn:keda:metadata:offsetResetPolicy
       consumerGroup:
         title: Consumer Group
         description: A string that uniquely identifies the group of consumers to which this source belongs.
         type: string
         example: "my-group-id"
-        x-descriptors:
-        - urn:keda:metadata:consumerGroup
-        - urn:keda:required
       deserializeHeaders:
         title: Automatically Deserialize Headers
         description: When enabled the Kamelet source will deserialize all message headers to String representation.
@@ -96,9 +84,6 @@ spec:
         title: Apicurio Registry URL
         description: The Apicurio Schema Registry URL.
         type: string
-        x-descriptors:
-        - urn:keda:metadata:bootstrapServers
-        - urn:keda:required
       avroDatumProvider:
         title: Avro Datum Provider
         description: How to read data with Avro.

--- a/kamelets/kafka-batch-apicurio-registry-source.kamelet.yaml
+++ b/kamelets/kafka-batch-apicurio-registry-source.kamelet.yaml
@@ -25,7 +25,6 @@ metadata:
     camel.apache.org/provider: "Apache Software Foundation"
     camel.apache.org/kamelet.group: "Kafka"
     camel.apache.org/kamelet.namespace: "Kafka"
-    camel.apache.org/keda.type: "kafka"
   labels:
     camel.apache.org/kamelet.type: "source"
 spec:
@@ -48,16 +47,10 @@ spec:
         title: Topic Names
         description: Comma separated list of Kafka topic names
         type: string
-        x-descriptors:
-        - urn:keda:metadata:topic
-        - urn:keda:required
       bootstrapServers:
         title: Bootstrap Servers
         description: Comma separated list of Kafka Broker URLs
         type: string
-        x-descriptors:
-        - urn:keda:metadata:bootstrapServers
-        - urn:keda:required
       autoCommitEnable:
         title: Auto Commit Enable
         description: If true, periodically commit to ZooKeeper the offset of messages already fetched by the consumer
@@ -78,16 +71,11 @@ spec:
         description: What to do when there is no initial offset. There are 3 enums and the value can be one of latest, earliest, none
         type: string
         default: "latest"
-        x-descriptors:
-        - urn:keda:metadata:offsetResetPolicy
       consumerGroup:
         title: Consumer Group
         description: A string that uniquely identifies the group of consumers to which this source belongs
         type: string
         example: "my-group-id"
-        x-descriptors:
-        - urn:keda:metadata:consumerGroup
-        - urn:keda:required
       deserializeHeaders:
         title: Automatically Deserialize Headers
         description: When enabled the Kamelet source will deserialize all message headers to String representation.
@@ -102,9 +90,6 @@ spec:
         title: Apicurio Registry URL
         description: The Apicurio Schema Registry URL
         type: string
-        x-descriptors:
-        - urn:keda:metadata:bootstrapServers
-        - urn:keda:required
       avroDatumProvider:
         title: Avro Datum Provider
         description: How to read data with Avro
@@ -148,8 +133,6 @@ spec:
         format: password
         x-descriptors:
         - urn:camel:group:credentials
-        - urn:keda:authentication:password
-        - urn:keda:required
       apicurioAuthUsername:
         title: Apicurio Registry Auth Username
         description: The Username in Keycloak instance securing the Apicurio Registry
@@ -161,8 +144,6 @@ spec:
         format: password
         x-descriptors:
         - urn:camel:group:credentials
-        - urn:keda:authentication:password
-        - urn:keda:required
       topicIsPattern:
         title: Topic Is Pattern
         description: Whether the topic is a pattern (regular expression). This can be used to subscribe to dynamic number of topics matching the pattern.

--- a/kamelets/kafka-batch-azure-schema-registry-source.kamelet.yaml
+++ b/kamelets/kafka-batch-azure-schema-registry-source.kamelet.yaml
@@ -25,7 +25,6 @@ metadata:
     camel.apache.org/provider: "Apache Software Foundation"
     camel.apache.org/kamelet.group: "Kafka"
     camel.apache.org/kamelet.namespace: "Kafka"
-    camel.apache.org/keda.type: "kafka"
   labels:
     camel.apache.org/kamelet.type: "source"
 spec:
@@ -43,16 +42,10 @@ spec:
         title: Topic Names
         description: Comma separated list of Kafka topic names
         type: string
-        x-descriptors:
-        - urn:keda:metadata:topic
-        - urn:keda:required
       bootstrapServers:
         title: Bootstrap Servers
         description: Comma separated list of Kafka Broker URLs
         type: string
-        x-descriptors:
-        - urn:keda:metadata:bootstrapServers
-        - urn:keda:required
       securityProtocol:
         title: Security Protocol
         description: Protocol used to communicate with brokers. SASL_PLAINTEXT, PLAINTEXT, SASL_SSL and SSL are supported
@@ -70,8 +63,6 @@ spec:
         format: password
         x-descriptors:
         - urn:camel:group:credentials
-        - urn:keda:authentication:password
-        - urn:keda:required
       autoCommitEnable:
         title: Auto Commit Enable
         description: If true, periodically commit to ZooKeeper the offset of messages already fetched by the consumer
@@ -92,16 +83,11 @@ spec:
         description: What to do when there is no initial offset. There are 3 enums and the value can be one of latest, earliest, none
         type: string
         default: "latest"
-        x-descriptors:
-        - urn:keda:metadata:offsetResetPolicy
       consumerGroup:
         title: Consumer Group
         description: A string that uniquely identifies the group of consumers to which this source belongs
         type: string
         example: "my-group-id"
-        x-descriptors:
-        - urn:keda:metadata:consumerGroup
-        - urn:keda:required
       deserializeHeaders:
         title: Automatically Deserialize Headers
         description: When enabled the Kamelet source will deserialize all message headers to String representation.
@@ -116,9 +102,6 @@ spec:
         title: Azure Schema Registry URL
         description: The Apicurio Schema Registry URL
         type: string
-        x-descriptors:
-        - urn:keda:metadata:bootstrapServers
-        - urn:keda:required
       specificAvroValueType:
         title: Specific Avro Value Type
         description: The Specific Type Avro will have to deal with

--- a/kamelets/kafka-batch-not-secured-source.kamelet.yaml
+++ b/kamelets/kafka-batch-not-secured-source.kamelet.yaml
@@ -25,7 +25,6 @@ metadata:
     camel.apache.org/provider: "Apache Software Foundation"
     camel.apache.org/kamelet.group: "Kafka"
     camel.apache.org/kamelet.namespace: "Kafka"
-    camel.apache.org/keda.type: "kafka"
   labels:
     camel.apache.org/kamelet.type: "source"
 spec:
@@ -41,16 +40,10 @@ spec:
         title: Topic Names
         description: Comma separated list of Kafka topic names
         type: string
-        x-descriptors:
-        - urn:keda:metadata:topic
-        - urn:keda:required
       bootstrapServers:
         title: Bootstrap Servers
         description: Comma separated list of Kafka Broker URLs
         type: string
-        x-descriptors:
-        - urn:keda:metadata:bootstrapServers
-        - urn:keda:required
       autoCommitEnable:
         title: Auto Commit Enable
         description: If true, periodically commit to ZooKeeper the offset of messages already fetched by the consumer
@@ -71,16 +64,11 @@ spec:
         description: What to do when there is no initial offset. There are 3 enums and the value can be one of latest, earliest, none
         type: string
         default: "latest"
-        x-descriptors:
-        - urn:keda:metadata:offsetResetPolicy
       consumerGroup:
         title: Consumer Group
         description: A string that uniquely identifies the group of consumers to which this source belongs
         type: string
         example: "my-group-id"
-        x-descriptors:
-        - urn:keda:metadata:consumerGroup
-        - urn:keda:required
       deserializeHeaders:
         title: Automatically Deserialize Headers
         description: When enabled the Kamelet source will deserialize all message headers to String representation.

--- a/kamelets/kafka-batch-scram-source.kamelet.yaml
+++ b/kamelets/kafka-batch-scram-source.kamelet.yaml
@@ -25,9 +25,6 @@ metadata:
     camel.apache.org/provider: "Apache Software Foundation"
     camel.apache.org/kamelet.group: "Kafka"
     camel.apache.org/kamelet.namespace: "Kafka"
-    camel.apache.org/keda.type: "kafka"
-    camel.apache.org/keda.authentication.sasl: "scram-sha-512"
-    camel.apache.org/keda.authentication.tls: "enable"
   labels:
     camel.apache.org/kamelet.type: "source"
 spec:
@@ -45,16 +42,10 @@ spec:
         title: Topic Names
         description: Comma separated list of Kafka topic names
         type: string
-        x-descriptors:
-        - urn:keda:metadata:topic
-        - urn:keda:required
       bootstrapServers:
         title: Bootstrap Servers
         description: Comma separated list of Kafka Broker URLs
         type: string
-        x-descriptors:
-        - urn:keda:metadata:bootstrapServers
-        - urn:keda:required
       securityProtocol:
         title: Security Protocol
         description: Protocol used to communicate with brokers. SASL_PLAINTEXT, PLAINTEXT, SASL_SSL and SSL are supported
@@ -71,8 +62,6 @@ spec:
         type: string
         x-descriptors:
         - urn:camel:group:credentials
-        - urn:keda:authentication:username
-        - urn:keda:required
       password:
         title: Password
         description: Password to authenticate to kafka
@@ -80,8 +69,6 @@ spec:
         format: password
         x-descriptors:
         - urn:camel:group:credentials
-        - urn:keda:authentication:password
-        - urn:keda:required
       autoCommitEnable:
         title: Auto Commit Enable
         description: If true, periodically commit to ZooKeeper the offset of messages already fetched by the consumer
@@ -102,16 +89,11 @@ spec:
         description: What to do when there is no initial offset. There are 3 enums and the value can be one of latest, earliest, none
         type: string
         default: "latest"
-        x-descriptors:
-        - urn:keda:metadata:offsetResetPolicy
       consumerGroup:
         title: Consumer Group
         description: A string that uniquely identifies the group of consumers to which this source belongs
         type: string
         example: "my-group-id"
-        x-descriptors:
-        - urn:keda:metadata:consumerGroup
-        - urn:keda:required
       deserializeHeaders:
         title: Automatically Deserialize Headers
         description: When enabled the Kamelet source will deserialize all message headers to String representation.

--- a/kamelets/kafka-batch-source.kamelet.yaml
+++ b/kamelets/kafka-batch-source.kamelet.yaml
@@ -25,9 +25,6 @@ metadata:
     camel.apache.org/provider: "Apache Software Foundation"
     camel.apache.org/kamelet.group: "Kafka"
     camel.apache.org/kamelet.namespace: "Kafka"
-    camel.apache.org/keda.type: "kafka"
-    camel.apache.org/keda.authentication.sasl: "plaintext"
-    camel.apache.org/keda.authentication.tls: "enable"
   labels:
     camel.apache.org/kamelet.type: "source"
 spec:
@@ -45,16 +42,10 @@ spec:
         title: Topic Names
         description: Comma separated list of Kafka topic names
         type: string
-        x-descriptors:
-        - urn:keda:metadata:topic
-        - urn:keda:required
       bootstrapServers:
         title: Bootstrap Servers
         description: Comma separated list of Kafka Broker URLs
         type: string
-        x-descriptors:
-        - urn:keda:metadata:bootstrapServers
-        - urn:keda:required
       securityProtocol:
         title: Security Protocol
         description: Protocol used to communicate with brokers. SASL_PLAINTEXT, PLAINTEXT, SASL_SSL and SSL are supported
@@ -71,8 +62,6 @@ spec:
         type: string
         x-descriptors:
         - urn:camel:group:credentials
-        - urn:keda:authentication:username
-        - urn:keda:required
       password:
         title: Password
         description: Password to authenticate to kafka
@@ -80,8 +69,6 @@ spec:
         format: password
         x-descriptors:
         - urn:camel:group:credentials
-        - urn:keda:authentication:password
-        - urn:keda:required
       autoCommitEnable:
         title: Auto Commit Enable
         description: If true, periodically commit to ZooKeeper the offset of messages already fetched by the consumer
@@ -102,16 +89,11 @@ spec:
         description: What to do when there is no initial offset. There are 3 enums and the value can be one of latest, earliest, none
         type: string
         default: "latest"
-        x-descriptors:
-        - urn:keda:metadata:offsetResetPolicy
       consumerGroup:
         title: Consumer Group
         description: A string that uniquely identifies the group of consumers to which this source belongs
         type: string
         example: "my-group-id"
-        x-descriptors:
-        - urn:keda:metadata:consumerGroup
-        - urn:keda:required
       deserializeHeaders:
         title: Automatically Deserialize Headers
         description: When enabled the Kamelet source will deserialize all message headers to String representation.
@@ -169,8 +151,8 @@ spec:
         maxPollIntervalMs: "{{?maxPollIntervalMs}}"
         batchingIntervalMs: "{{?batchingIntervalMs}}"
         batching: true
-        kafkaManualCommitFactory: "#bean:{{manualCommitFactory}}"      
-        topicIsPattern: "{{topicIsPattern}}"  
+        kafkaManualCommitFactory: "#bean:{{manualCommitFactory}}"
+        topicIsPattern: "{{topicIsPattern}}"
       steps:
         - process:
             ref: "{{kafkaHeaderDeserializer}}"

--- a/kamelets/kafka-batch-ssl-source.kamelet.yaml
+++ b/kamelets/kafka-batch-ssl-source.kamelet.yaml
@@ -42,16 +42,10 @@ spec:
         title: Topic Names
         description: Comma separated list of Kafka topic names
         type: string
-        x-descriptors:
-          - urn:keda:metadata:topic
-          - urn:keda:required
       bootstrapServers:
         title: Bootstrap Servers
         description: Comma separated list of Kafka Broker URLs
         type: string
-        x-descriptors:
-          - urn:keda:metadata:bootstrapServers
-          - urn:keda:required
       securityProtocol:
         title: Security Protocol
         description: Protocol used to communicate with brokers. SASL_PLAINTEXT, PLAINTEXT, SASL_SSL and SSL are supported
@@ -82,16 +76,11 @@ spec:
         description: What to do when there is no initial offset. There are 3 enums and the value can be one of latest, earliest, none
         type: string
         default: "latest"
-        x-descriptors:
-          - urn:keda:metadata:offsetResetPolicy
       consumerGroup:
         title: Consumer Group
         description: A string that uniquely identifies the group of consumers to which this source belongs
         type: string
         example: "my-group-id"
-        x-descriptors:
-          - urn:keda:metadata:consumerGroup
-          - urn:keda:required
       deserializeHeaders:
         title: Automatically Deserialize Headers
         description: When enabled the Kamelet source will deserialize all message headers to String representation.
@@ -104,16 +93,11 @@ spec:
         format: password
         x-descriptors:
           - urn:camel:group:credentials
-          - urn:keda:authentication:password
-          - urn:keda:required
       sslKeystorePassword:
         description: The store password for the key store file.This is optional for client and only needed if ssl.keystore.location is configured.
         title: SSL Keystore Password
         type: string
         format: password
-        x-descriptors:
-          - urn:camel:group:credentials
-          - urn:keda:authentication:password
       sslEndpointAlgorithm:
         description: The endpoint identification algorithm to validate server hostname using server certificate. Use none or false to disable server hostname verification.
         title: SSL Endpoint Algorithm

--- a/kamelets/kafka-not-secured-apicurio-registry-json-source.kamelet.yaml
+++ b/kamelets/kafka-not-secured-apicurio-registry-json-source.kamelet.yaml
@@ -25,7 +25,6 @@ metadata:
     camel.apache.org/provider: "Apache Software Foundation"
     camel.apache.org/kamelet.group: "Kafka"
     camel.apache.org/kamelet.namespace: "Kafka"
-    camel.apache.org/keda.type: "kafka"
   labels:
     camel.apache.org/kamelet.type: "source"
 spec:
@@ -48,16 +47,10 @@ spec:
         title: Topic Names
         description: Comma separated list of Kafka topic names
         type: string
-        x-descriptors:
-        - urn:keda:metadata:topic
-        - urn:keda:required
       bootstrapServers:
         title: Bootstrap Servers
         description: Comma separated list of Kafka Broker URLs
         type: string
-        x-descriptors:
-        - urn:keda:metadata:bootstrapServers
-        - urn:keda:required
       autoCommitEnable:
         title: Auto Commit Enable
         description: If true, periodically commit to ZooKeeper the offset of messages already fetched by the consumer
@@ -78,16 +71,11 @@ spec:
         description: What to do when there is no initial offset. There are 3 enums and the value can be one of latest, earliest, none
         type: string
         default: "latest"
-        x-descriptors:
-        - urn:keda:metadata:offsetResetPolicy
       consumerGroup:
         title: Consumer Group
         description: A string that uniquely identifies the group of consumers to which this source belongs
         type: string
         example: "my-group-id"
-        x-descriptors:
-        - urn:keda:metadata:consumerGroup
-        - urn:keda:required
       deserializeHeaders:
         title: Automatically Deserialize Headers
         description: When enabled the Kamelet source will deserialize all message headers to String representation.
@@ -102,9 +90,6 @@ spec:
         title: Apicurio Registry URL
         description: The Apicurio Schema Registry URL
         type: string
-        x-descriptors:
-        - urn:keda:metadata:bootstrapServers
-        - urn:keda:required
       apicurioAuthServiceUrl:
         title: Apicurio Registry Auth Service URL
         description: The URL for Keycloak instance securing the Apicurio Registry
@@ -125,8 +110,6 @@ spec:
         format: password
         x-descriptors:
         - urn:camel:group:credentials
-        - urn:keda:authentication:password
-        - urn:keda:required
       apicurioAuthUsername:
         title: Apicurio Registry Auth Username
         description: The Username in Keycloak instance securing the Apicurio Registry
@@ -138,8 +121,6 @@ spec:
         format: password
         x-descriptors:
         - urn:camel:group:credentials
-        - urn:keda:authentication:password
-        - urn:keda:required
       topicIsPattern:
         title: Topic Is Pattern
         description: Whether the topic is a pattern (regular expression). This can be used to subscribe to dynamic number of topics matching the pattern.

--- a/kamelets/kafka-not-secured-apicurio-registry-sink.kamelet.yaml
+++ b/kamelets/kafka-not-secured-apicurio-registry-sink.kamelet.yaml
@@ -60,9 +60,6 @@ spec:
         title: Apicurio Registry URL
         description: The Apicurio Schema Registry URL
         type: string
-        x-descriptors:
-        - urn:keda:metadata:apicurioRegistryUrl
-        - urn:keda:required
       avroDatumProvider:
         title: Avro Datum Provider
         description: How to write data with Avro
@@ -88,8 +85,6 @@ spec:
         format: password
         x-descriptors:
         - urn:camel:group:credentials
-        - urn:keda:authentication:password
-        - urn:keda:required
       apicurioAuthUsername:
         title: Apicurio Registry Auth Username
         description: The Username in Keycloak instance securing the Apicurio Registry
@@ -101,8 +96,6 @@ spec:
         format: password
         x-descriptors:
         - urn:camel:group:credentials
-        - urn:keda:authentication:password
-        - urn:keda:required
   dependencies:
     - "camel:core"
     - "camel:kamelet"

--- a/kamelets/kafka-not-secured-apicurio-registry-source.kamelet.yaml
+++ b/kamelets/kafka-not-secured-apicurio-registry-source.kamelet.yaml
@@ -25,7 +25,6 @@ metadata:
     camel.apache.org/provider: "Apache Software Foundation"
     camel.apache.org/kamelet.group: "Kafka"
     camel.apache.org/kamelet.namespace: "Kafka"
-    camel.apache.org/keda.type: "kafka"
   labels:
     camel.apache.org/kamelet.type: "source"
 spec:
@@ -48,16 +47,10 @@ spec:
         title: Topic Names
         description: Comma separated list of Kafka topic names
         type: string
-        x-descriptors:
-        - urn:keda:metadata:topic
-        - urn:keda:required
       bootstrapServers:
         title: Bootstrap Servers
         description: Comma separated list of Kafka Broker URLs
         type: string
-        x-descriptors:
-        - urn:keda:metadata:bootstrapServers
-        - urn:keda:required
       autoCommitEnable:
         title: Auto Commit Enable
         description: If true, periodically commit to ZooKeeper the offset of messages already fetched by the consumer
@@ -78,16 +71,11 @@ spec:
         description: What to do when there is no initial offset. There are 3 enums and the value can be one of latest, earliest, none
         type: string
         default: "latest"
-        x-descriptors:
-        - urn:keda:metadata:offsetResetPolicy
       consumerGroup:
         title: Consumer Group
         description: A string that uniquely identifies the group of consumers to which this source belongs
         type: string
         example: "my-group-id"
-        x-descriptors:
-        - urn:keda:metadata:consumerGroup
-        - urn:keda:required
       deserializeHeaders:
         title: Automatically Deserialize Headers
         description: When enabled the Kamelet source will deserialize all message headers to String representation.
@@ -102,9 +90,6 @@ spec:
         title: Apicurio Registry URL
         description: The Apicurio Schema Registry URL
         type: string
-        x-descriptors:
-        - urn:keda:metadata:bootstrapServers
-        - urn:keda:required
       avroDatumProvider:
         title: Avro Datum Provider
         description: How to read data with Avro
@@ -130,8 +115,6 @@ spec:
         format: password
         x-descriptors:
         - urn:camel:group:credentials
-        - urn:keda:authentication:password
-        - urn:keda:required
       apicurioAuthUsername:
         title: Apicurio Registry Auth Username
         description: The Username in Keycloak instance securing the Apicurio Registry
@@ -143,8 +126,6 @@ spec:
         format: password
         x-descriptors:
         - urn:camel:group:credentials
-        - urn:keda:authentication:password
-        - urn:keda:required
       topicIsPattern:
         title: Topic Is Pattern
         description: Whether the topic is a pattern (regular expression). This can be used to subscribe to dynamic number of topics matching the pattern.

--- a/kamelets/kafka-not-secured-source.kamelet.yaml
+++ b/kamelets/kafka-not-secured-source.kamelet.yaml
@@ -25,7 +25,6 @@ metadata:
     camel.apache.org/provider: "Apache Software Foundation"
     camel.apache.org/kamelet.group: "Kafka"
     camel.apache.org/kamelet.namespace: "Kafka"
-    camel.apache.org/keda.type: "kafka"
   labels:
     camel.apache.org/kamelet.type: "source"
 spec:
@@ -41,16 +40,10 @@ spec:
         title: Topic Names
         description: Comma separated list of Kafka topic names
         type: string
-        x-descriptors:
-        - urn:keda:metadata:topic
-        - urn:keda:required
       bootstrapServers:
         title: Bootstrap Servers
         description: Comma separated list of Kafka Broker URLs
         type: string
-        x-descriptors:
-        - urn:keda:metadata:bootstrapServers
-        - urn:keda:required
       autoCommitEnable:
         title: Auto Commit Enable
         description: If true, periodically commit to ZooKeeper the offset of messages already fetched by the consumer
@@ -71,16 +64,11 @@ spec:
         description: What to do when there is no initial offset. There are 3 enums and the value can be one of latest, earliest, none
         type: string
         default: "latest"
-        x-descriptors:
-        - urn:keda:metadata:offsetResetPolicy
       consumerGroup:
         title: Consumer Group
         description: A string that uniquely identifies the group of consumers to which this source belongs
         type: string
         example: "my-group-id"
-        x-descriptors:
-        - urn:keda:metadata:consumerGroup
-        - urn:keda:required
       deserializeHeaders:
         title: Automatically Deserialize Headers
         description: When enabled the Kamelet source will deserialize all message headers to String representation.

--- a/kamelets/kafka-scram-source.kamelet.yaml
+++ b/kamelets/kafka-scram-source.kamelet.yaml
@@ -25,9 +25,6 @@ metadata:
     camel.apache.org/provider: "Apache Software Foundation"
     camel.apache.org/kamelet.group: "Kafka"
     camel.apache.org/kamelet.namespace: "Kafka"
-    camel.apache.org/keda.type: "kafka"
-    camel.apache.org/keda.authentication.sasl: "scram-sha-512"
-    camel.apache.org/keda.authentication.tls: "enable"
   labels:
     camel.apache.org/kamelet.type: "source"
 spec:
@@ -45,16 +42,10 @@ spec:
         title: Topic Names
         description: Comma separated list of Kafka topic names
         type: string
-        x-descriptors:
-        - urn:keda:metadata:topic
-        - urn:keda:required
       bootstrapServers:
         title: Bootstrap Servers
         description: Comma separated list of Kafka Broker URLs
         type: string
-        x-descriptors:
-        - urn:keda:metadata:bootstrapServers
-        - urn:keda:required
       securityProtocol:
         title: Security Protocol
         description: Protocol used to communicate with brokers. SASL_PLAINTEXT, PLAINTEXT, SASL_SSL and SSL are supported
@@ -71,8 +62,6 @@ spec:
         type: string
         x-descriptors:
         - urn:camel:group:credentials
-        - urn:keda:authentication:username
-        - urn:keda:required
       password:
         title: Password
         description: Password to authenticate to kafka
@@ -80,8 +69,6 @@ spec:
         format: password
         x-descriptors:
         - urn:camel:group:credentials
-        - urn:keda:authentication:password
-        - urn:keda:required
       autoCommitEnable:
         title: Auto Commit Enable
         description: If true, periodically commit to ZooKeeper the offset of messages already fetched by the consumer
@@ -102,16 +89,11 @@ spec:
         description: What to do when there is no initial offset. There are 3 enums and the value can be one of latest, earliest, none
         type: string
         default: "latest"
-        x-descriptors:
-        - urn:keda:metadata:offsetResetPolicy
       consumerGroup:
         title: Consumer Group
         description: A string that uniquely identifies the group of consumers to which this source belongs
         type: string
         example: "my-group-id"
-        x-descriptors:
-        - urn:keda:metadata:consumerGroup
-        - urn:keda:required
       deserializeHeaders:
         title: Automatically Deserialize Headers
         description: When enabled the Kamelet source will deserialize all message headers to String representation.

--- a/kamelets/kafka-source.kamelet.yaml
+++ b/kamelets/kafka-source.kamelet.yaml
@@ -25,9 +25,6 @@ metadata:
     camel.apache.org/provider: "Apache Software Foundation"
     camel.apache.org/kamelet.group: "Kafka"
     camel.apache.org/kamelet.namespace: "Kafka"
-    camel.apache.org/keda.type: "kafka"
-    camel.apache.org/keda.authentication.sasl: "plaintext"
-    camel.apache.org/keda.authentication.tls: "enable"
   labels:
     camel.apache.org/kamelet.type: "source"
 spec:
@@ -45,16 +42,10 @@ spec:
         title: Topic Names
         description: Comma separated list of Kafka topic names
         type: string
-        x-descriptors:
-        - urn:keda:metadata:topic
-        - urn:keda:required
       bootstrapServers:
         title: Bootstrap Servers
         description: Comma separated list of Kafka Broker URLs
         type: string
-        x-descriptors:
-        - urn:keda:metadata:bootstrapServers
-        - urn:keda:required
       securityProtocol:
         title: Security Protocol
         description: Protocol used to communicate with brokers. SASL_PLAINTEXT, PLAINTEXT, SASL_SSL and SSL are supported
@@ -71,8 +62,6 @@ spec:
         type: string
         x-descriptors:
         - urn:camel:group:credentials
-        - urn:keda:authentication:username
-        - urn:keda:required
       password:
         title: Password
         description: Password to authenticate to kafka
@@ -80,8 +69,6 @@ spec:
         format: password
         x-descriptors:
         - urn:camel:group:credentials
-        - urn:keda:authentication:password
-        - urn:keda:required
       autoCommitEnable:
         title: Auto Commit Enable
         description: If true, periodically commit to ZooKeeper the offset of messages already fetched by the consumer
@@ -102,16 +89,11 @@ spec:
         description: What to do when there is no initial offset. There are 3 enums and the value can be one of latest, earliest, none
         type: string
         default: "latest"
-        x-descriptors:
-        - urn:keda:metadata:offsetResetPolicy
       consumerGroup:
         title: Consumer Group
         description: A string that uniquely identifies the group of consumers to which this source belongs
         type: string
         example: "my-group-id"
-        x-descriptors:
-        - urn:keda:metadata:consumerGroup
-        - urn:keda:required
       deserializeHeaders:
         title: Automatically Deserialize Headers
         description: When enabled the Kamelet source will deserialize all message headers to String representation.

--- a/kamelets/kafka-ssl-source.kamelet.yaml
+++ b/kamelets/kafka-ssl-source.kamelet.yaml
@@ -43,16 +43,10 @@ spec:
         title: Topic Names
         description: Comma separated list of Kafka topic names.
         type: string
-        x-descriptors:
-          - urn:keda:metadata:topic
-          - urn:keda:required
       bootstrapServers:
         title: Bootstrap Servers
         description: Comma separated list of Kafka Broker URLs.
         type: string
-        x-descriptors:
-          - urn:keda:metadata:bootstrapServers
-          - urn:keda:required
       securityProtocol:
         title: Security Protocol
         description: Protocol used to communicate with brokers. `SASL_PLAINTEXT`, `PLAINTEXT`, `SASL_SSL` and `SSL` are supported.
@@ -83,16 +77,11 @@ spec:
         description: What to do when there is no initial offset. There are 3 enums and the value can be one of latest, earliest, none.
         type: string
         default: "latest"
-        x-descriptors:
-          - urn:keda:metadata:offsetResetPolicy
       consumerGroup:
         title: Consumer Group
         description: A string that uniquely identifies the group of consumers to which this source belongs.
         type: string
         example: "my-group-id"
-        x-descriptors:
-          - urn:keda:metadata:consumerGroup
-          - urn:keda:required
       deserializeHeaders:
         title: Automatically Deserialize Headers
         description: When enabled the Kamelet source will deserialize all message headers to String representation.
@@ -103,10 +92,6 @@ spec:
         title: SSL Key Password
         type: string
         format: password
-        x-descriptors:
-          - urn:camel:group:credentials
-          - urn:keda:authentication:password
-          - urn:keda:required
       sslKeystorePassword:
         description: The store password for the key store file.This is optional for client and only needed if ssl.keystore.location is configured.
         title: SSL Keystore Password
@@ -114,7 +99,6 @@ spec:
         format: password
         x-descriptors:
           - urn:camel:group:credentials
-          - urn:keda:authentication:password
       sslEndpointAlgorithm:
         description: The endpoint identification algorithm to validate server hostname using server certificate. Use none or false to disable server hostname verification.
         title: SSL Endpoint Algorithm
@@ -140,7 +124,6 @@ spec:
         format: password
         x-descriptors:
           - urn:camel:group:credentials
-          - urn:keda:authentication:password
       sslEnabledProtocols:
         description:   The list of protocols enabled for SSL connections. TLSv1.2, TLSv1.1 and TLSv1 are enabled by default.
         title: SSL Enabled Protocols

--- a/library/camel-kamelets/src/main/resources/kamelets/aws-s3-event-based-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/aws-s3-event-based-source.kamelet.yaml
@@ -27,7 +27,6 @@ metadata:
     camel.apache.org/provider: Apache Software Foundation
     camel.apache.org/kamelet.group: AWS S3 Event-Based
     camel.apache.org/kamelet.namespace: "AWS"
-    camel.apache.org/keda.type: aws-s3-event-based-queue
   labels:
     camel.apache.org/kamelet.type: "source"
 spec:
@@ -57,8 +56,6 @@ spec:
         format: password
         x-descriptors:
           - 'urn:camel:group:credentials'
-          - 'urn:keda:authentication:awsAccessKeyID'
-          - 'urn:keda:required'
       secretKey:
         title: Secret Key
         description: The secret key obtained from AWS.
@@ -66,15 +63,10 @@ spec:
         format: password
         x-descriptors:
           - 'urn:camel:group:credentials'
-          - 'urn:keda:authentication:awsSecretAccessKey'
-          - 'urn:keda:required'
       region:
         title: AWS Region
         description: The AWS region to access.
         type: string
-        x-descriptors:
-          - 'urn:keda:metadata:awsRegion'
-          - 'urn:keda:required'
         enum:
           - ap-south-1
           - eu-south-1
@@ -129,11 +121,8 @@ spec:
         default: https
       queueURL:
         title: Queue URL
-        description: The full SQS Queue URL (required if using KEDA)
+        description: The full SQS Queue URL
         type: string
-        x-descriptors:
-          - 'urn:keda:metadata:queueURL'
-          - 'urn:keda:required'
       uriEndpointOverride:
         title: Overwrite Endpoint URI
         description: >-

--- a/library/camel-kamelets/src/main/resources/kamelets/aws-sqs-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/aws-sqs-source.kamelet.yaml
@@ -25,7 +25,6 @@ metadata:
     camel.apache.org/kamelet.icon: "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9Im5vIj8+CjxzdmcKICAgeG1sbnM6ZGM9Imh0dHA6Ly9wdXJsLm9yZy9kYy9lbGVtZW50cy8xLjEvIgogICB4bWxuczpjYz0iaHR0cDovL2NyZWF0aXZlY29tbW9ucy5vcmcvbnMjIgogICB4bWxuczpyZGY9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkvMDIvMjItcmRmLXN5bnRheC1ucyMiCiAgIHhtbG5zOnN2Zz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciCiAgIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIKICAgeG1sbnM6c29kaXBvZGk9Imh0dHA6Ly9zb2RpcG9kaS5zb3VyY2Vmb3JnZS5uZXQvRFREL3NvZGlwb2RpLTAuZHRkIgogICB4bWxuczppbmtzY2FwZT0iaHR0cDovL3d3dy5pbmtzY2FwZS5vcmcvbmFtZXNwYWNlcy9pbmtzY2FwZSIKICAgZW5hYmxlLWJhY2tncm91bmQ9Im5ldyAwIDAgMTAwIDEwMCIKICAgaGVpZ2h0PSI3Mi4xOTk5OTciCiAgIHZlcnNpb249IjEuMSIKICAgdmlld0JveD0iMCAwIDU5Ljg0OTk5OCA3Mi4xOTk5OTciCiAgIHdpZHRoPSI1OS44NDk5OTgiCiAgIHhtbDpzcGFjZT0icHJlc2VydmUiCiAgIGlkPSJzdmcxNDUiCiAgIHNvZGlwb2RpOmRvY25hbWU9ImRvd25sb2FkLnN2ZyIKICAgaW5rc2NhcGU6dmVyc2lvbj0iMS4wLjIgKGU4NmM4NzA4NzksIDIwMjEtMDEtMTUpIj48bWV0YWRhdGEKICAgICBpZD0ibWV0YWRhdGExNTEiPjxyZGY6UkRGPjxjYzpXb3JrCiAgICAgICAgIHJkZjphYm91dD0iIj48ZGM6Zm9ybWF0PmltYWdlL3N2Zyt4bWw8L2RjOmZvcm1hdD48ZGM6dHlwZQogICAgICAgICAgIHJkZjpyZXNvdXJjZT0iaHR0cDovL3B1cmwub3JnL2RjL2RjbWl0eXBlL1N0aWxsSW1hZ2UiIC8+PGRjOnRpdGxlPjwvZGM6dGl0bGU+PC9jYzpXb3JrPjwvcmRmOlJERj48L21ldGFkYXRhPjxkZWZzCiAgICAgaWQ9ImRlZnMxNDkiIC8+PHNvZGlwb2RpOm5hbWVkdmlldwogICAgIHBhZ2Vjb2xvcj0iI2ZmZmZmZiIKICAgICBib3JkZXJjb2xvcj0iIzY2NjY2NiIKICAgICBib3JkZXJvcGFjaXR5PSIxIgogICAgIG9iamVjdHRvbGVyYW5jZT0iMTAiCiAgICAgZ3JpZHRvbGVyYW5jZT0iMTAiCiAgICAgZ3VpZGV0b2xlcmFuY2U9IjEwIgogICAgIGlua3NjYXBlOnBhZ2VvcGFjaXR5PSIwIgogICAgIGlua3NjYXBlOnBhZ2VzaGFkb3c9IjIiCiAgICAgaW5rc2NhcGU6d2luZG93LXdpZHRoPSIxOTIwIgogICAgIGlua3NjYXBlOndpbmRvdy1oZWlnaHQ9IjEwMTYiCiAgICAgaWQ9Im5hbWVkdmlldzE0NyIKICAgICBzaG93Z3JpZD0iZmFsc2UiCiAgICAgZml0LW1hcmdpbi10b3A9IjAuMSIKICAgICBmaXQtbWFyZ2luLWxlZnQ9IjAuMSIKICAgICBmaXQtbWFyZ2luLXJpZ2h0PSIwLjEiCiAgICAgZml0LW1hcmdpbi1ib3R0b209IjAuMSIKICAgICBpbmtzY2FwZTp6b29tPSI4LjE5IgogICAgIGlua3NjYXBlOmN4PSIyOS45MjUiCiAgICAgaW5rc2NhcGU6Y3k9IjM2LjEiCiAgICAgaW5rc2NhcGU6d2luZG93LXg9IjAiCiAgICAgaW5rc2NhcGU6d2luZG93LXk9IjI3IgogICAgIGlua3NjYXBlOndpbmRvdy1tYXhpbWl6ZWQ9IjEiCiAgICAgaW5rc2NhcGU6Y3VycmVudC1sYXllcj0ic3ZnMTQ1IiAvPjxnCiAgICAgaWQ9IkFtYXpvbl9DbG91ZFNlYXJjaCIKICAgICB0cmFuc2Zvcm09InRyYW5zbGF0ZSgtMjAuMDc1LC0xMy45KSI+PGcKICAgICAgIGlkPSJnMTQyIj48cG9seWdvbgogICAgICAgICBmaWxsPSIjZDlhNzQxIgogICAgICAgICBwb2ludHM9IjIzLjk4NywzNi4yMDEgNTQuNDYyLDQwLjQ5NCA1NC40Niw1OS41MDYgMjMuOTg1LDYzLjc5MyAiCiAgICAgICAgIGlkPSJwb2x5Z29uMTIwIiAvPjxwb2x5Z29uCiAgICAgICAgIGZpbGw9IiM4NzY5MjkiCiAgICAgICAgIHBvaW50cz0iNTAuMDAzLDE0IDIwLjE3OSwyOC45MDggMjAuMTc5LDM3LjM0NCA1MC4wMDMsMjguMzk5ICIKICAgICAgICAgaWQ9InBvbHlnb24xMjIiIC8+PHBvbHlnb24KICAgICAgICAgZmlsbD0iIzg3NjkyOSIKICAgICAgICAgcG9pbnRzPSI0OS45OTcsODYgMjAuMTksNzEuMDk0IDIwLjE5LDYyLjY1NCA0OS45OTksNzEuNiAiCiAgICAgICAgIGlkPSJwb2x5Z29uMTI0IiAvPjxwb2x5Z29uCiAgICAgICAgIGZpbGw9IiNkOWE3NDEiCiAgICAgICAgIHBvaW50cz0iNTAuMDAzLDE0IDc5LjgyNSwyOC45MTQgNzkuODIzLDM3LjM1IDUwLjAwMywyOC4zOTkgIgogICAgICAgICBpZD0icG9seWdvbjEyNiIgLz48cG9seWdvbgogICAgICAgICBmaWxsPSIjZDlhNzQxIgogICAgICAgICBwb2ludHM9IjQ5Ljk5Nyw4NiA3OS44MDYsNzEuMDk5IDc5LjgwNiw2Mi42NiA0OS45OTksNzEuNiAiCiAgICAgICAgIGlkPSJwb2x5Z29uMTI4IiAvPjxwb2x5Z29uCiAgICAgICAgIGZpbGw9IiM4NzY5MjkiCiAgICAgICAgIHBvaW50cz0iMjAuMTc5LDI4LjkwOCAyMy45ODksMjcuMDA0IDIzLjk4NSw3Mi45OSAyMC4xNzUsNzEuMDg2ICIKICAgICAgICAgaWQ9InBvbHlnb24xMzAiIC8+PHBvbHlnb24KICAgICAgICAgZmlsbD0iIzg3NjkyOSIKICAgICAgICAgcG9pbnRzPSI1MC4wMDEsNDAuODMyIDM5LjAxOSw0Mi4yMjkgMzkuMDE3LDU3Ljc2MiA0OS45OTksNTkuMTYgIgogICAgICAgICBpZD0icG9seWdvbjEzMiIgLz48cG9seWdvbgogICAgICAgICBmaWxsPSIjODc2OTI5IgogICAgICAgICBwb2ludHM9IjM1LjA4Myw0Mi43MjkgMjcuOTU0LDQzLjYzNyAyNy45NTQsNTYuMzU0IDM1LjA4MSw1Ny4yNiAiCiAgICAgICAgIGlkPSJwb2x5Z29uMTM0IiAvPjxwb2x5Z29uCiAgICAgICAgIGZpbGw9IiM2MjRhMWUiCiAgICAgICAgIHBvaW50cz0iNzkuODIzLDM3LjM1IDU0LjQ4MSw0MC40OTYgMjMuOTg3LDM2LjIwMSA1MC4wMDMsMjguMzk5ICIKICAgICAgICAgaWQ9InBvbHlnb24xMzYiIC8+PHBvbHlnb24KICAgICAgICAgZmlsbD0iI2ZhZDc5MSIKICAgICAgICAgcG9pbnRzPSI3OS44MDYsNjIuNjYgNTQuNDYsNTkuNTA2IDIzLjk4NSw2My43OTMgNDkuOTk5LDcxLjYgIgogICAgICAgICBpZD0icG9seWdvbjEzOCIgLz48cG9seWdvbgogICAgICAgICBmaWxsPSIjZDlhNzQxIgogICAgICAgICBwb2ludHM9IjUwLjAwMSw0MC44MzIgNzkuODA4LDQ0LjYyOSA3OS44MDgsNTUuMzMgNDkuOTk5LDU5LjA5MiAiCiAgICAgICAgIGlkPSJwb2x5Z29uMTQwIiAvPjwvZz48L2c+PC9zdmc+Cg=="
     camel.apache.org/provider: "Apache Software Foundation"
     camel.apache.org/kamelet.group: "AWS SQS"
-    camel.apache.org/keda.type: "aws-sqs-queue"
     camel.apache.org/kamelet.namespace: "AWS"
   labels:
     camel.apache.org/kamelet.type: "source"
@@ -54,8 +53,6 @@ spec:
         format: password
         x-descriptors:
         - urn:camel:group:credentials
-        - urn:keda:authentication:awsAccessKeyID
-        - urn:keda:required
       secretKey:
         title: Secret Key
         description: The secret key obtained from AWS.
@@ -63,15 +60,10 @@ spec:
         format: password
         x-descriptors:
         - urn:camel:group:credentials
-        - urn:keda:authentication:awsSecretAccessKey
-        - urn:keda:required
       region:
         title: AWS Region
         description: The AWS region to access.
         type: string
-        x-descriptors:
-        - urn:keda:metadata:awsRegion
-        - urn:keda:required
         enum: ["ap-south-1", "eu-south-1", "us-gov-east-1", "me-central-1", "ca-central-1", "eu-central-1", "us-iso-west-1", "us-west-1", "us-west-2", "af-south-1", "eu-north-1", "eu-west-3", "eu-west-2", "eu-west-1", "ap-northeast-3", "ap-northeast-2", "ap-northeast-1", "me-south-1", "sa-east-1", "ap-east-1", "cn-north-1", "us-gov-west-1", "ap-southeast-1", "ap-southeast-2", "us-iso-east-1", "ap-southeast-3", "us-east-1", "us-east-2", "cn-northwest-1", "us-isob-east-1", "aws-global", "aws-cn-global", "aws-us-gov-global", "aws-iso-global", "aws-iso-b-global"]
       autoCreateQueue:
         title: Autocreate Queue
@@ -91,11 +83,8 @@ spec:
         default: https
       queueURL:
         title: Queue URL
-        description: The full SQS Queue URL (required if using KEDA).
+        description: The full SQS Queue URL.
         type: string
-        x-descriptors:
-        - urn:keda:metadata:queueURL
-        - urn:keda:required
       useDefaultCredentialsProvider:
         title: Default Credentials Provider
         description: If true, the SQS client loads credentials through a default credentials provider. If false, it uses the basic authentication method (access key and secret key).

--- a/library/camel-kamelets/src/main/resources/kamelets/jms-pooled-apache-artemis-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/jms-pooled-apache-artemis-sink.kamelet.yaml
@@ -58,21 +58,17 @@ spec:
         type: string
         x-descriptors:
         - urn:camel:group:credentials
-        - urn:keda:authentication:password
-        - urn:keda:required 
       password:
         title: "Broker Password"
         description: "The JMS Broker Password."
         type: string
         x-descriptors:
         - urn:camel:group:credentials
-        - urn:keda:authentication:password
-        - urn:keda:required
       maxSessionsPerConnection:
         title: "Max Sessions Per Connection"
         description: "The maximum number of pooled sessions per connection in the pool."
         type: integer
-        default: 500 
+        default: 500
       maxIdleSessionsPerConnection:
         title: "Max Idle Sessions Per Connection"
         description: "The number of idle sessions allowed per connection before they are closed."
@@ -82,7 +78,7 @@ spec:
         title: "Connection Idle Timeout"
         description: "The maximum time a pooled Connection can sit unused before it is eligible for removal (in milliseconds)."
         type: integer
-        default: 30000     
+        default: 30000
   dependencies:
   - "camel:jms"
   - "camel:kamelet"

--- a/library/camel-kamelets/src/main/resources/kamelets/jms-pooled-apache-artemis-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/jms-pooled-apache-artemis-source.kamelet.yaml
@@ -57,16 +57,12 @@ spec:
         type: string
         x-descriptors:
         - urn:camel:group:credentials
-        - urn:keda:authentication:password
-        - urn:keda:required 
       password:
         title: "Broker Password"
         description: "The JMS Broker Password."
         type: string
         x-descriptors:
         - urn:camel:group:credentials
-        - urn:keda:authentication:password
-        - urn:keda:required
       maxSessionsPerConnection:
         title: "Max Session Per Connection"
         description: "The maximum number of pooled sessions per connection in the pool."
@@ -81,7 +77,7 @@ spec:
         title: "Connection Idle Timeout"
         description: "The maximum time a pooled Connection can sit unused before it is eligible for removal (in milliseconds)."
         type: integer
-        default: 30000       
+        default: 30000
   dependencies:
   - "camel:jms"
   - "camel:kamelet"
@@ -101,7 +97,7 @@ spec:
           connectionFactory: '#bean:{{connectionFactoryBean}}'
           maxSessionsPerConnection: "{{maxSessionsPerConnection}}"
           maxIdleSessionsPerConnection: "{{maxIdleSessionsPerConnection}}"
-          connectionIdleTimeout: "{{connectionIdleTimeout}}"        
+          connectionIdleTimeout: "{{connectionIdleTimeout}}"
     from:
       uri: "jms:{{destinationType}}:{{destinationName}}"
       parameters:

--- a/library/camel-kamelets/src/main/resources/kamelets/kafka-apicurio-registry-not-secured-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/kafka-apicurio-registry-not-secured-sink.kamelet.yaml
@@ -54,9 +54,6 @@ spec:
         title: Apicurio Registry URL
         description: The Apicurio Schema Registry URL.
         type: string
-        x-descriptors:
-        - urn:keda:metadata:apicurioRegistryUrl
-        - urn:keda:required
       avroDatumProvider:
         title: Avro Datum Provider
         description: How to write data with Avro.

--- a/library/camel-kamelets/src/main/resources/kamelets/kafka-apicurio-registry-not-secured-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/kafka-apicurio-registry-not-secured-source.kamelet.yaml
@@ -25,7 +25,6 @@ metadata:
     camel.apache.org/provider: "Apache Software Foundation"
     camel.apache.org/kamelet.group: "Kafka"
     camel.apache.org/kamelet.namespace: "Kafka"
-    camel.apache.org/keda.type: "kafka"
   labels:
     camel.apache.org/kamelet.type: "source"
 spec:
@@ -42,16 +41,10 @@ spec:
         title: Topic Names
         description: Comma separated list of Kafka topic names
         type: string
-        x-descriptors:
-        - urn:keda:metadata:topic
-        - urn:keda:required
       bootstrapServers:
         title: Bootstrap Servers
         description: Comma separated list of Kafka Broker URLs
         type: string
-        x-descriptors:
-        - urn:keda:metadata:bootstrapServers
-        - urn:keda:required
       autoCommitEnable:
         title: Auto Commit Enable
         description: If true, periodically commit to ZooKeeper the offset of messages already fetched by the consumer
@@ -72,16 +65,11 @@ spec:
         description: What to do when there is no initial offset. There are 3 enums and the value can be one of latest, earliest, none
         type: string
         default: "latest"
-        x-descriptors:
-        - urn:keda:metadata:offsetResetPolicy
       consumerGroup:
         title: Consumer Group
         description: A string that uniquely identifies the group of consumers to which this source belongs
         type: string
         example: "my-group-id"
-        x-descriptors:
-        - urn:keda:metadata:consumerGroup
-        - urn:keda:required
       deserializeHeaders:
         title: Automatically Deserialize Headers
         description: When enabled the Kamelet source will deserialize all message headers to String representation.
@@ -96,9 +84,6 @@ spec:
         title: Apicurio Registry URL
         description: The Apicurio Schema Registry URL
         type: string
-        x-descriptors:
-        - urn:keda:metadata:bootstrapServers
-        - urn:keda:required
       topicIsPattern:
         title: Topic Is Pattern
         description: Whether the topic is a pattern (regular expression). This can be used to subscribe to dynamic number of topics matching the pattern.

--- a/library/camel-kamelets/src/main/resources/kamelets/kafka-azure-schema-registry-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/kafka-azure-schema-registry-sink.kamelet.yaml
@@ -53,7 +53,7 @@ spec:
         default: SASL_SSL
       saslMechanism:
         title: SASL Mechanism
-        description: The Simple Authentication and Security Layer (SASL) Mechanism used. 
+        description: The Simple Authentication and Security Layer (SASL) Mechanism used.
         type: string
         default: PLAIN
       password:
@@ -72,9 +72,6 @@ spec:
         title: Azure Schema Registry URL
         description: The Apicurio Schema Registry URL
         type: string
-        x-descriptors:
-        - urn:keda:metadata:bootstrapServers
-        - urn:keda:required
       specificAvroValueType:
         title: Specific Avro Value Type
         description: The Specific Type Avro will have to deal with

--- a/library/camel-kamelets/src/main/resources/kamelets/kafka-azure-schema-registry-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/kafka-azure-schema-registry-source.kamelet.yaml
@@ -25,7 +25,6 @@ metadata:
     camel.apache.org/provider: "Apache Software Foundation"
     camel.apache.org/kamelet.group: "Kafka"
     camel.apache.org/kamelet.namespace: "Kafka"
-    camel.apache.org/keda.type: "kafka"
   labels:
     camel.apache.org/kamelet.type: "source"
 spec:
@@ -43,16 +42,10 @@ spec:
         title: Topic Names
         description: Comma separated list of Kafka topic names
         type: string
-        x-descriptors:
-        - urn:keda:metadata:topic
-        - urn:keda:required
       bootstrapServers:
         title: Bootstrap Servers
         description: Comma separated list of Kafka Broker URLs
         type: string
-        x-descriptors:
-        - urn:keda:metadata:bootstrapServers
-        - urn:keda:required
       securityProtocol:
         title: Security Protocol
         description: Protocol used to communicate with brokers. SASL_PLAINTEXT, PLAINTEXT, SASL_SSL and SSL are supported
@@ -70,8 +63,6 @@ spec:
         format: password
         x-descriptors:
         - urn:camel:group:credentials
-        - urn:keda:authentication:password
-        - urn:keda:required
       autoCommitEnable:
         title: Auto Commit Enable
         description: If true, periodically commit to ZooKeeper the offset of messages already fetched by the consumer
@@ -92,16 +83,11 @@ spec:
         description: What to do when there is no initial offset. There are 3 enums and the value can be one of latest, earliest, none
         type: string
         default: "latest"
-        x-descriptors:
-        - urn:keda:metadata:offsetResetPolicy
       consumerGroup:
         title: Consumer Group
         description: A string that uniquely identifies the group of consumers to which this source belongs
         type: string
         example: "my-group-id"
-        x-descriptors:
-        - urn:keda:metadata:consumerGroup
-        - urn:keda:required
       deserializeHeaders:
         title: Automatically Deserialize Headers
         description: When enabled the Kamelet source will deserialize all message headers to String representation.
@@ -116,9 +102,6 @@ spec:
         title: Azure Schema Registry URL
         description: The Apicurio Schema Registry URL
         type: string
-        x-descriptors:
-        - urn:keda:metadata:bootstrapServers
-        - urn:keda:required
       specificAvroValueType:
         title: Specific Avro Value Type
         description: The Specific Type Avro will have to deal with

--- a/library/camel-kamelets/src/main/resources/kamelets/kafka-batch-apicurio-registry-not-secured-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/kafka-batch-apicurio-registry-not-secured-source.kamelet.yaml
@@ -25,7 +25,6 @@ metadata:
     camel.apache.org/provider: "Apache Software Foundation"
     camel.apache.org/kamelet.group: "Kafka"
     camel.apache.org/kamelet.namespace: "Kafka"
-    camel.apache.org/keda.type: "kafka"
   labels:
     camel.apache.org/kamelet.type: "source"
 spec:
@@ -42,16 +41,10 @@ spec:
         title: Topic Names
         description: Comma separated list of Kafka topic names.
         type: string
-        x-descriptors:
-        - urn:keda:metadata:topic
-        - urn:keda:required
       bootstrapServers:
         title: Bootstrap Servers
         description: Comma separated list of Kafka Broker URLs.
         type: string
-        x-descriptors:
-        - urn:keda:metadata:bootstrapServers
-        - urn:keda:required
       autoCommitEnable:
         title: Auto Commit Enable
         description: If true, periodically commit to ZooKeeper the offset of messages already fetched by the consumer.
@@ -72,16 +65,11 @@ spec:
         description: What to do when there is no initial offset. There are 3 enums and the value can be one of `latest`, `earliest`, `none`.
         type: string
         default: "latest"
-        x-descriptors:
-        - urn:keda:metadata:offsetResetPolicy
       consumerGroup:
         title: Consumer Group
         description: A string that uniquely identifies the group of consumers to which this source belongs.
         type: string
         example: "my-group-id"
-        x-descriptors:
-        - urn:keda:metadata:consumerGroup
-        - urn:keda:required
       deserializeHeaders:
         title: Automatically Deserialize Headers
         description: When enabled the Kamelet source will deserialize all message headers to String representation.
@@ -96,9 +84,6 @@ spec:
         title: Apicurio Registry URL
         description: The Apicurio Schema Registry URL.
         type: string
-        x-descriptors:
-        - urn:keda:metadata:bootstrapServers
-        - urn:keda:required
       avroDatumProvider:
         title: Avro Datum Provider
         description: How to read data with Avro.

--- a/library/camel-kamelets/src/main/resources/kamelets/kafka-batch-apicurio-registry-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/kafka-batch-apicurio-registry-source.kamelet.yaml
@@ -25,7 +25,6 @@ metadata:
     camel.apache.org/provider: "Apache Software Foundation"
     camel.apache.org/kamelet.group: "Kafka"
     camel.apache.org/kamelet.namespace: "Kafka"
-    camel.apache.org/keda.type: "kafka"
   labels:
     camel.apache.org/kamelet.type: "source"
 spec:
@@ -48,16 +47,10 @@ spec:
         title: Topic Names
         description: Comma separated list of Kafka topic names
         type: string
-        x-descriptors:
-        - urn:keda:metadata:topic
-        - urn:keda:required
       bootstrapServers:
         title: Bootstrap Servers
         description: Comma separated list of Kafka Broker URLs
         type: string
-        x-descriptors:
-        - urn:keda:metadata:bootstrapServers
-        - urn:keda:required
       autoCommitEnable:
         title: Auto Commit Enable
         description: If true, periodically commit to ZooKeeper the offset of messages already fetched by the consumer
@@ -78,16 +71,11 @@ spec:
         description: What to do when there is no initial offset. There are 3 enums and the value can be one of latest, earliest, none
         type: string
         default: "latest"
-        x-descriptors:
-        - urn:keda:metadata:offsetResetPolicy
       consumerGroup:
         title: Consumer Group
         description: A string that uniquely identifies the group of consumers to which this source belongs
         type: string
         example: "my-group-id"
-        x-descriptors:
-        - urn:keda:metadata:consumerGroup
-        - urn:keda:required
       deserializeHeaders:
         title: Automatically Deserialize Headers
         description: When enabled the Kamelet source will deserialize all message headers to String representation.
@@ -102,9 +90,6 @@ spec:
         title: Apicurio Registry URL
         description: The Apicurio Schema Registry URL
         type: string
-        x-descriptors:
-        - urn:keda:metadata:bootstrapServers
-        - urn:keda:required
       avroDatumProvider:
         title: Avro Datum Provider
         description: How to read data with Avro
@@ -148,8 +133,6 @@ spec:
         format: password
         x-descriptors:
         - urn:camel:group:credentials
-        - urn:keda:authentication:password
-        - urn:keda:required
       apicurioAuthUsername:
         title: Apicurio Registry Auth Username
         description: The Username in Keycloak instance securing the Apicurio Registry
@@ -161,8 +144,6 @@ spec:
         format: password
         x-descriptors:
         - urn:camel:group:credentials
-        - urn:keda:authentication:password
-        - urn:keda:required
       topicIsPattern:
         title: Topic Is Pattern
         description: Whether the topic is a pattern (regular expression). This can be used to subscribe to dynamic number of topics matching the pattern.

--- a/library/camel-kamelets/src/main/resources/kamelets/kafka-batch-azure-schema-registry-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/kafka-batch-azure-schema-registry-source.kamelet.yaml
@@ -25,7 +25,6 @@ metadata:
     camel.apache.org/provider: "Apache Software Foundation"
     camel.apache.org/kamelet.group: "Kafka"
     camel.apache.org/kamelet.namespace: "Kafka"
-    camel.apache.org/keda.type: "kafka"
   labels:
     camel.apache.org/kamelet.type: "source"
 spec:
@@ -43,16 +42,10 @@ spec:
         title: Topic Names
         description: Comma separated list of Kafka topic names
         type: string
-        x-descriptors:
-        - urn:keda:metadata:topic
-        - urn:keda:required
       bootstrapServers:
         title: Bootstrap Servers
         description: Comma separated list of Kafka Broker URLs
         type: string
-        x-descriptors:
-        - urn:keda:metadata:bootstrapServers
-        - urn:keda:required
       securityProtocol:
         title: Security Protocol
         description: Protocol used to communicate with brokers. SASL_PLAINTEXT, PLAINTEXT, SASL_SSL and SSL are supported
@@ -70,8 +63,6 @@ spec:
         format: password
         x-descriptors:
         - urn:camel:group:credentials
-        - urn:keda:authentication:password
-        - urn:keda:required
       autoCommitEnable:
         title: Auto Commit Enable
         description: If true, periodically commit to ZooKeeper the offset of messages already fetched by the consumer
@@ -92,16 +83,11 @@ spec:
         description: What to do when there is no initial offset. There are 3 enums and the value can be one of latest, earliest, none
         type: string
         default: "latest"
-        x-descriptors:
-        - urn:keda:metadata:offsetResetPolicy
       consumerGroup:
         title: Consumer Group
         description: A string that uniquely identifies the group of consumers to which this source belongs
         type: string
         example: "my-group-id"
-        x-descriptors:
-        - urn:keda:metadata:consumerGroup
-        - urn:keda:required
       deserializeHeaders:
         title: Automatically Deserialize Headers
         description: When enabled the Kamelet source will deserialize all message headers to String representation.
@@ -116,9 +102,6 @@ spec:
         title: Azure Schema Registry URL
         description: The Apicurio Schema Registry URL
         type: string
-        x-descriptors:
-        - urn:keda:metadata:bootstrapServers
-        - urn:keda:required
       specificAvroValueType:
         title: Specific Avro Value Type
         description: The Specific Type Avro will have to deal with

--- a/library/camel-kamelets/src/main/resources/kamelets/kafka-batch-not-secured-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/kafka-batch-not-secured-source.kamelet.yaml
@@ -25,7 +25,6 @@ metadata:
     camel.apache.org/provider: "Apache Software Foundation"
     camel.apache.org/kamelet.group: "Kafka"
     camel.apache.org/kamelet.namespace: "Kafka"
-    camel.apache.org/keda.type: "kafka"
   labels:
     camel.apache.org/kamelet.type: "source"
 spec:
@@ -41,16 +40,10 @@ spec:
         title: Topic Names
         description: Comma separated list of Kafka topic names
         type: string
-        x-descriptors:
-        - urn:keda:metadata:topic
-        - urn:keda:required
       bootstrapServers:
         title: Bootstrap Servers
         description: Comma separated list of Kafka Broker URLs
         type: string
-        x-descriptors:
-        - urn:keda:metadata:bootstrapServers
-        - urn:keda:required
       autoCommitEnable:
         title: Auto Commit Enable
         description: If true, periodically commit to ZooKeeper the offset of messages already fetched by the consumer
@@ -71,16 +64,11 @@ spec:
         description: What to do when there is no initial offset. There are 3 enums and the value can be one of latest, earliest, none
         type: string
         default: "latest"
-        x-descriptors:
-        - urn:keda:metadata:offsetResetPolicy
       consumerGroup:
         title: Consumer Group
         description: A string that uniquely identifies the group of consumers to which this source belongs
         type: string
         example: "my-group-id"
-        x-descriptors:
-        - urn:keda:metadata:consumerGroup
-        - urn:keda:required
       deserializeHeaders:
         title: Automatically Deserialize Headers
         description: When enabled the Kamelet source will deserialize all message headers to String representation.

--- a/library/camel-kamelets/src/main/resources/kamelets/kafka-batch-scram-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/kafka-batch-scram-source.kamelet.yaml
@@ -25,9 +25,6 @@ metadata:
     camel.apache.org/provider: "Apache Software Foundation"
     camel.apache.org/kamelet.group: "Kafka"
     camel.apache.org/kamelet.namespace: "Kafka"
-    camel.apache.org/keda.type: "kafka"
-    camel.apache.org/keda.authentication.sasl: "scram-sha-512"
-    camel.apache.org/keda.authentication.tls: "enable"
   labels:
     camel.apache.org/kamelet.type: "source"
 spec:
@@ -45,16 +42,10 @@ spec:
         title: Topic Names
         description: Comma separated list of Kafka topic names
         type: string
-        x-descriptors:
-        - urn:keda:metadata:topic
-        - urn:keda:required
       bootstrapServers:
         title: Bootstrap Servers
         description: Comma separated list of Kafka Broker URLs
         type: string
-        x-descriptors:
-        - urn:keda:metadata:bootstrapServers
-        - urn:keda:required
       securityProtocol:
         title: Security Protocol
         description: Protocol used to communicate with brokers. SASL_PLAINTEXT, PLAINTEXT, SASL_SSL and SSL are supported
@@ -71,8 +62,6 @@ spec:
         type: string
         x-descriptors:
         - urn:camel:group:credentials
-        - urn:keda:authentication:username
-        - urn:keda:required
       password:
         title: Password
         description: Password to authenticate to kafka
@@ -80,8 +69,6 @@ spec:
         format: password
         x-descriptors:
         - urn:camel:group:credentials
-        - urn:keda:authentication:password
-        - urn:keda:required
       autoCommitEnable:
         title: Auto Commit Enable
         description: If true, periodically commit to ZooKeeper the offset of messages already fetched by the consumer
@@ -102,16 +89,11 @@ spec:
         description: What to do when there is no initial offset. There are 3 enums and the value can be one of latest, earliest, none
         type: string
         default: "latest"
-        x-descriptors:
-        - urn:keda:metadata:offsetResetPolicy
       consumerGroup:
         title: Consumer Group
         description: A string that uniquely identifies the group of consumers to which this source belongs
         type: string
         example: "my-group-id"
-        x-descriptors:
-        - urn:keda:metadata:consumerGroup
-        - urn:keda:required
       deserializeHeaders:
         title: Automatically Deserialize Headers
         description: When enabled the Kamelet source will deserialize all message headers to String representation.

--- a/library/camel-kamelets/src/main/resources/kamelets/kafka-batch-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/kafka-batch-source.kamelet.yaml
@@ -25,9 +25,6 @@ metadata:
     camel.apache.org/provider: "Apache Software Foundation"
     camel.apache.org/kamelet.group: "Kafka"
     camel.apache.org/kamelet.namespace: "Kafka"
-    camel.apache.org/keda.type: "kafka"
-    camel.apache.org/keda.authentication.sasl: "plaintext"
-    camel.apache.org/keda.authentication.tls: "enable"
   labels:
     camel.apache.org/kamelet.type: "source"
 spec:
@@ -45,16 +42,10 @@ spec:
         title: Topic Names
         description: Comma separated list of Kafka topic names
         type: string
-        x-descriptors:
-        - urn:keda:metadata:topic
-        - urn:keda:required
       bootstrapServers:
         title: Bootstrap Servers
         description: Comma separated list of Kafka Broker URLs
         type: string
-        x-descriptors:
-        - urn:keda:metadata:bootstrapServers
-        - urn:keda:required
       securityProtocol:
         title: Security Protocol
         description: Protocol used to communicate with brokers. SASL_PLAINTEXT, PLAINTEXT, SASL_SSL and SSL are supported
@@ -71,8 +62,6 @@ spec:
         type: string
         x-descriptors:
         - urn:camel:group:credentials
-        - urn:keda:authentication:username
-        - urn:keda:required
       password:
         title: Password
         description: Password to authenticate to kafka
@@ -80,8 +69,6 @@ spec:
         format: password
         x-descriptors:
         - urn:camel:group:credentials
-        - urn:keda:authentication:password
-        - urn:keda:required
       autoCommitEnable:
         title: Auto Commit Enable
         description: If true, periodically commit to ZooKeeper the offset of messages already fetched by the consumer
@@ -102,16 +89,11 @@ spec:
         description: What to do when there is no initial offset. There are 3 enums and the value can be one of latest, earliest, none
         type: string
         default: "latest"
-        x-descriptors:
-        - urn:keda:metadata:offsetResetPolicy
       consumerGroup:
         title: Consumer Group
         description: A string that uniquely identifies the group of consumers to which this source belongs
         type: string
         example: "my-group-id"
-        x-descriptors:
-        - urn:keda:metadata:consumerGroup
-        - urn:keda:required
       deserializeHeaders:
         title: Automatically Deserialize Headers
         description: When enabled the Kamelet source will deserialize all message headers to String representation.
@@ -169,8 +151,8 @@ spec:
         maxPollIntervalMs: "{{?maxPollIntervalMs}}"
         batchingIntervalMs: "{{?batchingIntervalMs}}"
         batching: true
-        kafkaManualCommitFactory: "#bean:{{manualCommitFactory}}"      
-        topicIsPattern: "{{topicIsPattern}}"  
+        kafkaManualCommitFactory: "#bean:{{manualCommitFactory}}"
+        topicIsPattern: "{{topicIsPattern}}"
       steps:
         - process:
             ref: "{{kafkaHeaderDeserializer}}"

--- a/library/camel-kamelets/src/main/resources/kamelets/kafka-batch-ssl-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/kafka-batch-ssl-source.kamelet.yaml
@@ -42,16 +42,10 @@ spec:
         title: Topic Names
         description: Comma separated list of Kafka topic names
         type: string
-        x-descriptors:
-          - urn:keda:metadata:topic
-          - urn:keda:required
       bootstrapServers:
         title: Bootstrap Servers
         description: Comma separated list of Kafka Broker URLs
         type: string
-        x-descriptors:
-          - urn:keda:metadata:bootstrapServers
-          - urn:keda:required
       securityProtocol:
         title: Security Protocol
         description: Protocol used to communicate with brokers. SASL_PLAINTEXT, PLAINTEXT, SASL_SSL and SSL are supported
@@ -82,16 +76,11 @@ spec:
         description: What to do when there is no initial offset. There are 3 enums and the value can be one of latest, earliest, none
         type: string
         default: "latest"
-        x-descriptors:
-          - urn:keda:metadata:offsetResetPolicy
       consumerGroup:
         title: Consumer Group
         description: A string that uniquely identifies the group of consumers to which this source belongs
         type: string
         example: "my-group-id"
-        x-descriptors:
-          - urn:keda:metadata:consumerGroup
-          - urn:keda:required
       deserializeHeaders:
         title: Automatically Deserialize Headers
         description: When enabled the Kamelet source will deserialize all message headers to String representation.
@@ -104,16 +93,11 @@ spec:
         format: password
         x-descriptors:
           - urn:camel:group:credentials
-          - urn:keda:authentication:password
-          - urn:keda:required
       sslKeystorePassword:
         description: The store password for the key store file.This is optional for client and only needed if ssl.keystore.location is configured.
         title: SSL Keystore Password
         type: string
         format: password
-        x-descriptors:
-          - urn:camel:group:credentials
-          - urn:keda:authentication:password
       sslEndpointAlgorithm:
         description: The endpoint identification algorithm to validate server hostname using server certificate. Use none or false to disable server hostname verification.
         title: SSL Endpoint Algorithm

--- a/library/camel-kamelets/src/main/resources/kamelets/kafka-not-secured-apicurio-registry-json-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/kafka-not-secured-apicurio-registry-json-source.kamelet.yaml
@@ -25,7 +25,6 @@ metadata:
     camel.apache.org/provider: "Apache Software Foundation"
     camel.apache.org/kamelet.group: "Kafka"
     camel.apache.org/kamelet.namespace: "Kafka"
-    camel.apache.org/keda.type: "kafka"
   labels:
     camel.apache.org/kamelet.type: "source"
 spec:
@@ -48,16 +47,10 @@ spec:
         title: Topic Names
         description: Comma separated list of Kafka topic names
         type: string
-        x-descriptors:
-        - urn:keda:metadata:topic
-        - urn:keda:required
       bootstrapServers:
         title: Bootstrap Servers
         description: Comma separated list of Kafka Broker URLs
         type: string
-        x-descriptors:
-        - urn:keda:metadata:bootstrapServers
-        - urn:keda:required
       autoCommitEnable:
         title: Auto Commit Enable
         description: If true, periodically commit to ZooKeeper the offset of messages already fetched by the consumer
@@ -78,16 +71,11 @@ spec:
         description: What to do when there is no initial offset. There are 3 enums and the value can be one of latest, earliest, none
         type: string
         default: "latest"
-        x-descriptors:
-        - urn:keda:metadata:offsetResetPolicy
       consumerGroup:
         title: Consumer Group
         description: A string that uniquely identifies the group of consumers to which this source belongs
         type: string
         example: "my-group-id"
-        x-descriptors:
-        - urn:keda:metadata:consumerGroup
-        - urn:keda:required
       deserializeHeaders:
         title: Automatically Deserialize Headers
         description: When enabled the Kamelet source will deserialize all message headers to String representation.
@@ -102,9 +90,6 @@ spec:
         title: Apicurio Registry URL
         description: The Apicurio Schema Registry URL
         type: string
-        x-descriptors:
-        - urn:keda:metadata:bootstrapServers
-        - urn:keda:required
       apicurioAuthServiceUrl:
         title: Apicurio Registry Auth Service URL
         description: The URL for Keycloak instance securing the Apicurio Registry
@@ -125,8 +110,6 @@ spec:
         format: password
         x-descriptors:
         - urn:camel:group:credentials
-        - urn:keda:authentication:password
-        - urn:keda:required
       apicurioAuthUsername:
         title: Apicurio Registry Auth Username
         description: The Username in Keycloak instance securing the Apicurio Registry
@@ -138,8 +121,6 @@ spec:
         format: password
         x-descriptors:
         - urn:camel:group:credentials
-        - urn:keda:authentication:password
-        - urn:keda:required
       topicIsPattern:
         title: Topic Is Pattern
         description: Whether the topic is a pattern (regular expression). This can be used to subscribe to dynamic number of topics matching the pattern.

--- a/library/camel-kamelets/src/main/resources/kamelets/kafka-not-secured-apicurio-registry-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/kafka-not-secured-apicurio-registry-sink.kamelet.yaml
@@ -60,9 +60,6 @@ spec:
         title: Apicurio Registry URL
         description: The Apicurio Schema Registry URL
         type: string
-        x-descriptors:
-        - urn:keda:metadata:apicurioRegistryUrl
-        - urn:keda:required
       avroDatumProvider:
         title: Avro Datum Provider
         description: How to write data with Avro
@@ -88,8 +85,6 @@ spec:
         format: password
         x-descriptors:
         - urn:camel:group:credentials
-        - urn:keda:authentication:password
-        - urn:keda:required
       apicurioAuthUsername:
         title: Apicurio Registry Auth Username
         description: The Username in Keycloak instance securing the Apicurio Registry
@@ -101,8 +96,6 @@ spec:
         format: password
         x-descriptors:
         - urn:camel:group:credentials
-        - urn:keda:authentication:password
-        - urn:keda:required
   dependencies:
     - "camel:core"
     - "camel:kamelet"

--- a/library/camel-kamelets/src/main/resources/kamelets/kafka-not-secured-apicurio-registry-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/kafka-not-secured-apicurio-registry-source.kamelet.yaml
@@ -25,7 +25,6 @@ metadata:
     camel.apache.org/provider: "Apache Software Foundation"
     camel.apache.org/kamelet.group: "Kafka"
     camel.apache.org/kamelet.namespace: "Kafka"
-    camel.apache.org/keda.type: "kafka"
   labels:
     camel.apache.org/kamelet.type: "source"
 spec:
@@ -48,16 +47,10 @@ spec:
         title: Topic Names
         description: Comma separated list of Kafka topic names
         type: string
-        x-descriptors:
-        - urn:keda:metadata:topic
-        - urn:keda:required
       bootstrapServers:
         title: Bootstrap Servers
         description: Comma separated list of Kafka Broker URLs
         type: string
-        x-descriptors:
-        - urn:keda:metadata:bootstrapServers
-        - urn:keda:required
       autoCommitEnable:
         title: Auto Commit Enable
         description: If true, periodically commit to ZooKeeper the offset of messages already fetched by the consumer
@@ -78,16 +71,11 @@ spec:
         description: What to do when there is no initial offset. There are 3 enums and the value can be one of latest, earliest, none
         type: string
         default: "latest"
-        x-descriptors:
-        - urn:keda:metadata:offsetResetPolicy
       consumerGroup:
         title: Consumer Group
         description: A string that uniquely identifies the group of consumers to which this source belongs
         type: string
         example: "my-group-id"
-        x-descriptors:
-        - urn:keda:metadata:consumerGroup
-        - urn:keda:required
       deserializeHeaders:
         title: Automatically Deserialize Headers
         description: When enabled the Kamelet source will deserialize all message headers to String representation.
@@ -102,9 +90,6 @@ spec:
         title: Apicurio Registry URL
         description: The Apicurio Schema Registry URL
         type: string
-        x-descriptors:
-        - urn:keda:metadata:bootstrapServers
-        - urn:keda:required
       avroDatumProvider:
         title: Avro Datum Provider
         description: How to read data with Avro
@@ -130,8 +115,6 @@ spec:
         format: password
         x-descriptors:
         - urn:camel:group:credentials
-        - urn:keda:authentication:password
-        - urn:keda:required
       apicurioAuthUsername:
         title: Apicurio Registry Auth Username
         description: The Username in Keycloak instance securing the Apicurio Registry
@@ -143,8 +126,6 @@ spec:
         format: password
         x-descriptors:
         - urn:camel:group:credentials
-        - urn:keda:authentication:password
-        - urn:keda:required
       topicIsPattern:
         title: Topic Is Pattern
         description: Whether the topic is a pattern (regular expression). This can be used to subscribe to dynamic number of topics matching the pattern.

--- a/library/camel-kamelets/src/main/resources/kamelets/kafka-not-secured-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/kafka-not-secured-source.kamelet.yaml
@@ -25,7 +25,6 @@ metadata:
     camel.apache.org/provider: "Apache Software Foundation"
     camel.apache.org/kamelet.group: "Kafka"
     camel.apache.org/kamelet.namespace: "Kafka"
-    camel.apache.org/keda.type: "kafka"
   labels:
     camel.apache.org/kamelet.type: "source"
 spec:
@@ -41,16 +40,10 @@ spec:
         title: Topic Names
         description: Comma separated list of Kafka topic names
         type: string
-        x-descriptors:
-        - urn:keda:metadata:topic
-        - urn:keda:required
       bootstrapServers:
         title: Bootstrap Servers
         description: Comma separated list of Kafka Broker URLs
         type: string
-        x-descriptors:
-        - urn:keda:metadata:bootstrapServers
-        - urn:keda:required
       autoCommitEnable:
         title: Auto Commit Enable
         description: If true, periodically commit to ZooKeeper the offset of messages already fetched by the consumer
@@ -71,16 +64,11 @@ spec:
         description: What to do when there is no initial offset. There are 3 enums and the value can be one of latest, earliest, none
         type: string
         default: "latest"
-        x-descriptors:
-        - urn:keda:metadata:offsetResetPolicy
       consumerGroup:
         title: Consumer Group
         description: A string that uniquely identifies the group of consumers to which this source belongs
         type: string
         example: "my-group-id"
-        x-descriptors:
-        - urn:keda:metadata:consumerGroup
-        - urn:keda:required
       deserializeHeaders:
         title: Automatically Deserialize Headers
         description: When enabled the Kamelet source will deserialize all message headers to String representation.

--- a/library/camel-kamelets/src/main/resources/kamelets/kafka-scram-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/kafka-scram-source.kamelet.yaml
@@ -25,9 +25,6 @@ metadata:
     camel.apache.org/provider: "Apache Software Foundation"
     camel.apache.org/kamelet.group: "Kafka"
     camel.apache.org/kamelet.namespace: "Kafka"
-    camel.apache.org/keda.type: "kafka"
-    camel.apache.org/keda.authentication.sasl: "scram-sha-512"
-    camel.apache.org/keda.authentication.tls: "enable"
   labels:
     camel.apache.org/kamelet.type: "source"
 spec:
@@ -45,16 +42,10 @@ spec:
         title: Topic Names
         description: Comma separated list of Kafka topic names
         type: string
-        x-descriptors:
-        - urn:keda:metadata:topic
-        - urn:keda:required
       bootstrapServers:
         title: Bootstrap Servers
         description: Comma separated list of Kafka Broker URLs
         type: string
-        x-descriptors:
-        - urn:keda:metadata:bootstrapServers
-        - urn:keda:required
       securityProtocol:
         title: Security Protocol
         description: Protocol used to communicate with brokers. SASL_PLAINTEXT, PLAINTEXT, SASL_SSL and SSL are supported
@@ -71,8 +62,6 @@ spec:
         type: string
         x-descriptors:
         - urn:camel:group:credentials
-        - urn:keda:authentication:username
-        - urn:keda:required
       password:
         title: Password
         description: Password to authenticate to kafka
@@ -80,8 +69,6 @@ spec:
         format: password
         x-descriptors:
         - urn:camel:group:credentials
-        - urn:keda:authentication:password
-        - urn:keda:required
       autoCommitEnable:
         title: Auto Commit Enable
         description: If true, periodically commit to ZooKeeper the offset of messages already fetched by the consumer
@@ -102,16 +89,11 @@ spec:
         description: What to do when there is no initial offset. There are 3 enums and the value can be one of latest, earliest, none
         type: string
         default: "latest"
-        x-descriptors:
-        - urn:keda:metadata:offsetResetPolicy
       consumerGroup:
         title: Consumer Group
         description: A string that uniquely identifies the group of consumers to which this source belongs
         type: string
         example: "my-group-id"
-        x-descriptors:
-        - urn:keda:metadata:consumerGroup
-        - urn:keda:required
       deserializeHeaders:
         title: Automatically Deserialize Headers
         description: When enabled the Kamelet source will deserialize all message headers to String representation.

--- a/library/camel-kamelets/src/main/resources/kamelets/kafka-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/kafka-source.kamelet.yaml
@@ -25,9 +25,6 @@ metadata:
     camel.apache.org/provider: "Apache Software Foundation"
     camel.apache.org/kamelet.group: "Kafka"
     camel.apache.org/kamelet.namespace: "Kafka"
-    camel.apache.org/keda.type: "kafka"
-    camel.apache.org/keda.authentication.sasl: "plaintext"
-    camel.apache.org/keda.authentication.tls: "enable"
   labels:
     camel.apache.org/kamelet.type: "source"
 spec:
@@ -45,16 +42,10 @@ spec:
         title: Topic Names
         description: Comma separated list of Kafka topic names
         type: string
-        x-descriptors:
-        - urn:keda:metadata:topic
-        - urn:keda:required
       bootstrapServers:
         title: Bootstrap Servers
         description: Comma separated list of Kafka Broker URLs
         type: string
-        x-descriptors:
-        - urn:keda:metadata:bootstrapServers
-        - urn:keda:required
       securityProtocol:
         title: Security Protocol
         description: Protocol used to communicate with brokers. SASL_PLAINTEXT, PLAINTEXT, SASL_SSL and SSL are supported
@@ -71,8 +62,6 @@ spec:
         type: string
         x-descriptors:
         - urn:camel:group:credentials
-        - urn:keda:authentication:username
-        - urn:keda:required
       password:
         title: Password
         description: Password to authenticate to kafka
@@ -80,8 +69,6 @@ spec:
         format: password
         x-descriptors:
         - urn:camel:group:credentials
-        - urn:keda:authentication:password
-        - urn:keda:required
       autoCommitEnable:
         title: Auto Commit Enable
         description: If true, periodically commit to ZooKeeper the offset of messages already fetched by the consumer
@@ -102,16 +89,11 @@ spec:
         description: What to do when there is no initial offset. There are 3 enums and the value can be one of latest, earliest, none
         type: string
         default: "latest"
-        x-descriptors:
-        - urn:keda:metadata:offsetResetPolicy
       consumerGroup:
         title: Consumer Group
         description: A string that uniquely identifies the group of consumers to which this source belongs
         type: string
         example: "my-group-id"
-        x-descriptors:
-        - urn:keda:metadata:consumerGroup
-        - urn:keda:required
       deserializeHeaders:
         title: Automatically Deserialize Headers
         description: When enabled the Kamelet source will deserialize all message headers to String representation.

--- a/library/camel-kamelets/src/main/resources/kamelets/kafka-ssl-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/kafka-ssl-source.kamelet.yaml
@@ -43,16 +43,10 @@ spec:
         title: Topic Names
         description: Comma separated list of Kafka topic names.
         type: string
-        x-descriptors:
-          - urn:keda:metadata:topic
-          - urn:keda:required
       bootstrapServers:
         title: Bootstrap Servers
         description: Comma separated list of Kafka Broker URLs.
         type: string
-        x-descriptors:
-          - urn:keda:metadata:bootstrapServers
-          - urn:keda:required
       securityProtocol:
         title: Security Protocol
         description: Protocol used to communicate with brokers. `SASL_PLAINTEXT`, `PLAINTEXT`, `SASL_SSL` and `SSL` are supported.
@@ -83,16 +77,11 @@ spec:
         description: What to do when there is no initial offset. There are 3 enums and the value can be one of latest, earliest, none.
         type: string
         default: "latest"
-        x-descriptors:
-          - urn:keda:metadata:offsetResetPolicy
       consumerGroup:
         title: Consumer Group
         description: A string that uniquely identifies the group of consumers to which this source belongs.
         type: string
         example: "my-group-id"
-        x-descriptors:
-          - urn:keda:metadata:consumerGroup
-          - urn:keda:required
       deserializeHeaders:
         title: Automatically Deserialize Headers
         description: When enabled the Kamelet source will deserialize all message headers to String representation.
@@ -103,10 +92,6 @@ spec:
         title: SSL Key Password
         type: string
         format: password
-        x-descriptors:
-          - urn:camel:group:credentials
-          - urn:keda:authentication:password
-          - urn:keda:required
       sslKeystorePassword:
         description: The store password for the key store file.This is optional for client and only needed if ssl.keystore.location is configured.
         title: SSL Keystore Password
@@ -114,7 +99,6 @@ spec:
         format: password
         x-descriptors:
           - urn:camel:group:credentials
-          - urn:keda:authentication:password
       sslEndpointAlgorithm:
         description: The endpoint identification algorithm to validate server hostname using server certificate. Use none or false to disable server hostname verification.
         title: SSL Endpoint Algorithm
@@ -140,7 +124,6 @@ spec:
         format: password
         x-descriptors:
           - urn:camel:group:credentials
-          - urn:keda:authentication:password
       sslEnabledProtocols:
         description:   The list of protocols enabled for SSL connections. TLSv1.2, TLSv1.1 and TLSv1 are enabled by default.
         title: SSL Enabled Protocols

--- a/script/validator/validator.go
+++ b/script/validator/validator.go
@@ -388,12 +388,6 @@ func getUsedParams(k camelapiv1.Kamelet) map[string]bool {
 		}
 		params := make(map[string]bool)
 		inspectTemplateParams(templateData, params)
-		for propName, propVal := range k.Spec.Definition.Properties {
-			if hasXDescriptorPrefix(propVal, "urn:keda:") {
-				// Assume KEDA parameters may be used by KEDA
-				params[propName] = true
-			}
-		}
 		return params
 	}
 	return nil


### PR DESCRIPTION
* They were used in an experimental Camel K feature
* Removed as they requires the operator to access to the secrets
* Also, the auth model suggest the usage of a separate credentials from the application's one