### PR TITLE
chore: add Citrus test for counter-source

### DIFF
--- a/tests/camel-kamelets-itest/src/test/java/CommonIT.java
+++ b/tests/camel-kamelets-itest/src/test/java/CommonIT.java
@@ -98,4 +98,9 @@ public class CommonIT {
     public Stream<DynamicTest> log() {
         return CitrusTestFactorySupport.factory(TestLoader.YAML).packageScan("log");
     }
+
+    @CitrusTestFactory
+    public Stream<DynamicTest> counter() {
+        return CitrusTestFactorySupport.factory(TestLoader.YAML).packageScan("counter");
+    }
 }

--- a/tests/camel-kamelets-itest/src/test/resources/counter/counter-source-pipe.citrus.it.yaml
+++ b/tests/camel-kamelets-itest/src/test/resources/counter/counter-source-pipe.citrus.it.yaml
@@ -1,0 +1,33 @@
+# ---------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ---------------------------------------------------------------------------
+
+name: counter-source-pipe-test
+actions:
+  # Run the counter-source -> log-sink Pipe via Camel JBang
+  - camel:
+      jbang:
+        run:
+          waitForRunningState: false
+          integration:
+            file: "counter/counter-source-pipe.yaml"
+
+  # Verify the generated sequential number reaches the log sink
+  - camel:
+      jbang:
+        verify:
+          integration: "counter-source-pipe"
+          logMessage: "777777"

--- a/tests/camel-kamelets-itest/src/test/resources/counter/counter-source-pipe.yaml
+++ b/tests/camel-kamelets-itest/src/test/resources/counter/counter-source-pipe.yaml
@@ -1,0 +1,39 @@
+# ---------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ---------------------------------------------------------------------------
+
+apiVersion: camel.apache.org/v1
+kind: Pipe
+metadata:
+  name: counter-source-pipe
+spec:
+  source:
+    ref:
+      kind: Kamelet
+      apiVersion: camel.apache.org/v1
+      name: counter-source
+    properties:
+      period: 1000
+      start: 777777
+      numbers: 1
+  sink:
+    ref:
+      kind: Kamelet
+      apiVersion: camel.apache.org/v1
+      name: log-sink
+    properties:
+      loggerName: "test-counter-source"
+      showHeaders: false


### PR DESCRIPTION
## Summary

`counter-source` carries the `camel.apache.org/kamelet.verified: "true"` label, but had **no behaviour test** under `tests/camel-kamelets-itest`. Per the catalog convention the verified label means "passing behaviour tests", so this adds the missing Citrus test rather than dropping the label.

## What it does
- `tests/.../resources/counter/counter-source-pipe.yaml` — a Pipe running `counter-source` → `log-sink` (`start: 777777`, `numbers: 1`).
- `tests/.../resources/counter/counter-source-pipe.citrus.it.yaml` — runs the Pipe via Camel JBang and verifies the generated sequential number reaches the sink (`logMessage: "777777"`).
- Registers the new `counter` package in `CommonIT`.

## Verification
- `mvn verify -Dit.test=CommonIT#counter` → **TEST SUCCESS** (`Verified Camel integration 'counter-source-pipe' ... All values OK!`, ~29s).
- Smoke-tested the Kamelet directly via `camel run`: it loads, the `counter` `AtomicInteger` bean resolves, and it emits the sequence with `Content-Type: text/plain`. (Relevant to #2771 — the bean-backed `counter-source` loads and runs on the current catalog version, `4.21.0-SNAPSHOT`.)

---
_AI-generated by Claude Code on behalf of Andrea Cosentino (@oscerd)._
