### PR TITLE
Fix #2529: Add crypto encrypt/decrypt action kamelets

### DIFF
--- a/kamelets/crypto-decrypt-action.kamelet.yaml
+++ b/kamelets/crypto-decrypt-action.kamelet.yaml
@@ -1,0 +1,69 @@
+# ---------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ---------------------------------------------------------------------------
+apiVersion: camel.apache.org/v1
+kind: Kamelet
+metadata:
+  name: crypto-decrypt-action
+  annotations:
+    camel.apache.org/kamelet.support.level: "Stable"
+    camel.apache.org/catalog.version: "4.19.0-SNAPSHOT"
+    camel.apache.org/kamelet.icon: "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI0MjAiCmhlaWdodD0iNDIwIiBzdHJva2U9IiMwMDAiIGZpbGw9Im5vbmUiPgo8cGF0aCBzdHJva2Utd2lkdGg9IjI2IgpkPSJNMjA5LDE1YTE5NSwxOTUgMCAxLDAgMiwweiIvPgo8cGF0aCBzdHJva2Utd2lkdGg9IjE4IgpkPSJtMjEwLDE1djM5MG0xOTUtMTk1SDE1TTU5LDkwYTI2MCwyNjAgMCAwLDAgMzAyLDAgbTAsMjQwIGEyNjAsMjYwIDAgMCwwLTMwMiwwTTE5NSwyMGEyNTAsMjUwIDAgMCwwIDAsMzgyIG0zMCwwIGEyNTAsMjUwIDAgMCwwIDAtMzgyIi8+Cjwvc3ZnPg=="
+    camel.apache.org/provider: "Apache Software Foundation"
+    camel.apache.org/kamelet.group: "Actions"
+    camel.apache.org/kamelet.namespace: "Transformation"
+  labels:
+    camel.apache.org/kamelet.type: "action"
+spec:
+  definition:
+    title: "Crypto Decrypt Action"
+    description: Decrypt the payload using the Java Cryptographic Extension (JCE) and a fixed key.
+    required:
+      - algorithm
+      - key
+    type: object
+    properties:
+      algorithm:
+        title: Algorithm
+        description: The JCE algorithm name indicating the cryptographic algorithm that will be used.
+        type: string
+        example: "AES"
+      key:
+        title: Secret Key
+        description: The secret key to use to decrypt the payload. The length must match the requirements of the selected algorithm (for example 16, 24 or 32 bytes for AES).
+        type: string
+        format: password
+        x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:password
+          - urn:camel:group:credentials
+  dependencies:
+    - "camel:kamelet"
+    - "camel:core"
+    - "camel:crypto"
+  template:
+    beans:
+      - name: cryptoKey
+        type: "javax.crypto.spec.SecretKeySpec"
+        constructors:
+          "0": "{{key}}"
+          "1": "{{algorithm}}"
+    from:
+      uri: kamelet:source
+      steps:
+        - unmarshal:
+            crypto:
+              algorithm: "{{algorithm}}"
+              key: "{{cryptoKey}}"

--- a/kamelets/crypto-encrypt-action.kamelet.yaml
+++ b/kamelets/crypto-encrypt-action.kamelet.yaml
@@ -1,0 +1,69 @@
+# ---------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ---------------------------------------------------------------------------
+apiVersion: camel.apache.org/v1
+kind: Kamelet
+metadata:
+  name: crypto-encrypt-action
+  annotations:
+    camel.apache.org/kamelet.support.level: "Stable"
+    camel.apache.org/catalog.version: "4.19.0-SNAPSHOT"
+    camel.apache.org/kamelet.icon: "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI0MjAiCmhlaWdodD0iNDIwIiBzdHJva2U9IiMwMDAiIGZpbGw9Im5vbmUiPgo8cGF0aCBzdHJva2Utd2lkdGg9IjI2IgpkPSJNMjA5LDE1YTE5NSwxOTUgMCAxLDAgMiwweiIvPgo8cGF0aCBzdHJva2Utd2lkdGg9IjE4IgpkPSJtMjEwLDE1djM5MG0xOTUtMTk1SDE1TTU5LDkwYTI2MCwyNjAgMCAwLDAgMzAyLDAgbTAsMjQwIGEyNjAsMjYwIDAgMCwwLTMwMiwwTTE5NSwyMGEyNTAsMjUwIDAgMCwwIDAsMzgyIG0zMCwwIGEyNTAsMjUwIDAgMCwwIDAtMzgyIi8+Cjwvc3ZnPg=="
+    camel.apache.org/provider: "Apache Software Foundation"
+    camel.apache.org/kamelet.group: "Actions"
+    camel.apache.org/kamelet.namespace: "Transformation"
+  labels:
+    camel.apache.org/kamelet.type: "action"
+spec:
+  definition:
+    title: "Crypto Encrypt Action"
+    description: Encrypt the payload using the Java Cryptographic Extension (JCE) and a fixed key.
+    required:
+      - algorithm
+      - key
+    type: object
+    properties:
+      algorithm:
+        title: Algorithm
+        description: The JCE algorithm name indicating the cryptographic algorithm that will be used.
+        type: string
+        example: "AES"
+      key:
+        title: Secret Key
+        description: The secret key to use to encrypt the payload. The length must match the requirements of the selected algorithm (for example 16, 24 or 32 bytes for AES).
+        type: string
+        format: password
+        x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:password
+          - urn:camel:group:credentials
+  dependencies:
+    - "camel:kamelet"
+    - "camel:core"
+    - "camel:crypto"
+  template:
+    beans:
+      - name: cryptoKey
+        type: "javax.crypto.spec.SecretKeySpec"
+        constructors:
+          "0": "{{key}}"
+          "1": "{{algorithm}}"
+    from:
+      uri: kamelet:source
+      steps:
+        - marshal:
+            crypto:
+              algorithm: "{{algorithm}}"
+              key: "{{cryptoKey}}"

--- a/library/camel-kamelets/src/main/resources/kamelets/crypto-decrypt-action.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/crypto-decrypt-action.kamelet.yaml
@@ -1,0 +1,69 @@
+# ---------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ---------------------------------------------------------------------------
+apiVersion: camel.apache.org/v1
+kind: Kamelet
+metadata:
+  name: crypto-decrypt-action
+  annotations:
+    camel.apache.org/kamelet.support.level: "Stable"
+    camel.apache.org/catalog.version: "4.19.0-SNAPSHOT"
+    camel.apache.org/kamelet.icon: "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI0MjAiCmhlaWdodD0iNDIwIiBzdHJva2U9IiMwMDAiIGZpbGw9Im5vbmUiPgo8cGF0aCBzdHJva2Utd2lkdGg9IjI2IgpkPSJNMjA5LDE1YTE5NSwxOTUgMCAxLDAgMiwweiIvPgo8cGF0aCBzdHJva2Utd2lkdGg9IjE4IgpkPSJtMjEwLDE1djM5MG0xOTUtMTk1SDE1TTU5LDkwYTI2MCwyNjAgMCAwLDAgMzAyLDAgbTAsMjQwIGEyNjAsMjYwIDAgMCwwLTMwMiwwTTE5NSwyMGEyNTAsMjUwIDAgMCwwIDAsMzgyIG0zMCwwIGEyNTAsMjUwIDAgMCwwIDAtMzgyIi8+Cjwvc3ZnPg=="
+    camel.apache.org/provider: "Apache Software Foundation"
+    camel.apache.org/kamelet.group: "Actions"
+    camel.apache.org/kamelet.namespace: "Transformation"
+  labels:
+    camel.apache.org/kamelet.type: "action"
+spec:
+  definition:
+    title: "Crypto Decrypt Action"
+    description: Decrypt the payload using the Java Cryptographic Extension (JCE) and a fixed key.
+    required:
+      - algorithm
+      - key
+    type: object
+    properties:
+      algorithm:
+        title: Algorithm
+        description: The JCE algorithm name indicating the cryptographic algorithm that will be used.
+        type: string
+        example: "AES"
+      key:
+        title: Secret Key
+        description: The secret key to use to decrypt the payload. The length must match the requirements of the selected algorithm (for example 16, 24 or 32 bytes for AES).
+        type: string
+        format: password
+        x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:password
+          - urn:camel:group:credentials
+  dependencies:
+    - "camel:kamelet"
+    - "camel:core"
+    - "camel:crypto"
+  template:
+    beans:
+      - name: cryptoKey
+        type: "javax.crypto.spec.SecretKeySpec"
+        constructors:
+          "0": "{{key}}"
+          "1": "{{algorithm}}"
+    from:
+      uri: kamelet:source
+      steps:
+        - unmarshal:
+            crypto:
+              algorithm: "{{algorithm}}"
+              key: "{{cryptoKey}}"

--- a/library/camel-kamelets/src/main/resources/kamelets/crypto-encrypt-action.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/crypto-encrypt-action.kamelet.yaml
@@ -1,0 +1,69 @@
+# ---------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ---------------------------------------------------------------------------
+apiVersion: camel.apache.org/v1
+kind: Kamelet
+metadata:
+  name: crypto-encrypt-action
+  annotations:
+    camel.apache.org/kamelet.support.level: "Stable"
+    camel.apache.org/catalog.version: "4.19.0-SNAPSHOT"
+    camel.apache.org/kamelet.icon: "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI0MjAiCmhlaWdodD0iNDIwIiBzdHJva2U9IiMwMDAiIGZpbGw9Im5vbmUiPgo8cGF0aCBzdHJva2Utd2lkdGg9IjI2IgpkPSJNMjA5LDE1YTE5NSwxOTUgMCAxLDAgMiwweiIvPgo8cGF0aCBzdHJva2Utd2lkdGg9IjE4IgpkPSJtMjEwLDE1djM5MG0xOTUtMTk1SDE1TTU5LDkwYTI2MCwyNjAgMCAwLDAgMzAyLDAgbTAsMjQwIGEyNjAsMjYwIDAgMCwwLTMwMiwwTTE5NSwyMGEyNTAsMjUwIDAgMCwwIDAsMzgyIG0zMCwwIGEyNTAsMjUwIDAgMCwwIDAtMzgyIi8+Cjwvc3ZnPg=="
+    camel.apache.org/provider: "Apache Software Foundation"
+    camel.apache.org/kamelet.group: "Actions"
+    camel.apache.org/kamelet.namespace: "Transformation"
+  labels:
+    camel.apache.org/kamelet.type: "action"
+spec:
+  definition:
+    title: "Crypto Encrypt Action"
+    description: Encrypt the payload using the Java Cryptographic Extension (JCE) and a fixed key.
+    required:
+      - algorithm
+      - key
+    type: object
+    properties:
+      algorithm:
+        title: Algorithm
+        description: The JCE algorithm name indicating the cryptographic algorithm that will be used.
+        type: string
+        example: "AES"
+      key:
+        title: Secret Key
+        description: The secret key to use to encrypt the payload. The length must match the requirements of the selected algorithm (for example 16, 24 or 32 bytes for AES).
+        type: string
+        format: password
+        x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:password
+          - urn:camel:group:credentials
+  dependencies:
+    - "camel:kamelet"
+    - "camel:core"
+    - "camel:crypto"
+  template:
+    beans:
+      - name: cryptoKey
+        type: "javax.crypto.spec.SecretKeySpec"
+        constructors:
+          "0": "{{key}}"
+          "1": "{{algorithm}}"
+    from:
+      uri: kamelet:source
+      steps:
+        - marshal:
+            crypto:
+              algorithm: "{{algorithm}}"
+              key: "{{cryptoKey}}"

--- a/tests/camel-kamelets-itest/src/test/java/CommonIT.java
+++ b/tests/camel-kamelets-itest/src/test/java/CommonIT.java
@@ -73,4 +73,9 @@ public class CommonIT {
     public Stream<DynamicTest> transformation() {
         return CitrusTestFactorySupport.factory(TestLoader.YAML).packageScan("transformation");
     }
+
+    @CitrusTestFactory
+    public Stream<DynamicTest> crypto() {
+        return CitrusTestFactorySupport.factory(TestLoader.YAML).packageScan("crypto");
+    }
 }

--- a/tests/camel-kamelets-itest/src/test/resources/crypto/crypto-action-pipe.citrus.it.yaml
+++ b/tests/camel-kamelets-itest/src/test/resources/crypto/crypto-action-pipe.citrus.it.yaml
@@ -1,0 +1,67 @@
+# ---------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ---------------------------------------------------------------------------
+
+name: crypto-action-pipe-test
+variables:
+  - name: "crypto.algorithm"
+    value: "AES"
+  - name: "crypto.key"
+    value: "0123456789abcdef"
+  - name: "plaintext"
+    value: "Camel Kamelets crypto rocks!"
+actions:
+  - createVariables:
+      variables:
+        - name: "http.server.url"
+          value: "http://localhost:${http.server.port}"
+  # Create Camel JBang integration
+  - camel:
+      jbang:
+        run:
+          waitForRunningState: false
+          integration:
+            file: "crypto/crypto-action-pipe.yaml"
+            systemProperties:
+              properties:
+                - name: "http.sink.url"
+                  value: "${http.server.url}"
+                - name: "crypto.algorithm"
+                  value: "${crypto.algorithm}"
+                - name: "crypto.key"
+                  value: "${crypto.key}"
+                - name: "input"
+                  value: "${plaintext}"
+
+  # Verify Http request receives the decrypted plaintext
+  - http:
+      server: "httpServer"
+      receiveRequest:
+        POST:
+          path: "/result"
+          body:
+            data: |
+              ${plaintext}
+
+  - http:
+      server: "httpServer"
+      sendResponse:
+        response:
+          status: 200
+          reasonPhrase: "OK"
+          version: "HTTP/1.1"
+          body:
+            data: "Thank You!"

--- a/tests/camel-kamelets-itest/src/test/resources/crypto/crypto-action-pipe.yaml
+++ b/tests/camel-kamelets-itest/src/test/resources/crypto/crypto-action-pipe.yaml
@@ -1,0 +1,49 @@
+# ---------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ---------------------------------------------------------------------------
+
+apiVersion: camel.apache.org/v1
+kind: Pipe
+metadata:
+  name: crypto-action-pipe
+spec:
+  source:
+    ref:
+      kind: Kamelet
+      apiVersion: camel.apache.org/v1
+      name: timer-source
+    properties:
+      period: 10000
+      contentType: text/plain
+      message: >
+        {{input}}
+  steps:
+    - ref:
+        kind: Kamelet
+        apiVersion: camel.apache.org/v1
+        name: crypto-encrypt-action
+      properties:
+        algorithm: "{{crypto.algorithm}}"
+        key: "{{crypto.key}}"
+    - ref:
+        kind: Kamelet
+        apiVersion: camel.apache.org/v1
+        name: crypto-decrypt-action
+      properties:
+        algorithm: "{{crypto.algorithm}}"
+        key: "{{crypto.key}}"
+  sink:
+    uri: "{{http.sink.url}}/result"


### PR DESCRIPTION
## Summary

Introduces two new action kamelets that expose the Camel crypto dataformat for payload encryption/decryption with a fixed JCE key:

- `crypto-encrypt-action` — marshals (encrypts) the body using JCE.
- `crypto-decrypt-action` — unmarshals (decrypts) the body using JCE.

Both kamelets require an `algorithm` (e.g., `AES`, `DES`) and a `key`. The secret key is built through a `javax.crypto.spec.SecretKeySpec` bean declared in the kamelet template (via `constructors`) and wired to the crypto dataformat by name.

Closes apache/camel-kamelets#2529

## Test plan

- [x] `mvn clean install -DskipTests` builds successfully (`camel-kamelets`, `camel-kamelets-catalog`, `camel-kamelets-itest`)
- [x] `mvn test` passes on all modules (catalog validation includes the new kamelets)
- [x] `kamelets-maven-plugin:validate` reports `Validation passed`
- [x] Local JBang round-trip: plaintext → `crypto-encrypt-action` → `crypto-decrypt-action` returns the original plaintext
- [x] New Citrus integration test added under `tests/camel-kamelets-itest/src/test/resources/crypto/crypto-action-pipe.citrus.it.yaml` and wired into `CommonIT`