### PR TITLE
Use the camel-bom version for camel-core/camel-aws2-eventbridge

### DIFF
--- a/tests/camel-kamelets-itest/pom.xml
+++ b/tests/camel-kamelets-itest/pom.xml
@@ -61,7 +61,6 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-core</artifactId>
-            <version>${camel.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -92,7 +91,6 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-aws2-eventbridge</artifactId>
-            <version>${camel.version}</version>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
camel-bom is already being imported in tests/camel-kamelets-itest - use the camel-bom versions for camel-core and camel-aws2-eventbridge