### PR TITLE
Remove camel-version from camel-aws2-eventbridge 

### DIFF
--- a/tests/camel-kamelets-itest/pom.xml
+++ b/tests/camel-kamelets-itest/pom.xml
@@ -97,7 +97,6 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-aws2-eventbridge</artifactId>
-            <version>${camel.version}</version>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
Remove camel-version from camel-aws2-eventbridge  - should be using the version from camel-bom which is imported in this directory