### PR TITLE
Change camel version to 4.21.0-SNAPSHOT

### DIFF
--- a/library/camel-kamelets-catalog/src/test/java/org/apache/camel/kamelets/catalog/KameletsCatalogTest.java
+++ b/library/camel-kamelets-catalog/src/test/java/org/apache/camel/kamelets/catalog/KameletsCatalogTest.java
@@ -162,9 +162,9 @@ public class KameletsCatalogTest {
         verifyHeaders("azure-eventhubs-sink", 2);
         verifyHeaders("azure-functions-sink", 8);
         verifyHeaders("azure-servicebus-source", 21);
-        verifyHeaders("azure-storage-blob-source", 35);
-        verifyHeaders("azure-storage-blob-sink", 38);
-        verifyHeaders("azure-storage-blob-changefeed-source", 35);
+        verifyHeaders("azure-storage-blob-source", 39);
+        verifyHeaders("azure-storage-blob-sink", 46);
+        verifyHeaders("azure-storage-blob-changefeed-source", 39);
         verifyHeaders("azure-storage-datalake-source", 25);
         verifyHeaders("azure-storage-datalake-sink", 37);
         verifyHeaders("azure-storage-queue-source", 6);
@@ -235,7 +235,7 @@ public class KameletsCatalogTest {
         verifyHeaders("mysql-sink", 9);
         verifyHeaders("mysql-source", 0);
         verifyHeaders("nats-sink", 5);
-        verifyHeaders("nats-source", 8);
+        verifyHeaders("nats-source", 9);
         verifyHeaders("oracle-database-sink", 9);
         verifyHeaders("oracle-database-source", 0);
         verifyHeaders("postgresql-sink", 9);
@@ -249,7 +249,7 @@ public class KameletsCatalogTest {
         verifyHeaders("salesforce-delete-sink", 1);
         verifyHeaders("salesforce-update-sink", 1);
         verifyHeaders("salesforce-composite-upsert-sink", 1);
-        verifyHeaders("salesforce-source", 21);
+        verifyHeaders("salesforce-source", 22);
         verifyHeaders("scp-sink", 0);
         verifyHeaders("sftp-sink", 6);
         verifyHeaders("sftp-source", 15);

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-dependencies</artifactId>
-        <version>4.20.0</version>
+        <version>4.21.0-SNAPSHOT</version>
     </parent>
 
     <groupId>org.apache.camel.kamelets</groupId>
@@ -73,7 +73,7 @@
         <apache-rat-plugin.version>0.18</apache-rat-plugin.version>
         <cyclonedx-maven-plugin-version>2.9.1</cyclonedx-maven-plugin-version>
 
-        <camel.version>4.20.0</camel.version>
+        <camel.version>4.21.0-SNAPSHOT</camel.version>
 
         <citrus.version>4.10.1</citrus.version>
         <jose4j.version>0.9.6</jose4j.version>

--- a/tests/camel-kamelets-itest/src/test/resources-filtered/jbang.properties
+++ b/tests/camel-kamelets-itest/src/test/resources-filtered/jbang.properties
@@ -16,5 +16,5 @@
 #
 
 # Declare required additional dependencies
-run.deps=org.apache.camel:camel-jackson-avro:4.14.0,\
-org.apache.camel:camel-jackson-protobuf:4.14.0
+run.deps=org.apache.camel:camel-jackson-avro:${camel.version},\
+org.apache.camel:camel-jackson-protobuf:${camel.version}


### PR DESCRIPTION
Change camel version to 4.21.0-SNAPSHOT - main has changes that will help us get the integration tests to pass.