### PR TITLE
Fix Kafka SMT kamelets for CAMEL-23584 header rename

### DIFF
--- a/kamelets/timestamp-router-action.kamelet.yaml
+++ b/kamelets/timestamp-router-action.kamelet.yaml
@@ -46,7 +46,7 @@ spec:
         title: Timestamp Header Name
         description: The name of the header containing a timestamp
         type: string
-        default: "kafka.TIMESTAMP"
+        default: "CamelKafkaTimestamp"
       topicHeaderName:
         title: Topic Header Name
         description: The name of the header containing the topic name. When not set, the default Kafka topic header (CamelKafkaTopic) is used.

--- a/kamelets/topic-name-matches-filter-action.kamelet.yaml
+++ b/kamelets/topic-name-matches-filter-action.kamelet.yaml
@@ -47,6 +47,6 @@ spec:
       uri: kamelet:source
       steps:
       - filter:
-          simple: "${header[kafka.TOPIC]} !regex '{{regex}}'"
+          simple: "${header[CamelKafkaTopic]} !regex '{{regex}}'"
           steps:
             - stop: {}

--- a/library/camel-kamelets/src/main/resources/kamelets/timestamp-router-action.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/timestamp-router-action.kamelet.yaml
@@ -46,7 +46,7 @@ spec:
         title: Timestamp Header Name
         description: The name of the header containing a timestamp
         type: string
-        default: "kafka.TIMESTAMP"
+        default: "CamelKafkaTimestamp"
       topicHeaderName:
         title: Topic Header Name
         description: The name of the header containing the topic name. When not set, the default Kafka topic header (CamelKafkaTopic) is used.

--- a/library/camel-kamelets/src/main/resources/kamelets/topic-name-matches-filter-action.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/topic-name-matches-filter-action.kamelet.yaml
@@ -47,6 +47,6 @@ spec:
       uri: kamelet:source
       steps:
       - filter:
-          simple: "${header[kafka.TOPIC]} !regex '{{regex}}'"
+          simple: "${header[CamelKafkaTopic]} !regex '{{regex}}'"
           steps:
             - stop: {}


### PR DESCRIPTION
## Summary

CAMEL-23584 renamed all camel-kafka Exchange header constants from `kafka.*` to `CamelKafka*` prefix, but two kamelet YAML definitions were not updated, causing silent failures:

- **topic-name-matches-filter-action**: `${header[kafka.TOPIC]}` is always null → filter drops all messages
- **timestamp-router-action**: `timestampHeaderName` defaults to `kafka.TIMESTAMP` (null) → timestamp never read → override topic never set

## Changes

- `topic-name-matches-filter-action.kamelet.yaml`: `${header[kafka.TOPIC]}` → `${header[CamelKafkaTopic]}`
- `timestamp-router-action.kamelet.yaml`: `timestampHeaderName` default `kafka.TIMESTAMP` → `CamelKafkaTimestamp`

Both in `kamelets/` and `library/camel-kamelets/src/main/resources/kamelets/`.