### PR TITLE
Remove hardcoded camel / camel-kamelets versions from citrus-application.properties

### DIFF
--- a/tests/camel-kamelets-itest/pom.xml
+++ b/tests/camel-kamelets-itest/pom.xml
@@ -186,6 +186,18 @@
     </dependencies>
 
     <build>
+        <testResources>
+            <!-- Standard test resources without filtering to preserve runtime placeholders like ${avro.webhook.server.port} -->
+            <testResource>
+                <directory>src/test/resources</directory>
+                <filtering>false</filtering>
+            </testResource>
+            <!-- This is needed to provide maven filtering of the citrus-application.properties file so that we can keep the camel and camel-kamelets versions up to date -->
+            <testResource>
+                <directory>src/test/resources-filtered</directory>
+                <filtering>true</filtering>
+            </testResource>
+        </testResources>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/tests/camel-kamelets-itest/src/test/resources-filtered/citrus-application.properties
+++ b/tests/camel-kamelets-itest/src/test/resources-filtered/citrus-application.properties
@@ -25,9 +25,9 @@ citrus.cluster.type=local
 citrus.camel.jbang.max.attempts=10
 
 # Camel JBang version (should align with version used in pom.xml)
-citrus.camel.jbang.version=4.20.0-SNAPSHOT
+citrus.camel.jbang.version=${camel.version}
 # Kamelets version (should point to the current snapshot release version)
-citrus.camel.jbang.kamelets.version=4.20.0-SNAPSHOT
+citrus.camel.jbang.kamelets.version=${project.version}
 
 # Enable dump of Camel JBang integration output
 citrus.camel.jbang.dump.integration.output=true

--- a/tests/camel-kamelets-itest/src/test/resources/avro/avro-data-type.citrus.it.yaml
+++ b/tests/camel-kamelets-itest/src/test/resources/avro/avro-data-type.citrus.it.yaml
@@ -20,6 +20,10 @@ variables:
   - name: "uuid"
     value: citrus:randomUUID()
 actions:
+  - echo:
+      message: "Camel JBang version: citrus:env('citrus.camel.jbang.version')"
+  - echo:
+      message: "Kamelets version: citrus:env('citrus.camel.jbang.kamelets.version')"
   - camel:
       jbang:
         run:

--- a/tests/camel-kamelets-itest/src/test/resources/avro/avro-data-type.citrus.it.yaml
+++ b/tests/camel-kamelets-itest/src/test/resources/avro/avro-data-type.citrus.it.yaml
@@ -19,11 +19,15 @@ name: avro-data-type-test
 variables:
   - name: "uuid"
     value: citrus:randomUUID()
+  - name: "camelVersion"
+    value: "citrus:systemProperty('citrus.camel.jbang.version')"
+  - name: "kameletsVersion"
+    value: "citrus:systemProperty('citrus.camel.jbang.kamelets.version')"
 actions:
   - echo:
-      message: "Camel JBang version: citrus:env('citrus.camel.jbang.version')"
+      message: "Camel JBang version: ${camelVersion}"
   - echo:
-      message: "Kamelets version: citrus:env('citrus.camel.jbang.kamelets.version')"
+      message: "Kamelets version: ${kameletsVersion}"
   - camel:
       jbang:
         run:

--- a/tests/camel-kamelets-itest/src/test/resources/avro/avro-serdes-action.citrus.it.yaml
+++ b/tests/camel-kamelets-itest/src/test/resources/avro/avro-serdes-action.citrus.it.yaml
@@ -20,6 +20,10 @@ variables:
   - name: "uuid"
     value: citrus:randomUUID()
 actions:
+  - echo:
+      message: "Camel JBang version: citrus:env('citrus.camel.jbang.version')"
+  - echo:
+      message: "Kamelets version: citrus:env('citrus.camel.jbang.kamelets.version')"
   - camel:
       jbang:
         run:

--- a/tests/camel-kamelets-itest/src/test/resources/avro/avro-serdes-action.citrus.it.yaml
+++ b/tests/camel-kamelets-itest/src/test/resources/avro/avro-serdes-action.citrus.it.yaml
@@ -19,11 +19,15 @@ name: avro-serdes-action-test
 variables:
   - name: "uuid"
     value: citrus:randomUUID()
+  - name: "camelVersion"
+    value: "citrus:systemProperty('citrus.camel.jbang.version')"
+  - name: "kameletsVersion"
+    value: "citrus:systemProperty('citrus.camel.jbang.kamelets.version')"
 actions:
   - echo:
-      message: "Camel JBang version: citrus:env('citrus.camel.jbang.version')"
+      message: "Camel JBang version: ${camelVersion}"
   - echo:
-      message: "Kamelets version: citrus:env('citrus.camel.jbang.kamelets.version')"
+      message: "Kamelets version: ${kameletsVersion}"
   - camel:
       jbang:
         run:


### PR DESCRIPTION
Starting to work through the integration test failures - there seem to be multiple issues and I think it makes sense to handle them one by one.

The citrus-application.properties file being used contains hardcoded versions of kamelets and camel - we want it to use the versions for testing that are defined in the camel-kamelets pom.xml - so for kamelets, we'd like `${project.version}` and for camel we would like `${camel.version}`.      Make this file a filtered testResource and ensure that the rest of src/test/resources remain unfiltered.

Log the values of citrus.camel.jbang.version and citrus.camel.jbang.kamelets.version to ensure that this fix works in the integration tests.

I expect that after this PR integration tests will still fail as there are other issues (will be handled in separate PRs)