### PR TITLE
CAMEL-23655: Update GitHub topics for better discoverability

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -24,8 +24,20 @@ github:
   homepage: https://camel.apache.org
   labels:
     - camel
-    - integration
     - kamelet
+    - integration
+    - integration-framework
+    - enterprise-integration-patterns
+    - java
+    - low-code
+    - yaml
+    - cloud-native
+    - kafka
+    - rest-api
+    - data-transformation
+    - middleware
+    - microservices
+    - mcp
   enabled_merge_buttons:
     merge: false
     rebase: true


### PR DESCRIPTION
## Summary

- Expand GitHub topics from 3 to 15 (out of 20 max) to improve discoverability
- Add `integration-framework`, `enterprise-integration-patterns`
- Add `low-code`, `yaml`, `java`
- Add deployment/ecosystem: `cloud-native`, `kafka`
- Add capabilities: `rest-api`, `data-transformation`, `middleware`
- Add `microservices`, `mcp`
- Keep `kamelet`

Follows the same topic expansion done in apache/camel#23673.

## Test plan

- [ ] After merge, verify topics appear on https://github.com/apache/camel-kamelets

_Claude Code on behalf of Claus Ibsen_