### PR TITLE
Fix #2830: Remove deprecated Camel endpoint options from pulsar-sink and slack-sink

### DIFF
--- a/kamelets/pulsar-sink.kamelet.yaml
+++ b/kamelets/pulsar-sink.kamelet.yaml
@@ -112,11 +112,6 @@ spec:
         description: "Size of the pending massages queue. When the queue is full, by default, any further sends will fail unless blockIfQueueFull=true."
         type: integer
         default: 1000
-      maxPendingMessagesAcrossPartitions:
-        title: Maximum Pending Messages Across Partitions
-        description: "The maximum number of pending messages for partitioned topics. The `maxPendingMessages` value is reduced if (number of partitions `maxPendingMessages`) exceeds this value. Partitioned topics have a pending message queue for each partition."
-        type: integer
-        default: 50000
       messageRoutingMode:
         title: Message Routing Mode
         description: "Message Routing Mode to use."
@@ -151,7 +146,6 @@ spec:
               initialSequenceId: "{{?initialSequenceId}}"
               lazyStartProducer: "{{?lazyStartProducer}}"
               maxPendingMessages: "{{?maxPendingMessages}}"
-              maxPendingMessagesAcrossPartitions: "{{?maxPendingMessagesAcrossPartitions}}"
               messageRoutingMode: "{{?messageRoutingMode}}"
               producerName: "{{?producerName}}"
               sendTimeoutMs: "{{?sendTimeoutMs}}"

--- a/kamelets/slack-sink.kamelet.yaml
+++ b/kamelets/slack-sink.kamelet.yaml
@@ -48,14 +48,6 @@ spec:
         format: password
         x-descriptors:
         - urn:camel:group:credentials
-      iconEmoji:
-        title: Icon Emoji
-        description: Use a Slack emoji as an avatar.
-        type: string
-      iconUrl:
-        title: Icon URL
-        description: The avatar to use when sending a message to a channel or user.
-        type: string
   types:
     out:
       mediaType: application/json
@@ -71,5 +63,3 @@ spec:
           uri: "slack:{{channel}}"
           parameters:
             webhookUrl: "{{webhookUrl}}"
-            iconEmoji: "{{?iconEmoji}}"
-            iconUrl: "{{?iconUrl}}"


### PR DESCRIPTION
## Summary

Addresses #2830 — audit the catalog for deprecated Camel component/option usage on the move to 4.21.0.

Audited the catalog against the **Camel 4.21.0-SNAPSHOT component catalog** (`camel catalog component --json` plus the `camel-catalog` option metadata), covering all 109 used components and the options the Kamelets actually set. Two Kamelets set **deprecated endpoint options** — fixed here. The deprecated **components** found by the audit have no safe drop-in replacement and are listed below for a PMC decision rather than a breaking change.

## Fixed in this PR

| Kamelet | Removed option | Rationale |
|---|---|---|
| `pulsar-sink` | `maxPendingMessagesAcrossPartitions` | Deprecated on `camel-pulsar`. The non-deprecated `maxPendingMessages` is **already exposed** in the same Kamelet and remains. |
| `slack-sink` | `iconEmoji`, `iconUrl` | Deprecated on `camel-slack` (Slack removed API-side bot icon overrides for modern apps). No replacement option. |

Both were **optional** properties; removed the property declarations and their template mappings only. No functional change to the core behaviour of either Kamelet.

## Audit findings that need a PMC decision (NOT changed here)

These Kamelets use deprecated **components** with no safe drop-in replacement — flagging rather than making a breaking/behavioural change in this PR:

- **`json-patch-action`** → `camel:json-patch` (deprecated): no replacement component exists in the 4.21 catalog.
- **`mqtt-source`, `mqtt-sink`** → `camel:paho` (MQTT v3, deprecated): the only sibling is `camel:paho-mqtt5` (MQTT **v5** — a protocol change), and `mqtt5-source`/`mqtt5-sink` already cover v5. Migrating would break v3 users / duplicate the v5 Kamelets.
- **`splunk-sink`, `splunk-source`** → `camel:splunk` (deprecated): `splunk-hec` is publish-only and config-incompatible; `splunk-source` (search) has no HEC equivalent, and `splunk-hec-sink` already covers HEC publishing.

Suggest tracking these in a follow-up issue for a PMC call (deprecate the affected Kamelets, accept the behavioural change, or keep them until the components are removed upstream).

## Verification
- `script/validator` over all 250 Kamelets: **no errors**.
- `mvn clean install` (full reactor, with tests): **passes**.
- No test resource references the removed options.
- Per repo convention only `kamelets/` is committed; the `library/camel-kamelets` mirror is regenerated by the post-merge regen bot.

---
_AI-generated by Claude Code on behalf of Andrea Cosentino (@oscerd)._
