### PR TITLE
Exclude jackson3 artifacts coming in from citrus validation; current camel default is using jackson 2

### DIFF
--- a/tests/camel-kamelets-itest/pom.xml
+++ b/tests/camel-kamelets-itest/pom.xml
@@ -161,6 +161,22 @@
             <groupId>org.citrusframework</groupId>
             <artifactId>citrus-validation-json</artifactId>
             <scope>test</scope>
+            <!-- The current camel jackson default is jackson 2 - citrus-validation-json brings in jackson 3 -->
+            <!-- dependencies which cause confusion when trying to resolve transformers and datatypes -->
+            <exclusions>
+                <exclusion>
+                    <groupId>tools.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>tools.jackson.core</groupId>
+                    <artifactId>jackson-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>tools.jackson.dataformat</groupId>
+                    <artifactId>jackson-dataformat-yaml</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- Logging -->


### PR DESCRIPTION
We need to exclude jackson 3 artifacts coming in from citrus-validation-json - I'm trying to work out the errors in the camel-kamelet integration tests and I'm seeing issues with resolving the correct classes for datatypes and transformers in the protobuf tests.      The issue is that the jackson 3 classes being on the classpath cause the camel-jackson3 versions of datatype/transformers to be resolved while the tests expect jackson 2.

When camel moves over to using jackson 3 as the default (https://github.com/apache/camel/pull/21800) we can remove these exclusions.