### PR TITLE
Fix #2802: bump Camel and camel-dependencies to 4.20.0

### DIFF
--- a/library/camel-kamelets-catalog/src/test/java/org/apache/camel/kamelets/catalog/KameletsCatalogTest.java
+++ b/library/camel-kamelets-catalog/src/test/java/org/apache/camel/kamelets/catalog/KameletsCatalogTest.java
@@ -162,9 +162,9 @@ public class KameletsCatalogTest {
         verifyHeaders("azure-eventhubs-sink", 2);
         verifyHeaders("azure-functions-sink", 8);
         verifyHeaders("azure-servicebus-source", 21);
-        verifyHeaders("azure-storage-blob-source", 34);
-        verifyHeaders("azure-storage-blob-sink", 37);
-        verifyHeaders("azure-storage-blob-changefeed-source", 34);
+        verifyHeaders("azure-storage-blob-source", 35);
+        verifyHeaders("azure-storage-blob-sink", 38);
+        verifyHeaders("azure-storage-blob-changefeed-source", 35);
         verifyHeaders("azure-storage-datalake-source", 25);
         verifyHeaders("azure-storage-datalake-sink", 37);
         verifyHeaders("azure-storage-queue-source", 6);

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-dependencies</artifactId>
-        <version>4.19.0</version>
+        <version>4.20.0</version>
     </parent>
 
     <groupId>org.apache.camel.kamelets</groupId>
@@ -62,7 +62,7 @@
         <apache-rat-plugin.version>0.18</apache-rat-plugin.version>
         <cyclonedx-maven-plugin-version>2.9.1</cyclonedx-maven-plugin-version>
 
-        <camel.version>4.19.0</camel.version>
+        <camel.version>4.20.0</camel.version>
 
         <citrus.version>4.10.0</citrus.version>
         <jose4j.version>0.9.6</jose4j.version>


### PR DESCRIPTION
Fixes #2802.

Bumps the Apache Camel version and `camel-dependencies` parent BOM from `4.19.0` to `4.20.0`.

Changes (`pom.xml`):
- `<camel.version>` → `4.20.0`
- Parent `org.apache.camel:camel-dependencies` → `4.20.0`

Verified locally with `mvn clean install -DskipTests` (full reactor build succeeds; `4.20.0` artifacts resolved from Maven Central).