### PR TITLE
fix: Change YAML literal scalars to folded scalars to fix integration test timeouts

### DIFF
--- a/tests/camel-kamelets-itest/src/test/resources/avro/avro-data-type.citrus.it.yaml
+++ b/tests/camel-kamelets-itest/src/test/resources/avro/avro-data-type.citrus.it.yaml
@@ -46,7 +46,7 @@ actions:
                 - name: "http.sink.url"
                   value: "http://localhost:${avro.webhook.server.port}/user"
                 - name: "input"
-                  value: |
+                  value: >-
                     { \"id\": \"${uuid}\", \"firstname\": \"Sheldon\", \"lastname\": \"Cooper\", \"age\": 28 }
   - camel:
       jbang:

--- a/tests/camel-kamelets-itest/src/test/resources/avro/avro-serdes-action.citrus.it.yaml
+++ b/tests/camel-kamelets-itest/src/test/resources/avro/avro-serdes-action.citrus.it.yaml
@@ -46,7 +46,7 @@ actions:
                 - name: "http.sink.url"
                   value: "http://localhost:${avro.webhook.server.port}/user"
                 - name: "input"
-                  value: |
+                  value: >-
                     { \"id\": \"${uuid}\", \"firstname\": \"Sheldon\", \"lastname\": \"Cooper\", \"age\": 28 }
   - camel:
       jbang:

--- a/tests/camel-kamelets-itest/src/test/resources/aws/ddb/aws-ddb-sink-delete-item.citrus.it.yaml
+++ b/tests/camel-kamelets-itest/src/test/resources/aws/ddb/aws-ddb-sink-delete-item.citrus.it.yaml
@@ -65,7 +65,7 @@ actions:
         - name: "aws.ddb.item.title"
           value: "Back to the future"
         - name: "aws.ddb.json.data"
-          value: |
+          value: >-
             {"id": ${aws.ddb.item.id}}
   - groovy:
       script:

--- a/tests/camel-kamelets-itest/src/test/resources/aws/ddb/aws-ddb-sink-put-item.citrus.it.yaml
+++ b/tests/camel-kamelets-itest/src/test/resources/aws/ddb/aws-ddb-sink-put-item.citrus.it.yaml
@@ -65,7 +65,7 @@ actions:
         - name: "aws.ddb.item.title"
           value: "Star Wars IV"
         - name: "aws.ddb.json.data"
-          value: |
+          value: >-
             { \"id\": ${aws.ddb.item.id}, \"year\": ${aws.ddb.item.year}, \"title\": \"${aws.ddb.item.title}\" }
 
   # Create Camel JBang integration

--- a/tests/camel-kamelets-itest/src/test/resources/aws/ddb/aws-ddb-sink-update-item.citrus.it.yaml
+++ b/tests/camel-kamelets-itest/src/test/resources/aws/ddb/aws-ddb-sink-update-item.citrus.it.yaml
@@ -67,10 +67,10 @@ actions:
         - name: "aws.ddb.item.title.new"
           value: "King Kong - Historical"
         - name: "aws.ddb.item.directors"
-          value: |
+          value: >-
             [\"Merian C. Cooper\", \"Ernest B. Schoedsack\"]
         - name: "aws.ddb.json.data"
-          value: |
+          value: >-
             { \"key\": {\"id\": ${aws.ddb.item.id}}, \"item\": {\"title\": \"${aws.ddb.item.title.new}\", \"year\": ${aws.ddb.item.year}, \"directors\": ${aws.ddb.item.directors}} }
   - groovy:
       script:

--- a/tests/camel-kamelets-itest/src/test/resources/aws/eventbridge/aws-eventbridge-sink.citrus.it.yaml
+++ b/tests/camel-kamelets-itest/src/test/resources/aws/eventbridge/aws-eventbridge-sink.citrus.it.yaml
@@ -32,7 +32,7 @@ variables:
   - name: "aws.eventbridge.detailType"
     value: "Object Created"
   - name: "aws.eventbridge.json.data"
-    value: |
+    value: >-
       { \"message\": \"Hello AWS EventBridge!\" }
   - name: "timer.source.period"
     value: "10000"

--- a/tests/camel-kamelets-itest/src/test/resources/aws/kinesis/aws-kinesis-sink.citrus.it.yaml
+++ b/tests/camel-kamelets-itest/src/test/resources/aws/kinesis/aws-kinesis-sink.citrus.it.yaml
@@ -26,7 +26,7 @@ variables:
   - name: "aws.kinesis.message"
     value: "Camel rocks!"
   - name: "aws.kinesis.json.data"
-    value: |
+    value: >-
       { \"message\": \"${aws.kinesis.message}\" }
   - name: "timer.source.period"
     value: "10000"

--- a/tests/camel-kamelets-itest/src/test/resources/openapi/rest-openapi-sink-add-pet.citrus.it.yaml
+++ b/tests/camel-kamelets-itest/src/test/resources/openapi/rest-openapi-sink-add-pet.citrus.it.yaml
@@ -40,7 +40,7 @@ actions:
                 - name: "petId"
                   value: "${petId}"
                 - name: "pet"
-                  value: |
+                  value: >-
                     { \"id\": ${petId}, \"name\": \"fluffy\", \"category\": {\"id\": ${petId}, \"name\": \"dog\"}, \"photoUrls\": [ \"petstore/v3/photos/${petId}\" ], \"tags\": [{\"id\": ${petId}, \"name\": \"generated\"}], \"status\": \"available\"}
                 - name: "spec.operation"
                   value: "${spec.operation}"

--- a/tests/camel-kamelets-itest/src/test/resources/protobuf/protobuf-data-type.citrus.it.yaml
+++ b/tests/camel-kamelets-itest/src/test/resources/protobuf/protobuf-data-type.citrus.it.yaml
@@ -38,7 +38,7 @@ actions:
                 - name: "http.sink.url"
                   value: "http://localhost:${protobuf.webhook.server.port}/user"
                 - name: "input"
-                  value: |
+                  value: >-
                     { \"id\": \"${uuid}\", \"firstname\": \"Sheldon\", \"lastname\": \"Cooper\", \"age\": 28 }
   - camel:
       jbang:

--- a/tests/camel-kamelets-itest/src/test/resources/protobuf/protobuf-serdes-action.citrus.it.yaml
+++ b/tests/camel-kamelets-itest/src/test/resources/protobuf/protobuf-serdes-action.citrus.it.yaml
@@ -38,7 +38,7 @@ actions:
                 - name: "http.sink.url"
                   value: "http://localhost:${protobuf.webhook.server.port}/user"
                 - name: "input"
-                  value: |
+                  value: >-
                     { \"id\": \"${uuid}\", \"firstname\": \"Sheldon\", \"lastname\": \"Cooper\", \"age\": 28 }
   - camel:
       jbang:

--- a/tests/camel-kamelets-itest/src/test/resources/transformation/data-type-action-pipe.citrus.it.yaml
+++ b/tests/camel-kamelets-itest/src/test/resources/transformation/data-type-action-pipe.citrus.it.yaml
@@ -36,7 +36,7 @@ actions:
                 - name: "http.sink.url"
                   value: "${http.server.url}"
                 - name: "input"
-                  value: |
+                  value: >-
                     { \"id\": \"${uuid}\" }
 
   # Verify Http request

--- a/tests/camel-kamelets-itest/src/test/resources/transformation/extract-field-action-pipe.citrus.it.yaml
+++ b/tests/camel-kamelets-itest/src/test/resources/transformation/extract-field-action-pipe.citrus.it.yaml
@@ -40,7 +40,7 @@ actions:
                 - name: "field.name"
                   value: "${field.name}"
                 - name: "input"
-                  value: |
+                  value: >-
                     { \"id\": \"citrus:randomUUID()\", \"${field.name}\": \"${field.value}\" }
 
   # Verify Http request

--- a/tests/camel-kamelets-itest/src/test/resources/transformation/insert-field-action-pipe.citrus.it.yaml
+++ b/tests/camel-kamelets-itest/src/test/resources/transformation/insert-field-action-pipe.citrus.it.yaml
@@ -44,7 +44,7 @@ actions:
                 - name: "field.value"
                   value: "${field.value}"
                 - name: "input"
-                  value: |
+                  value: >-
                     { \"id\": \"${id}\" }
 
   # Verify Http request


### PR DESCRIPTION
## Summary

Fixes integration test timeouts by changing YAML literal block scalars (`|`) to folded scalars (`>-`) in test configuration files.

## Problem

The `rest-openapi-sink-add-pet-test` was timing out after 123 seconds because the Camel JBang process failed to start when multi-line JSON strings were passed as command-line arguments using YAML's literal block scalar (`|`).

When YAML literal scalars are used for system properties, the newlines are preserved in the resulting command-line arguments, causing shell parsing errors that prevent the Camel integration from starting.

## Solution

Changed all instances of `value: |` to `value: >-` (folded scalar with trailing newline stripped) in test files. This folds multi-line content into single-line strings, which:
- Avoids command-line parsing issues
- Works correctly with shell arguments
- Preserves the JSON content while removing problematic newlines

## Changes

Updated 13 test configuration files across:
- OpenAPI tests (1 file)
- Transformation tests (3 files)
- Avro tests (2 files)
- Protobuf tests (2 files)
- AWS tests (5 files)

All changes are purely YAML formatting - the actual JSON content remains identical.

## Test Results

### Before
- OpenApiIT: 1/2 passing (`rest-openapi-sink-add-pet-test` timing out after 123s)

### After
- OpenApiIT: 2/2 passing (add-pet test now completes in ~11s)

### No Regressions
- All previously passing tests continue to pass
- Pre-existing test failures in AvroIT, ProtobufIT, and CommonIT remain unchanged (different root causes)

## Background

YAML Scalar Comparison:
- **Literal (`|`)**: Preserves all newlines → multi-line command arguments → shell parsing fails
- **Folded (`>-`)**: Joins lines with spaces → single-line arguments → shell parsing succeeds

This is a preventive fix that also protects other tests from similar timeout issues in the future.

🤖 Generated with [Claude Code](https://claude.com/claude-code)