### PR TITLE
chore: remove duplicate credentials x-descriptor

### DIFF
--- a/kamelets/crypto-decrypt-action.kamelet.yaml
+++ b/kamelets/crypto-decrypt-action.kamelet.yaml
@@ -48,7 +48,6 @@ spec:
         format: password
         x-descriptors:
           - urn:camel:group:credentials
-          - urn:camel:group:credentials
   dependencies:
     - "camel:kamelet"
     - "camel:core"

--- a/kamelets/crypto-encrypt-action.kamelet.yaml
+++ b/kamelets/crypto-encrypt-action.kamelet.yaml
@@ -48,7 +48,6 @@ spec:
         format: password
         x-descriptors:
           - urn:camel:group:credentials
-          - urn:camel:group:credentials
   dependencies:
     - "camel:kamelet"
     - "camel:core"

--- a/kamelets/spring-rabbitmq-sink.kamelet.yaml
+++ b/kamelets/spring-rabbitmq-sink.kamelet.yaml
@@ -64,7 +64,6 @@ spec:
         format: password
         x-descriptors:
         - urn:camel:group:credentials
-        - urn:camel:group:credentials
       exchangeName:
         title: Exchange name
         description: The exchange name determines the exchange the queue is bound to.

--- a/kamelets/spring-rabbitmq-source.kamelet.yaml
+++ b/kamelets/spring-rabbitmq-source.kamelet.yaml
@@ -64,7 +64,6 @@ spec:
         format: password
         x-descriptors:
         - urn:camel:group:credentials
-        - urn:camel:group:credentials
       exchangeName:
         title: Exchange name
         description: The exchange name determines the exchange the queue is bound to.


### PR DESCRIPTION
## Summary

Follow-up to #2879 (merged). That PR converted the deprecated `urn:alm:descriptor:com.tectonic.ui:password` x-descriptor to `urn:camel:group:credentials` on four properties that **already** carried the canonical `urn:camel:group:credentials`, leaving a duplicate entry. @apupier spotted it while reviewing #2881.

This removes the redundant descriptor so each property lists `urn:camel:group:credentials` exactly once.

## Affected
- `crypto-encrypt-action` — `key`
- `crypto-decrypt-action` — `key`
- `spring-rabbitmq-sink` — `password`
- `spring-rabbitmq-source` — `password`

## Verification
- Catalog-wide check: **no property has duplicate `x-descriptors`** across the 250 Kamelets.
- `script/validator` over all 250 Kamelets: no errors.
- All four files parse as valid YAML.

> Note: the "duplicate x-descriptors" class of bug would be caught automatically by a validator rule; #2881 already hardens `script/validator` and a dedup rule is noted there as a natural follow-up.

---
_AI-generated by Claude Code on behalf of Andrea Cosentino (@oscerd)._
