### PR TITLE
Add integration tests for transformation, header, filter, http, and log kamelets

### DIFF
--- a/tests/camel-kamelets-itest/src/test/java/CommonIT.java
+++ b/tests/camel-kamelets-itest/src/test/java/CommonIT.java
@@ -78,4 +78,24 @@ public class CommonIT {
     public Stream<DynamicTest> crypto() {
         return CitrusTestFactorySupport.factory(TestLoader.YAML).packageScan("crypto");
     }
+
+    @CitrusTestFactory
+    public Stream<DynamicTest> header() {
+        return CitrusTestFactorySupport.factory(TestLoader.YAML).packageScan("header");
+    }
+
+    @CitrusTestFactory
+    public Stream<DynamicTest> filter() {
+        return CitrusTestFactorySupport.factory(TestLoader.YAML).packageScan("filter");
+    }
+
+    @CitrusTestFactory
+    public Stream<DynamicTest> httpTests() {
+        return CitrusTestFactorySupport.factory(TestLoader.YAML).packageScan("http");
+    }
+
+    @CitrusTestFactory
+    public Stream<DynamicTest> log() {
+        return CitrusTestFactorySupport.factory(TestLoader.YAML).packageScan("log");
+    }
 }

--- a/tests/camel-kamelets-itest/src/test/resources/filter/has-header-filter-action-pipe.citrus.it.yaml
+++ b/tests/camel-kamelets-itest/src/test/resources/filter/has-header-filter-action-pipe.citrus.it.yaml
@@ -1,0 +1,68 @@
+# ---------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ---------------------------------------------------------------------------
+
+name: has-header-filter-action-pipe-test
+variables:
+  - name: "id"
+    value: "citrus:randomUUID()"
+  - name: "header.name"
+    value: "myTestHeader"
+  - name: "header.value"
+    value: "myTestValue"
+actions:
+  - createVariables:
+      variables:
+        - name: "http.server.url"
+          value: "http://localhost:${http.server.port}"
+  # Create Camel JBang integration
+  - camel:
+      jbang:
+        run:
+          waitForRunningState: false
+          integration:
+            file: "filter/has-header-filter-action-pipe.yaml"
+            systemProperties:
+              properties:
+                - name: "http.sink.url"
+                  value: "${http.server.url}"
+                - name: "header.name"
+                  value: "${header.name}"
+                - name: "header.value"
+                  value: "${header.value}"
+                - name: "input"
+                  value: |
+                    { \"id\": \"${id}\" }
+
+  # Verify Http request - message should pass through because header exists
+  - http:
+      server: "httpServer"
+      receiveRequest:
+        POST:
+          path: "/result"
+          headers:
+            - name: "${header.name}"
+              value: "${header.value}"
+
+  - http:
+      server: "httpServer"
+      sendResponse:
+        response:
+          status: 200
+          reasonPhrase: "OK"
+          version: "HTTP/1.1"
+          body:
+            data: "Thank You!"

--- a/tests/camel-kamelets-itest/src/test/resources/filter/has-header-filter-action-pipe.yaml
+++ b/tests/camel-kamelets-itest/src/test/resources/filter/has-header-filter-action-pipe.yaml
@@ -18,7 +18,7 @@
 apiVersion: camel.apache.org/v1
 kind: Pipe
 metadata:
-  name: extract-field-action-pipe
+  name: has-header-filter-action-pipe
 spec:
   source:
     ref:
@@ -27,14 +27,20 @@ spec:
       name: timer-source
     properties:
       period: 10000
-      contentType: application/json
       message: "{{input}}"
   steps:
     - ref:
         kind: Kamelet
         apiVersion: camel.apache.org/v1
-        name: extract-field-action
+        name: insert-header-action
       properties:
-        field: "{{field.name}}"
+        name: "{{header.name}}"
+        value: "{{header.value}}"
+    - ref:
+        kind: Kamelet
+        apiVersion: camel.apache.org/v1
+        name: has-header-filter-action
+      properties:
+        name: "{{header.name}}"
   sink:
     uri: "{{http.sink.url}}/result"

--- a/tests/camel-kamelets-itest/src/test/resources/filter/predicate-filter-action-pipe.citrus.it.yaml
+++ b/tests/camel-kamelets-itest/src/test/resources/filter/predicate-filter-action-pipe.citrus.it.yaml
@@ -1,0 +1,62 @@
+# ---------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ---------------------------------------------------------------------------
+
+name: predicate-filter-action-pipe-test
+variables:
+  - name: "name.value"
+    value: "Camel"
+actions:
+  - createVariables:
+      variables:
+        - name: "http.server.url"
+          value: "http://localhost:${http.server.port}"
+  # Create Camel JBang integration
+  - camel:
+      jbang:
+        run:
+          waitForRunningState: false
+          integration:
+            file: "filter/predicate-filter-action-pipe.yaml"
+            systemProperties:
+              properties:
+                - name: "http.sink.url"
+                  value: "${http.server.url}"
+                - name: "filter.expression"
+                  value: "@.name =~ /.*Camel.*/"
+                - name: "input"
+                  value: |
+                    { \"name\": \"${name.value}\" }
+
+  # Verify Http request - message should pass through because expression matches
+  - http:
+      server: "httpServer"
+      receiveRequest:
+        POST:
+          path: "/result"
+          body:
+            data: |
+              { "name": "${name.value}" }
+
+  - http:
+      server: "httpServer"
+      sendResponse:
+        response:
+          status: 200
+          reasonPhrase: "OK"
+          version: "HTTP/1.1"
+          body:
+            data: "Thank You!"

--- a/tests/camel-kamelets-itest/src/test/resources/filter/predicate-filter-action-pipe.yaml
+++ b/tests/camel-kamelets-itest/src/test/resources/filter/predicate-filter-action-pipe.yaml
@@ -18,7 +18,7 @@
 apiVersion: camel.apache.org/v1
 kind: Pipe
 metadata:
-  name: extract-field-action-pipe
+  name: predicate-filter-action-pipe
 spec:
   source:
     ref:
@@ -33,8 +33,8 @@ spec:
     - ref:
         kind: Kamelet
         apiVersion: camel.apache.org/v1
-        name: extract-field-action
+        name: predicate-filter-action
       properties:
-        field: "{{field.name}}"
+        expression: "{{filter.expression}}"
   sink:
     uri: "{{http.sink.url}}/result"

--- a/tests/camel-kamelets-itest/src/test/resources/header/insert-header-action-pipe.citrus.it.yaml
+++ b/tests/camel-kamelets-itest/src/test/resources/header/insert-header-action-pipe.citrus.it.yaml
@@ -1,0 +1,68 @@
+# ---------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ---------------------------------------------------------------------------
+
+name: insert-header-action-pipe-test
+variables:
+  - name: "id"
+    value: "citrus:randomUUID()"
+  - name: "header.name"
+    value: "myTestHeader"
+  - name: "header.value"
+    value: "myTestValue"
+actions:
+  - createVariables:
+      variables:
+        - name: "http.server.url"
+          value: "http://localhost:${http.server.port}"
+  # Create Camel JBang integration
+  - camel:
+      jbang:
+        run:
+          waitForRunningState: false
+          integration:
+            file: "header/insert-header-action-pipe.yaml"
+            systemProperties:
+              properties:
+                - name: "http.sink.url"
+                  value: "${http.server.url}"
+                - name: "header.name"
+                  value: "${header.name}"
+                - name: "header.value"
+                  value: "${header.value}"
+                - name: "input"
+                  value: |
+                    { \"id\": \"${id}\" }
+
+  # Verify Http request with the inserted header
+  - http:
+      server: "httpServer"
+      receiveRequest:
+        POST:
+          path: "/result"
+          headers:
+            - name: "${header.name}"
+              value: "${header.value}"
+
+  - http:
+      server: "httpServer"
+      sendResponse:
+        response:
+          status: 200
+          reasonPhrase: "OK"
+          version: "HTTP/1.1"
+          body:
+            data: "Thank You!"

--- a/tests/camel-kamelets-itest/src/test/resources/header/insert-header-action-pipe.yaml
+++ b/tests/camel-kamelets-itest/src/test/resources/header/insert-header-action-pipe.yaml
@@ -18,7 +18,7 @@
 apiVersion: camel.apache.org/v1
 kind: Pipe
 metadata:
-  name: extract-field-action-pipe
+  name: insert-header-action-pipe
 spec:
   source:
     ref:
@@ -27,14 +27,14 @@ spec:
       name: timer-source
     properties:
       period: 10000
-      contentType: application/json
       message: "{{input}}"
   steps:
     - ref:
         kind: Kamelet
         apiVersion: camel.apache.org/v1
-        name: extract-field-action
+        name: insert-header-action
       properties:
-        field: "{{field.name}}"
+        name: "{{header.name}}"
+        value: "{{header.value}}"
   sink:
     uri: "{{http.sink.url}}/result"

--- a/tests/camel-kamelets-itest/src/test/resources/http/http-sink-pipe.citrus.it.yaml
+++ b/tests/camel-kamelets-itest/src/test/resources/http/http-sink-pipe.citrus.it.yaml
@@ -1,0 +1,60 @@
+# ---------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ---------------------------------------------------------------------------
+
+name: http-sink-pipe-test
+variables:
+  - name: "id"
+    value: "citrus:randomUUID()"
+actions:
+  - createVariables:
+      variables:
+        - name: "http.server.url"
+          value: "http://localhost:${http.server.port}"
+  # Create Camel JBang integration
+  - camel:
+      jbang:
+        run:
+          waitForRunningState: false
+          integration:
+            file: "http/http-sink-pipe.yaml"
+            systemProperties:
+              properties:
+                - name: "http.sink.url"
+                  value: "${http.server.url}"
+                - name: "input"
+                  value: |
+                    { \"id\": \"${id}\", \"message\": \"Hello from http-sink\" }
+
+  # Verify Http request received by the mock server
+  - http:
+      server: "httpServer"
+      receiveRequest:
+        POST:
+          path: "/result"
+          body:
+            data: |
+              { "id": "${id}", "message": "Hello from http-sink" }
+
+  - http:
+      server: "httpServer"
+      sendResponse:
+        response:
+          status: 200
+          reasonPhrase: "OK"
+          version: "HTTP/1.1"
+          body:
+            data: "Thank You!"

--- a/tests/camel-kamelets-itest/src/test/resources/http/http-sink-pipe.yaml
+++ b/tests/camel-kamelets-itest/src/test/resources/http/http-sink-pipe.yaml
@@ -18,7 +18,7 @@
 apiVersion: camel.apache.org/v1
 kind: Pipe
 metadata:
-  name: extract-field-action-pipe
+  name: http-sink-pipe
 spec:
   source:
     ref:
@@ -27,14 +27,12 @@ spec:
       name: timer-source
     properties:
       period: 10000
-      contentType: application/json
       message: "{{input}}"
-  steps:
-    - ref:
-        kind: Kamelet
-        apiVersion: camel.apache.org/v1
-        name: extract-field-action
-      properties:
-        field: "{{field.name}}"
   sink:
-    uri: "{{http.sink.url}}/result"
+    ref:
+      kind: Kamelet
+      apiVersion: camel.apache.org/v1
+      name: http-sink
+    properties:
+      url: "{{http.sink.url}}/result"
+      method: "POST"

--- a/tests/camel-kamelets-itest/src/test/resources/http/http-source-to-http.citrus.it.yaml
+++ b/tests/camel-kamelets-itest/src/test/resources/http/http-source-to-http.citrus.it.yaml
@@ -1,0 +1,78 @@
+# ---------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ---------------------------------------------------------------------------
+
+name: http-source-to-http-test
+variables:
+  - name: "id"
+    value: "citrus:randomUUID()"
+actions:
+  - createVariables:
+      variables:
+        - name: "http.server.url"
+          value: "http://localhost:${http.server.port}"
+  # Create Camel JBang integration
+  - camel:
+      jbang:
+        run:
+          waitForRunningState: false
+          integration:
+            file: "http/http-source-to-http.yaml"
+            systemProperties:
+              properties:
+                - name: "http.source.url"
+                  value: "${http.server.url}"
+                - name: "http.sink.url"
+                  value: "${http.server.url}"
+
+  # The http-source will poll GET /data - respond with test data
+  - http:
+      server: "httpServer"
+      receiveRequest:
+        GET:
+          path: "/data"
+
+  - http:
+      server: "httpServer"
+      sendResponse:
+        response:
+          status: 200
+          reasonPhrase: "OK"
+          version: "HTTP/1.1"
+          contentType: "application/json"
+          body:
+            data: |
+              { "id": "${id}", "message": "Hello from http-source" }
+
+  # Verify the data arrives at the sink endpoint
+  - http:
+      server: "httpServer"
+      receiveRequest:
+        POST:
+          path: "/result"
+          body:
+            data: |
+              { "id": "${id}", "message": "Hello from http-source" }
+
+  - http:
+      server: "httpServer"
+      sendResponse:
+        response:
+          status: 200
+          reasonPhrase: "OK"
+          version: "HTTP/1.1"
+          body:
+            data: "Thank You!"

--- a/tests/camel-kamelets-itest/src/test/resources/http/http-source-to-http.yaml
+++ b/tests/camel-kamelets-itest/src/test/resources/http/http-source-to-http.yaml
@@ -18,23 +18,16 @@
 apiVersion: camel.apache.org/v1
 kind: Pipe
 metadata:
-  name: extract-field-action-pipe
+  name: http-source-to-http
 spec:
   source:
     ref:
       kind: Kamelet
       apiVersion: camel.apache.org/v1
-      name: timer-source
+      name: http-source
     properties:
+      url: "{{http.source.url}}/data"
       period: 10000
       contentType: application/json
-      message: "{{input}}"
-  steps:
-    - ref:
-        kind: Kamelet
-        apiVersion: camel.apache.org/v1
-        name: extract-field-action
-      properties:
-        field: "{{field.name}}"
   sink:
     uri: "{{http.sink.url}}/result"

--- a/tests/camel-kamelets-itest/src/test/resources/log/log-sink-pipe.citrus.it.yaml
+++ b/tests/camel-kamelets-itest/src/test/resources/log/log-sink-pipe.citrus.it.yaml
@@ -15,26 +15,26 @@
 # limitations under the License.
 # ---------------------------------------------------------------------------
 
-apiVersion: camel.apache.org/v1
-kind: Pipe
-metadata:
-  name: extract-field-action-pipe
-spec:
-  source:
-    ref:
-      kind: Kamelet
-      apiVersion: camel.apache.org/v1
-      name: timer-source
-    properties:
-      period: 10000
-      contentType: application/json
-      message: "{{input}}"
-  steps:
-    - ref:
-        kind: Kamelet
-        apiVersion: camel.apache.org/v1
-        name: extract-field-action
-      properties:
-        field: "{{field.name}}"
-  sink:
-    uri: "{{http.sink.url}}/result"
+name: log-sink-pipe-test
+variables:
+  - name: "log.message"
+    value: "Hello from log-sink test!"
+actions:
+  # Create Camel JBang integration
+  - camel:
+      jbang:
+        run:
+          waitForRunningState: false
+          integration:
+            file: "log/log-sink-pipe.yaml"
+            systemProperties:
+              properties:
+                - name: "message"
+                  value: "${log.message}"
+
+  # Verify the log output contains the message
+  - camel:
+      jbang:
+        verify:
+          integration: "log-sink-pipe"
+          logMessage: "${log.message}"

--- a/tests/camel-kamelets-itest/src/test/resources/log/log-sink-pipe.yaml
+++ b/tests/camel-kamelets-itest/src/test/resources/log/log-sink-pipe.yaml
@@ -18,7 +18,7 @@
 apiVersion: camel.apache.org/v1
 kind: Pipe
 metadata:
-  name: extract-field-action-pipe
+  name: log-sink-pipe
 spec:
   source:
     ref:
@@ -27,14 +27,12 @@ spec:
       name: timer-source
     properties:
       period: 10000
-      contentType: application/json
-      message: "{{input}}"
-  steps:
-    - ref:
-        kind: Kamelet
-        apiVersion: camel.apache.org/v1
-        name: extract-field-action
-      properties:
-        field: "{{field.name}}"
+      message: "{{message}}"
   sink:
-    uri: "{{http.sink.url}}/result"
+    ref:
+      kind: Kamelet
+      apiVersion: camel.apache.org/v1
+      name: log-sink
+    properties:
+      loggerName: "test-log-sink"
+      showHeaders: false

--- a/tests/camel-kamelets-itest/src/test/resources/transformation/data-type-action-pipe.yaml
+++ b/tests/camel-kamelets-itest/src/test/resources/transformation/data-type-action-pipe.yaml
@@ -31,8 +31,7 @@ spec:
     properties:
       period: 10000
       contentType: application/json
-      message: >
-        {{input}}
+      message: "{{input}}"
   steps:
     - ref:
         kind: Kamelet

--- a/tests/camel-kamelets-itest/src/test/resources/transformation/drop-field-action-pipe.citrus.it.yaml
+++ b/tests/camel-kamelets-itest/src/test/resources/transformation/drop-field-action-pipe.citrus.it.yaml
@@ -1,0 +1,64 @@
+# ---------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ---------------------------------------------------------------------------
+
+name: drop-field-action-pipe-test
+variables:
+  - name: "field.name"
+    value: "subject"
+  - name: "id"
+    value: "citrus:randomUUID()"
+actions:
+  - createVariables:
+      variables:
+        - name: "http.server.url"
+          value: "http://localhost:${http.server.port}"
+  # Create Camel JBang integration
+  - camel:
+      jbang:
+        run:
+          waitForRunningState: false
+          integration:
+            file: "transformation/drop-field-action-pipe.yaml"
+            systemProperties:
+              properties:
+                - name: "http.sink.url"
+                  value: "${http.server.url}"
+                - name: "field.name"
+                  value: "${field.name}"
+                - name: "input"
+                  value: |
+                    { \"id\": \"${id}\", \"${field.name}\": \"Camel rocks!\" }
+
+  # Verify Http request
+  - http:
+      server: "httpServer"
+      receiveRequest:
+        POST:
+          path: "/result"
+          body:
+            data: |
+              {"id":"${id}"}
+
+  - http:
+      server: "httpServer"
+      sendResponse:
+        response:
+          status: 200
+          reasonPhrase: "OK"
+          version: "HTTP/1.1"
+          body:
+            data: "Thank You!"

--- a/tests/camel-kamelets-itest/src/test/resources/transformation/drop-field-action-pipe.yaml
+++ b/tests/camel-kamelets-itest/src/test/resources/transformation/drop-field-action-pipe.yaml
@@ -18,7 +18,7 @@
 apiVersion: camel.apache.org/v1
 kind: Pipe
 metadata:
-  name: extract-field-action-pipe
+  name: drop-field-action-pipe
 spec:
   source:
     ref:
@@ -33,7 +33,7 @@ spec:
     - ref:
         kind: Kamelet
         apiVersion: camel.apache.org/v1
-        name: extract-field-action
+        name: drop-field-action
       properties:
         field: "{{field.name}}"
   sink:

--- a/tests/camel-kamelets-itest/src/test/resources/transformation/hoist-field-action-pipe.citrus.it.yaml
+++ b/tests/camel-kamelets-itest/src/test/resources/transformation/hoist-field-action-pipe.citrus.it.yaml
@@ -1,0 +1,64 @@
+# ---------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ---------------------------------------------------------------------------
+
+name: hoist-field-action-pipe-test
+variables:
+  - name: "id"
+    value: "citrus:randomUUID()"
+  - name: "hoist.field"
+    value: "wrapped"
+actions:
+  - createVariables:
+      variables:
+        - name: "http.server.url"
+          value: "http://localhost:${http.server.port}"
+  # Create Camel JBang integration
+  - camel:
+      jbang:
+        run:
+          waitForRunningState: false
+          integration:
+            file: "transformation/hoist-field-action-pipe.yaml"
+            systemProperties:
+              properties:
+                - name: "http.sink.url"
+                  value: "${http.server.url}"
+                - name: "hoist.field"
+                  value: "${hoist.field}"
+                - name: "input"
+                  value: |
+                    { \"id\": \"${id}\" }
+
+  # Verify Http request
+  - http:
+      server: "httpServer"
+      receiveRequest:
+        POST:
+          path: "/result"
+          body:
+            data: |
+              {"${hoist.field}":{"id":"${id}"}}
+
+  - http:
+      server: "httpServer"
+      sendResponse:
+        response:
+          status: 200
+          reasonPhrase: "OK"
+          version: "HTTP/1.1"
+          body:
+            data: "Thank You!"

--- a/tests/camel-kamelets-itest/src/test/resources/transformation/hoist-field-action-pipe.yaml
+++ b/tests/camel-kamelets-itest/src/test/resources/transformation/hoist-field-action-pipe.yaml
@@ -18,7 +18,7 @@
 apiVersion: camel.apache.org/v1
 kind: Pipe
 metadata:
-  name: extract-field-action-pipe
+  name: hoist-field-action-pipe
 spec:
   source:
     ref:
@@ -33,8 +33,8 @@ spec:
     - ref:
         kind: Kamelet
         apiVersion: camel.apache.org/v1
-        name: extract-field-action
+        name: hoist-field-action
       properties:
-        field: "{{field.name}}"
+        field: "{{hoist.field}}"
   sink:
     uri: "{{http.sink.url}}/result"

--- a/tests/camel-kamelets-itest/src/test/resources/transformation/insert-field-action-pipe.yaml
+++ b/tests/camel-kamelets-itest/src/test/resources/transformation/insert-field-action-pipe.yaml
@@ -28,8 +28,7 @@ spec:
     properties:
       period: 10000
       contentType: application/json
-      message: >
-        {{input}}
+      message: "{{input}}"
   steps:
     - ref:
         kind: Kamelet

--- a/tests/camel-kamelets-itest/src/test/resources/transformation/mask-field-action-pipe.citrus.it.yaml
+++ b/tests/camel-kamelets-itest/src/test/resources/transformation/mask-field-action-pipe.citrus.it.yaml
@@ -1,0 +1,68 @@
+# ---------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ---------------------------------------------------------------------------
+
+name: mask-field-action-pipe-test
+variables:
+  - name: "id"
+    value: "citrus:randomUUID()"
+  - name: "mask.fields"
+    value: "password"
+  - name: "mask.replacement"
+    value: "***"
+actions:
+  - createVariables:
+      variables:
+        - name: "http.server.url"
+          value: "http://localhost:${http.server.port}"
+  # Create Camel JBang integration
+  - camel:
+      jbang:
+        run:
+          waitForRunningState: false
+          integration:
+            file: "transformation/mask-field-action-pipe.yaml"
+            systemProperties:
+              properties:
+                - name: "http.sink.url"
+                  value: "${http.server.url}"
+                - name: "mask.fields"
+                  value: "${mask.fields}"
+                - name: "mask.replacement"
+                  value: "${mask.replacement}"
+                - name: "input"
+                  value: |
+                    { \"id\": \"${id}\", \"password\": \"secret123\" }
+
+  # Verify Http request
+  - http:
+      server: "httpServer"
+      receiveRequest:
+        POST:
+          path: "/result"
+          body:
+            data: |
+              {"id":"${id}","password":"${mask.replacement}"}
+
+  - http:
+      server: "httpServer"
+      sendResponse:
+        response:
+          status: 200
+          reasonPhrase: "OK"
+          version: "HTTP/1.1"
+          body:
+            data: "Thank You!"

--- a/tests/camel-kamelets-itest/src/test/resources/transformation/mask-field-action-pipe.yaml
+++ b/tests/camel-kamelets-itest/src/test/resources/transformation/mask-field-action-pipe.yaml
@@ -18,7 +18,7 @@
 apiVersion: camel.apache.org/v1
 kind: Pipe
 metadata:
-  name: extract-field-action-pipe
+  name: mask-field-action-pipe
 spec:
   source:
     ref:
@@ -33,8 +33,9 @@ spec:
     - ref:
         kind: Kamelet
         apiVersion: camel.apache.org/v1
-        name: extract-field-action
+        name: mask-field-action
       properties:
-        field: "{{field.name}}"
+        fields: "{{mask.fields}}"
+        replacement: "{{mask.replacement}}"
   sink:
     uri: "{{http.sink.url}}/result"

--- a/tests/camel-kamelets-itest/src/test/resources/transformation/replace-field-action-pipe.citrus.it.yaml
+++ b/tests/camel-kamelets-itest/src/test/resources/transformation/replace-field-action-pipe.citrus.it.yaml
@@ -1,0 +1,62 @@
+# ---------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ---------------------------------------------------------------------------
+
+name: replace-field-action-pipe-test
+variables:
+  - name: "field.value"
+    value: "Camel rocks!"
+actions:
+  - createVariables:
+      variables:
+        - name: "http.server.url"
+          value: "http://localhost:${http.server.port}"
+  # Create Camel JBang integration
+  - camel:
+      jbang:
+        run:
+          waitForRunningState: false
+          integration:
+            file: "transformation/replace-field-action-pipe.yaml"
+            systemProperties:
+              properties:
+                - name: "http.sink.url"
+                  value: "${http.server.url}"
+                - name: "renames"
+                  value: "oldName:newName"
+                - name: "input"
+                  value: |
+                    { \"oldName\": \"${field.value}\" }
+
+  # Verify Http request
+  - http:
+      server: "httpServer"
+      receiveRequest:
+        POST:
+          path: "/result"
+          body:
+            data: |
+              {"newName":"${field.value}"}
+
+  - http:
+      server: "httpServer"
+      sendResponse:
+        response:
+          status: 200
+          reasonPhrase: "OK"
+          version: "HTTP/1.1"
+          body:
+            data: "Thank You!"

--- a/tests/camel-kamelets-itest/src/test/resources/transformation/replace-field-action-pipe.yaml
+++ b/tests/camel-kamelets-itest/src/test/resources/transformation/replace-field-action-pipe.yaml
@@ -18,7 +18,7 @@
 apiVersion: camel.apache.org/v1
 kind: Pipe
 metadata:
-  name: extract-field-action-pipe
+  name: replace-field-action-pipe
 spec:
   source:
     ref:
@@ -33,8 +33,8 @@ spec:
     - ref:
         kind: Kamelet
         apiVersion: camel.apache.org/v1
-        name: extract-field-action
+        name: replace-field-action
       properties:
-        field: "{{field.name}}"
+        renames: "{{renames}}"
   sink:
     uri: "{{http.sink.url}}/result"


### PR DESCRIPTION
## Summary

- Add 10 new Citrus integration tests covering actions, sources, and sinks:
  - **Transformation actions (4):** drop-field, mask-field, replace-field, hoist-field
  - **Header actions (1):** insert-header
  - **Filter actions (2):** predicate-filter, has-header-filter
  - **Source kamelets (1):** http-source
  - **Sink kamelets (2):** http-sink, log-sink
- Fix YAML folded block scalar (`message: >`) to quoted string in existing pipe definitions (extract-field, insert-field, data-type) to avoid trailing newline in property resolution
- Add 4 new `@CitrusTestFactory` methods to `CommonIT.java` for the new test categories (`header`, `filter`, `httpTests`, `log`)

## Test plan

- [ ] Verify all new pipe definitions start correctly with Camel JBang
- [ ] Run `CommonIT` integration tests and verify new tests pass
- [ ] Verify existing tests (earthquake, timer) still pass
- [ ] Verify the YAML message property fix resolves property resolution for existing transformation tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)