### PR TITLE
ci: use relative links in security-model.adoc (follow-up to #2836)

### DIFF
--- a/docs/modules/ROOT/pages/security-model.adoc
+++ b/docs/modules/ROOT/pages/security-model.adoc
@@ -9,7 +9,7 @@ hardened in a Kamelet template or addressed by the deployment.
 
 The Kamelet Catalog is an *Apache Camel sub-project*. It does not define its own
 trust model from scratch: it *specialises* the
-https://camel.apache.org/manual/security-model.html[Apache Camel Security Model]
+link:/manual/security-model.html[Apache Camel Security Model]
 for the specific shape of a Kamelet (a pre-written, PMC-reviewed Camel route
 template distributed as YAML). Where this document is silent, the Camel Security
 Model governs. Where they overlap, this document is the more specific authority
@@ -441,7 +441,7 @@ change matches this model:
 
 The Kamelet Catalog uses the standard Apache Camel / ASF vulnerability process:
 
-* Read https://camel.apache.org/security/[Apache Camel Security].
+* Read link:/security/[Apache Camel Security].
 * Email `private-security@camel.apache.org` with the affected catalog
   version(s), the specific Kamelet, and a proof of concept that demonstrates the
   trust-boundary breach *through a shipped template in its default
@@ -577,10 +577,10 @@ revise this page rather than make an ad-hoc call.
 
 == Related documents
 
-* https://camel.apache.org/manual/security-model.html[Apache Camel Security
+* link:/manual/security-model.html[Apache Camel Security
   Model] - the parent model this page specialises.
 * xref:development.adoc[Kamelets Developer Guide] - how Kamelets are authored.
 * xref:apis/spec.adoc[Kamelet CRD specification] - the YAML contract.
-* https://camel.apache.org/security/[Apache Camel Security] - the public
+* link:/security/[Apache Camel Security] - the public
   advisory index and reporting process.
 * `SECURITY.md` (repository root) - the GitHub-rendered security pointer.


### PR DESCRIPTION
## CI Fix

**Failed run (camel-website):** https://github.com/apache/camel-website/actions/runs/25926572539

### Why a second PR

#2836 was **squash-merged with only its first commit** (`ci: escape Kamelet
placeholder syntax`). The second commit (relative links) was pushed after the
squash-merge and was therefore orphaned, so `main` still carries the 4 absolute
`https://camel.apache.org/...` links. With the camel-kafka-connector (#1774)
and camel-quarkus (#8661) fixes now merged, **this page is the sole remaining
`camel/relative-links` failure** — 4 errors in
`public/camel-kamelets/next/security-model.html`, keeping every camel-website
PR red.

### Fix

Convert the 4 in-site links to root-relative `link:/security/` and
`link:/manual/security-model.html`, matching apache/camel core
`security-model.adoc` (apache/camel#23224). The merged placeholder-escaping
fix from #2836 is preserved untouched; `private-security@camel.apache.org`
email references are unchanged.

- Documentation-only, single file, same link targets (rendered relative).
- No local Antora CLI in the environment; the camel-website Antora/htmltest
  build is the definitive check.

### Deferred Issues
None.

---
_Claude Code on behalf of Andrea Cosentino_