### PR TITLE
CAMEL-23300: add connectionString option to couchbase-sink kamelet

### DIFF
--- a/kamelets/couchbase-sink.kamelet.yaml
+++ b/kamelets/couchbase-sink.kamelet.yaml
@@ -72,6 +72,10 @@ spec:
         description: The starting id
         type: integer
         default: 1
+      connectionString:
+        title: Connection String
+        description: The full Couchbase SDK connection string (e.g. couchbase://host:port). When set, it takes precedence over hostname extraction for the KV service port.
+        type: string
       autoStartId:
         title: Auto Start Id
         description: Auto Start Id or not
@@ -92,3 +96,4 @@ spec:
             startingIdForInsertsFrom: "{{startingId}}"
             username: "{{username}}"
             password: "{{password}}"
+            connectionString: "{{?connectionString}}"

--- a/library/camel-kamelets/src/main/resources/kamelets/couchbase-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/couchbase-sink.kamelet.yaml
@@ -72,6 +72,10 @@ spec:
         description: The starting id
         type: integer
         default: 1
+      connectionString:
+        title: Connection String
+        description: The full Couchbase SDK connection string (e.g. couchbase://host:port). When set, it takes precedence over hostname extraction for the KV service port.
+        type: string
       autoStartId:
         title: Auto Start Id
         description: Auto Start Id or not
@@ -92,3 +96,4 @@ spec:
             startingIdForInsertsFrom: "{{startingId}}"
             username: "{{username}}"
             password: "{{password}}"
+            connectionString: "{{?connectionString}}"


### PR DESCRIPTION
## Summary
- Expose the new `connectionString` endpoint option (added in [CAMEL-23300](https://issues.apache.org/jira/browse/CAMEL-23300)) as an optional property on the `couchbase-sink` kamelet
- Uses `{{?connectionString}}` so the parameter is only included when explicitly set
- Required for `camel-kafka-connector` daily CI which uses Testcontainers with random port mapping — without `connectionString`, the Couchbase SDK defaults the KV port to 11210 which is unreachable on the host side

## Context
The `camel-couchbase` component added `connectionString` in two commits on `main`:
- `6c2f458` — add `connectionString` endpoint option and switch test-infra to random ports
- `d004589` — bypass Couchbase 8.0 CPU microarchitecture check in test-infra

The camel-kafka-connector daily build has been failing since build #345 because the couchbase-sink kamelet does not expose `connectionString`, so the connector cannot pass it to the endpoint.

## Test plan
- [x] Verified locally: applied this kamelet change + corresponding CKC test changes, ran `CamelSinkCouchbaseITCase` — test passes
- No couchbase integration tests exist in camel-kamelets currently