### PR TITLE
Fix #2829: Add missing x-descriptors for sslKeyPassword in Kafka kamelets

### DIFF
--- a/kamelets/kafka-batch-source.kamelet.yaml
+++ b/kamelets/kafka-batch-source.kamelet.yaml
@@ -109,6 +109,8 @@ spec:
         description: The password of the private key in the key store file.
         type: string
         format: password
+        x-descriptors:
+          - urn:camel:group:credentials
       autoCommitEnable:
         title: Auto Commit Enable
         description: If true, periodically commit to ZooKeeper the offset of messages already fetched by the consumer

--- a/kamelets/kafka-sink.kamelet.yaml
+++ b/kamelets/kafka-sink.kamelet.yaml
@@ -109,6 +109,8 @@ spec:
         description: The password of the private key in the key store file.
         type: string
         format: password
+        x-descriptors:
+          - urn:camel:group:credentials
   dependencies:
     - "camel:core"
     - "camel:kafka"

--- a/kamelets/kafka-source.kamelet.yaml
+++ b/kamelets/kafka-source.kamelet.yaml
@@ -109,6 +109,8 @@ spec:
         description: The password of the private key in the key store file.
         type: string
         format: password
+        x-descriptors:
+          - urn:camel:group:credentials
       autoCommitEnable:
         title: Auto Commit Enable
         description: If true, periodically commit to ZooKeeper the offset of messages already fetched by the consumer

--- a/library/camel-kamelets/src/main/resources/kamelets/kafka-batch-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/kafka-batch-source.kamelet.yaml
@@ -109,6 +109,8 @@ spec:
         description: The password of the private key in the key store file.
         type: string
         format: password
+        x-descriptors:
+          - urn:camel:group:credentials
       autoCommitEnable:
         title: Auto Commit Enable
         description: If true, periodically commit to ZooKeeper the offset of messages already fetched by the consumer

--- a/library/camel-kamelets/src/main/resources/kamelets/kafka-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/kafka-sink.kamelet.yaml
@@ -109,6 +109,8 @@ spec:
         description: The password of the private key in the key store file.
         type: string
         format: password
+        x-descriptors:
+          - urn:camel:group:credentials
   dependencies:
     - "camel:core"
     - "camel:kafka"

--- a/library/camel-kamelets/src/main/resources/kamelets/kafka-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/kafka-source.kamelet.yaml
@@ -109,6 +109,8 @@ spec:
         description: The password of the private key in the key store file.
         type: string
         format: password
+        x-descriptors:
+          - urn:camel:group:credentials
       autoCommitEnable:
         title: Auto Commit Enable
         description: If true, periodically commit to ZooKeeper the offset of messages already fetched by the consumer


### PR DESCRIPTION
## Summary

- Added `x-descriptors: [urn:camel:group:credentials]` to the `sslKeyPassword` property in `kafka-sink`, `kafka-source`, and `kafka-batch-source` kamelets
- This ensures UI tools (Kaoto, Hawtio) properly group and mask this sensitive field alongside other credentials
- All other password properties in these kamelets already had the correct descriptor

## Test plan

- [x] Full Maven build with tests passes (`mvn clean install`)
- [x] Verified other password fields in the same kamelets have the descriptor (consistency check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)