### PR TITLE
ci: validate all Kamelets (remove early break in listKamelets)

### DIFF
--- a/script/validator/validator.go
+++ b/script/validator/validator.go
@@ -317,7 +317,6 @@ func listKamelets(dir string) []KameletInfo {
 			FileName: fileName,
 		}
 		kamelets = append(kamelets, kameletInfo)
-		break
 	}
 	return kamelets
 }
@@ -326,6 +325,7 @@ func verifyUsedParams(kamelets []KameletInfo) (errors []error) {
 	for _, k := range kamelets {
 		if k.FileName != "../../kamelets/azure-storage-blob-source.kamelet.yaml" &&
 			k.FileName != "../../kamelets/aws-s3-event-based-source.kamelet.yaml" &&
+			k.FileName != "../../kamelets/aws-sqs-source.kamelet.yaml" &&
 			k.FileName != "../../kamelets/set-kafka-key-action.kamelet.yaml" &&
 			k.FileName != "../../kamelets/azure-storage-blob-event-based-source.kamelet.yaml" &&
 			k.FileName != "../../kamelets/google-storage-event-based-source.kamelet.yaml" &&
@@ -334,7 +334,8 @@ func verifyUsedParams(kamelets []KameletInfo) (errors []error) {
 			k.FileName != "../../kamelets/kafka-azure-schema-registry-source.kamelet.yaml" &&
 			k.FileName != "../../kamelets/kafka-azure-schema-registry-sink.kamelet.yaml" &&
 			k.FileName != "../../kamelets/kafka-batch-azure-schema-registry-source.kamelet.yaml" &&
-			k.FileName != "../../kamelets/cassandra-sink.kamelet.yaml" {
+			k.FileName != "../../kamelets/cassandra-sink.kamelet.yaml" &&
+			k.FileName != "../../kamelets/data-type-action.kamelet.yaml" {
 			used := getUsedParams(k.Kamelet)
 			declared := getDeclaredParams(k.Kamelet)
 			for p := range used {


### PR DESCRIPTION
## Summary

`listKamelets` in `script/validator/validator.go` appended the first Kamelet file and then `break`-ed out of the loop, so the validator only ever inspected **one** Kamelet (`avro-deserialize-action`, alphabetically first) out of ~250. Every rule (`verifyParameters`, `verifyDescriptors`, `verifyAnnotations`, `verifyUsedParams`, …) silently ran against that single file and the tool exited `0`.

The stray `break` was introduced in `1caed85e3` (2025-09-05, _"make the golang independent from camel k"_), so the catalog's authoring safety net — the `cd script/validator && go run . ../../kamelets/` gate referenced in CI and in the contributor guide — has effectively been a no-op for ~9 months.

## Fix

Remove the stray `break` so every Kamelet is validated again.

Re-arming the validator surfaced exactly two latent `declared-but-never-used` findings in Kamelets that had simply never been checked:

- **`aws-sqs-source` → `queueURL`**: a vestigial KEDA scaler hint (added in 2022 together with KEDA markers; the KEDA descriptors were later removed). Its twin `aws-s3-event-based-source` carries the same property and is already in the `verifyUsedParams` exclusion list — `aws-sqs-source` was simply missed.
- **`data-type-action` → `dataTypeProcessor`**: not a parameter at all but a `template.beans` entry, used via `process: ref:`. The used-params check only detects `{{property}}` placeholders, so it does not yet recognise `ref:` / `#bean:` usage.

Both are added to the existing `verifyUsedParams` exclusion list to keep the validator green, consistent with the entries already there. Deliberately kept minimal so this can be reviewed and merged quickly to restore CI protection.

## Verification

- `go vet` and `gofmt -l`: clean.
- `go run . ../../kamelets/`: exits `0` across all 250 Kamelets.
- **Coverage proof:** injecting a violation into `log-sink` (which is *not* alphabetically first) is now reported — `ERROR: kamelet "log-sink" does not contain title`, exit `1`. Before this change it was silently ignored.

## Follow-ups (separate PRs)

- Improve `verifyUsedParams` bean / `ref:` detection and replace the hard-coded relative-path exclusion list with an in-Kamelet opt-out annotation, so the entries above (and most of the existing list) can be retired.
- Add new validator rules: reject the deprecated `urn:alm:descriptor:com.tectonic.ui` descriptors, enforce `camel.apache.org/catalog.version` matches the pom version, enforce the source→`kamelet:sink` / sink→`kamelet:source` convention, and validate dependency syntax.

---
_AI-generated by Claude Code on behalf of Andrea Cosentino (@oscerd)._
