### PR TITLE
Use folded scalars to fix item issues in filter integration tests

### DIFF
--- a/tests/camel-kamelets-itest/src/test/resources/filter/has-header-filter-action-pipe.citrus.it.yaml
+++ b/tests/camel-kamelets-itest/src/test/resources/filter/has-header-filter-action-pipe.citrus.it.yaml
@@ -44,7 +44,7 @@ actions:
                 - name: "header.value"
                   value: "${header.value}"
                 - name: "input"
-                  value: |
+                  value: >-
                     { \"id\": \"${id}\" }
 
   # Verify Http request - message should pass through because header exists

--- a/tests/camel-kamelets-itest/src/test/resources/filter/predicate-filter-action-pipe.citrus.it.yaml
+++ b/tests/camel-kamelets-itest/src/test/resources/filter/predicate-filter-action-pipe.citrus.it.yaml
@@ -38,7 +38,7 @@ actions:
                 - name: "filter.expression"
                   value: "@.name =~ /.*Camel.*/"
                 - name: "input"
-                  value: |
+                  value: >-
                     { \"name\": \"${name.value}\" }
 
   # Verify Http request - message should pass through because expression matches


### PR DESCRIPTION
The item was not being parsed correctly in the filter integration tests - use folded scalars to fix item issues in filter integration tests