### PR TITLE
Fix #2824: Upgrade Camel to 4.18.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-dependencies</artifactId>
-	<version>4.18.1</version>
+	<version>4.18.2</version>
     </parent>
 
     <groupId>org.apache.camel.kamelets</groupId>
@@ -62,7 +62,7 @@
         <apache-rat-plugin.version>0.17</apache-rat-plugin.version>
         <cyclonedx-maven-plugin-version>2.9.1</cyclonedx-maven-plugin-version>
 
-        <camel.version>4.18.1</camel.version>
+        <camel.version>4.18.2</camel.version>
 
         <citrus.version>4.9.2</citrus.version>
         <jose4j.version>0.9.6</jose4j.version>


### PR DESCRIPTION
Upgrades the Apache Camel dependency from 4.18.1 to 4.18.2 on the 4.18.x maintenance branch.

Closes #2824