### PR TITLE
Update header names for Camel 4.18.3 header renames

### DIFF
--- a/kamelets/elasticsearch-index-sink.kamelet.yaml
+++ b/kamelets/elasticsearch-index-sink.kamelet.yaml
@@ -97,27 +97,27 @@ spec:
       steps:
       - choice:
           when:
-          - simple: "${header[indexId]}"
+          - simple: "${header[CamelElasticsearchIndexId]}"
             steps:
             - setHeader:
-                name: "indexId"
-                simple: "${header[indexId]}"
+                name: "CamelElasticsearchIndexId"
+                simple: "${header[CamelElasticsearchIndexId]}"
           - simple: "${header[ce-indexid]}"
             steps:
             - setHeader:
-                name: "indexId"
+                name: "CamelElasticsearchIndexId"
                 simple: "${header[ce-indexid]}"
       - choice:
           when:
-          - simple: "${header[indexName]}"
+          - simple: "${header[CamelElasticsearchIndexName]}"
             steps:
             - setHeader:
-                name: "indexName"
-                simple: "${header[indexName]}"
+                name: "CamelElasticsearchIndexName"
+                simple: "${header[CamelElasticsearchIndexName]}"
           - simple: "${header[ce-indexname]}"
             steps:
             - setHeader:
-                name: "indexName"
+                name: "CamelElasticsearchIndexName"
                 simple: "${header[ce-indexname]}"
       - unmarshal:
           json: {}

--- a/kamelets/kafka-apicurio-registry-not-secured-sink.kamelet.yaml
+++ b/kamelets/kafka-apicurio-registry-not-secured-sink.kamelet.yaml
@@ -73,24 +73,24 @@ spec:
           - simple: "${header[key]}"
             steps:
             - setHeader:
-                name: kafka.KEY
+                name: CamelKafkaKey
                 simple: "${header[key]}"
           - simple: "${header[ce-key]}"
             steps:
             - setHeader:
-                name: kafka.KEY
+                name: CamelKafkaKey
                 simple: "${header[ce-key]}"
       - choice:
           when:
           - simple: "${header[partition-key]}"
             steps:
             - setHeader:
-                name: kafka.PARTITION_KEY
+                name: CamelKafkaPartitionKey
                 simple: "${header[partition-key]}"
           - simple: "${header[ce-partitionkey]}"
             steps:
             - setHeader:
-                name: kafka.PARTITION_KEY
+                name: CamelKafkaPartitionKey
                 simple: "${header[ce-partitionkey]}"
       - to:
           uri: "kafka:{{topic}}"

--- a/kamelets/kafka-azure-schema-registry-sink.kamelet.yaml
+++ b/kamelets/kafka-azure-schema-registry-sink.kamelet.yaml
@@ -97,24 +97,24 @@ spec:
           - simple: "${header[key]}"
             steps:
             - setHeader:
-                name: kafka.KEY
+                name: CamelKafkaKey
                 simple: "${header[key]}"
           - simple: "${header[ce-key]}"
             steps:
             - setHeader:
-                name: kafka.KEY
+                name: CamelKafkaKey
                 simple: "${header[ce-key]}"
       - choice:
           when:
           - simple: "${header[partition-key]}"
             steps:
             - setHeader:
-                name: kafka.PARTITION_KEY
+                name: CamelKafkaPartitionKey
                 simple: "${header[partition-key]}"
           - simple: "${header[ce-partitionkey]}"
             steps:
             - setHeader:
-                name: kafka.PARTITION_KEY
+                name: CamelKafkaPartitionKey
                 simple: "${header[ce-partitionkey]}"
       - to:
           uri: "kafka:{{topic}}"

--- a/kamelets/kafka-not-secured-apicurio-registry-sink.kamelet.yaml
+++ b/kamelets/kafka-not-secured-apicurio-registry-sink.kamelet.yaml
@@ -110,24 +110,24 @@ spec:
           - simple: "${header[key]}"
             steps:
             - setHeader:
-                name: kafka.KEY
+                name: CamelKafkaKey
                 simple: "${header[key]}"
           - simple: "${header[ce-key]}"
             steps:
             - setHeader:
-                name: kafka.KEY
+                name: CamelKafkaKey
                 simple: "${header[ce-key]}"
       - choice:
           when:
           - simple: "${header[partition-key]}"
             steps:
             - setHeader:
-                name: kafka.PARTITION_KEY
+                name: CamelKafkaPartitionKey
                 simple: "${header[partition-key]}"
           - simple: "${header[ce-partitionkey]}"
             steps:
             - setHeader:
-                name: kafka.PARTITION_KEY
+                name: CamelKafkaPartitionKey
                 simple: "${header[ce-partitionkey]}"
       - to:
           uri: "kafka:{{topic}}"

--- a/kamelets/kafka-sink.kamelet.yaml
+++ b/kamelets/kafka-sink.kamelet.yaml
@@ -122,24 +122,24 @@ spec:
           - simple: "${header[key]}"
             steps:
             - setHeader:
-                name: kafka.KEY
+                name: CamelKafkaKey
                 simple: "${header[key]}"
           - simple: "${header[ce-key]}"
             steps:
             - setHeader:
-                name: kafka.KEY
+                name: CamelKafkaKey
                 simple: "${header[ce-key]}"
       - choice:
           when:
           - simple: "${header[partition-key]}"
             steps:
             - setHeader:
-                name: kafka.PARTITION_KEY
+                name: CamelKafkaPartitionKey
                 simple: "${header[partition-key]}"
           - simple: "${header[ce-partitionkey]}"
             steps:
             - setHeader:
-                name: kafka.PARTITION_KEY
+                name: CamelKafkaPartitionKey
                 simple: "${header[ce-partitionkey]}"
       - to:
           uri: "kafka:{{topic}}"

--- a/kamelets/opensearch-index-sink.kamelet.yaml
+++ b/kamelets/opensearch-index-sink.kamelet.yaml
@@ -97,27 +97,27 @@ spec:
       steps:
       - choice:
           when:
-          - simple: "${header[indexId]}"
+          - simple: "${header[CamelOpensearchIndexId]}"
             steps:
             - setHeader:
-                name: "indexId"
-                simple: "${header[indexId]}"
+                name: "CamelOpensearchIndexId"
+                simple: "${header[CamelOpensearchIndexId]}"
           - simple: "${header[ce-indexid]}"
             steps:
             - setHeader:
-                name: "indexId"
+                name: "CamelOpensearchIndexId"
                 simple: "${header[ce-indexid]}"
       - choice:
           when:
-          - simple: "${header[indexName]}"
+          - simple: "${header[CamelOpensearchIndexName]}"
             steps:
             - setHeader:
-                name: "indexName"
-                simple: "${header[indexName]}"
+                name: "CamelOpensearchIndexName"
+                simple: "${header[CamelOpensearchIndexName]}"
           - simple: "${header[ce-indexname]}"
             steps:
             - setHeader:
-                name: "indexName"
+                name: "CamelOpensearchIndexName"
                 simple: "${header[ce-indexname]}"
       - unmarshal:
           json: {}

--- a/kamelets/salesforce-delete-sink.kamelet.yaml
+++ b/kamelets/salesforce-delete-sink.kamelet.yaml
@@ -99,16 +99,16 @@ spec:
       uri: kamelet:source
       steps:
         - setHeader:
-            name: sObjectId
+            name: CamelSalesforceSObjectId
             jsonpath: "$['sObjectId']"
         - setHeader:
-            name: sObjectName
+            name: CamelSalesforceSObjectName
             jsonpath: "$['sObjectName']"
         - setBody:
             simple: "${null}"
         - to:
             uri: "{{local-delete-salesforce}}:deleteSObject"
         - removeHeader:
-            name: sObjectId
+            name: CamelSalesforceSObjectId
         - removeHeader:
-            name: sObjectName
+            name: CamelSalesforceSObjectName

--- a/kamelets/salesforce-update-sink.kamelet.yaml
+++ b/kamelets/salesforce-update-sink.kamelet.yaml
@@ -93,10 +93,10 @@ spec:
       uri: kamelet:source
       steps:
         - setHeader:
-            name: sObjectId
+            name: CamelSalesforceSObjectId
             jsonpath: "$.sObjectId"
         - setHeader:
-            name: sObjectName
+            name: CamelSalesforceSObjectName
             jsonpath: "$.sObjectName"
         - transform:
             jsonpath: "$.payload"
@@ -107,6 +107,6 @@ spec:
             parameters:
               rawPayload: "true"
         - removeHeader:
-            name: sObjectId
+            name: CamelSalesforceSObjectId
         - removeHeader:
-            name: sObjectName
+            name: CamelSalesforceSObjectName

--- a/kamelets/set-kafka-key-action.kamelet.yaml
+++ b/kamelets/set-kafka-key-action.kamelet.yaml
@@ -52,7 +52,7 @@ spec:
       uri: kamelet:source
       steps:
       - setHeader:
-          name: kafka.KEY
+          name: CamelKafkaKey
           simple: "${header.{{headerName}}}"
       - choice:
           precondition: true

--- a/library/camel-kamelets/src/main/resources/kamelets/elasticsearch-index-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/elasticsearch-index-sink.kamelet.yaml
@@ -97,27 +97,27 @@ spec:
       steps:
       - choice:
           when:
-          - simple: "${header[indexId]}"
+          - simple: "${header[CamelElasticsearchIndexId]}"
             steps:
             - setHeader:
-                name: "indexId"
-                simple: "${header[indexId]}"
+                name: "CamelElasticsearchIndexId"
+                simple: "${header[CamelElasticsearchIndexId]}"
           - simple: "${header[ce-indexid]}"
             steps:
             - setHeader:
-                name: "indexId"
+                name: "CamelElasticsearchIndexId"
                 simple: "${header[ce-indexid]}"
       - choice:
           when:
-          - simple: "${header[indexName]}"
+          - simple: "${header[CamelElasticsearchIndexName]}"
             steps:
             - setHeader:
-                name: "indexName"
-                simple: "${header[indexName]}"
+                name: "CamelElasticsearchIndexName"
+                simple: "${header[CamelElasticsearchIndexName]}"
           - simple: "${header[ce-indexname]}"
             steps:
             - setHeader:
-                name: "indexName"
+                name: "CamelElasticsearchIndexName"
                 simple: "${header[ce-indexname]}"
       - unmarshal:
           json: {}

--- a/library/camel-kamelets/src/main/resources/kamelets/kafka-apicurio-registry-not-secured-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/kafka-apicurio-registry-not-secured-sink.kamelet.yaml
@@ -73,24 +73,24 @@ spec:
           - simple: "${header[key]}"
             steps:
             - setHeader:
-                name: kafka.KEY
+                name: CamelKafkaKey
                 simple: "${header[key]}"
           - simple: "${header[ce-key]}"
             steps:
             - setHeader:
-                name: kafka.KEY
+                name: CamelKafkaKey
                 simple: "${header[ce-key]}"
       - choice:
           when:
           - simple: "${header[partition-key]}"
             steps:
             - setHeader:
-                name: kafka.PARTITION_KEY
+                name: CamelKafkaPartitionKey
                 simple: "${header[partition-key]}"
           - simple: "${header[ce-partitionkey]}"
             steps:
             - setHeader:
-                name: kafka.PARTITION_KEY
+                name: CamelKafkaPartitionKey
                 simple: "${header[ce-partitionkey]}"
       - to:
           uri: "kafka:{{topic}}"

--- a/library/camel-kamelets/src/main/resources/kamelets/kafka-azure-schema-registry-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/kafka-azure-schema-registry-sink.kamelet.yaml
@@ -97,24 +97,24 @@ spec:
           - simple: "${header[key]}"
             steps:
             - setHeader:
-                name: kafka.KEY
+                name: CamelKafkaKey
                 simple: "${header[key]}"
           - simple: "${header[ce-key]}"
             steps:
             - setHeader:
-                name: kafka.KEY
+                name: CamelKafkaKey
                 simple: "${header[ce-key]}"
       - choice:
           when:
           - simple: "${header[partition-key]}"
             steps:
             - setHeader:
-                name: kafka.PARTITION_KEY
+                name: CamelKafkaPartitionKey
                 simple: "${header[partition-key]}"
           - simple: "${header[ce-partitionkey]}"
             steps:
             - setHeader:
-                name: kafka.PARTITION_KEY
+                name: CamelKafkaPartitionKey
                 simple: "${header[ce-partitionkey]}"
       - to:
           uri: "kafka:{{topic}}"

--- a/library/camel-kamelets/src/main/resources/kamelets/kafka-not-secured-apicurio-registry-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/kafka-not-secured-apicurio-registry-sink.kamelet.yaml
@@ -110,24 +110,24 @@ spec:
           - simple: "${header[key]}"
             steps:
             - setHeader:
-                name: kafka.KEY
+                name: CamelKafkaKey
                 simple: "${header[key]}"
           - simple: "${header[ce-key]}"
             steps:
             - setHeader:
-                name: kafka.KEY
+                name: CamelKafkaKey
                 simple: "${header[ce-key]}"
       - choice:
           when:
           - simple: "${header[partition-key]}"
             steps:
             - setHeader:
-                name: kafka.PARTITION_KEY
+                name: CamelKafkaPartitionKey
                 simple: "${header[partition-key]}"
           - simple: "${header[ce-partitionkey]}"
             steps:
             - setHeader:
-                name: kafka.PARTITION_KEY
+                name: CamelKafkaPartitionKey
                 simple: "${header[ce-partitionkey]}"
       - to:
           uri: "kafka:{{topic}}"

--- a/library/camel-kamelets/src/main/resources/kamelets/kafka-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/kafka-sink.kamelet.yaml
@@ -122,24 +122,24 @@ spec:
           - simple: "${header[key]}"
             steps:
             - setHeader:
-                name: kafka.KEY
+                name: CamelKafkaKey
                 simple: "${header[key]}"
           - simple: "${header[ce-key]}"
             steps:
             - setHeader:
-                name: kafka.KEY
+                name: CamelKafkaKey
                 simple: "${header[ce-key]}"
       - choice:
           when:
           - simple: "${header[partition-key]}"
             steps:
             - setHeader:
-                name: kafka.PARTITION_KEY
+                name: CamelKafkaPartitionKey
                 simple: "${header[partition-key]}"
           - simple: "${header[ce-partitionkey]}"
             steps:
             - setHeader:
-                name: kafka.PARTITION_KEY
+                name: CamelKafkaPartitionKey
                 simple: "${header[ce-partitionkey]}"
       - to:
           uri: "kafka:{{topic}}"

--- a/library/camel-kamelets/src/main/resources/kamelets/opensearch-index-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/opensearch-index-sink.kamelet.yaml
@@ -97,27 +97,27 @@ spec:
       steps:
       - choice:
           when:
-          - simple: "${header[indexId]}"
+          - simple: "${header[CamelOpensearchIndexId]}"
             steps:
             - setHeader:
-                name: "indexId"
-                simple: "${header[indexId]}"
+                name: "CamelOpensearchIndexId"
+                simple: "${header[CamelOpensearchIndexId]}"
           - simple: "${header[ce-indexid]}"
             steps:
             - setHeader:
-                name: "indexId"
+                name: "CamelOpensearchIndexId"
                 simple: "${header[ce-indexid]}"
       - choice:
           when:
-          - simple: "${header[indexName]}"
+          - simple: "${header[CamelOpensearchIndexName]}"
             steps:
             - setHeader:
-                name: "indexName"
-                simple: "${header[indexName]}"
+                name: "CamelOpensearchIndexName"
+                simple: "${header[CamelOpensearchIndexName]}"
           - simple: "${header[ce-indexname]}"
             steps:
             - setHeader:
-                name: "indexName"
+                name: "CamelOpensearchIndexName"
                 simple: "${header[ce-indexname]}"
       - unmarshal:
           json: {}

--- a/library/camel-kamelets/src/main/resources/kamelets/salesforce-delete-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/salesforce-delete-sink.kamelet.yaml
@@ -99,16 +99,16 @@ spec:
       uri: kamelet:source
       steps:
         - setHeader:
-            name: sObjectId
+            name: CamelSalesforceSObjectId
             jsonpath: "$['sObjectId']"
         - setHeader:
-            name: sObjectName
+            name: CamelSalesforceSObjectName
             jsonpath: "$['sObjectName']"
         - setBody:
             simple: "${null}"
         - to:
             uri: "{{local-delete-salesforce}}:deleteSObject"
         - removeHeader:
-            name: sObjectId
+            name: CamelSalesforceSObjectId
         - removeHeader:
-            name: sObjectName
+            name: CamelSalesforceSObjectName

--- a/library/camel-kamelets/src/main/resources/kamelets/salesforce-update-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/salesforce-update-sink.kamelet.yaml
@@ -93,10 +93,10 @@ spec:
       uri: kamelet:source
       steps:
         - setHeader:
-            name: sObjectId
+            name: CamelSalesforceSObjectId
             jsonpath: "$.sObjectId"
         - setHeader:
-            name: sObjectName
+            name: CamelSalesforceSObjectName
             jsonpath: "$.sObjectName"
         - transform:
             jsonpath: "$.payload"
@@ -107,6 +107,6 @@ spec:
             parameters:
               rawPayload: "true"
         - removeHeader:
-            name: sObjectId
+            name: CamelSalesforceSObjectId
         - removeHeader:
-            name: sObjectName
+            name: CamelSalesforceSObjectName

--- a/library/camel-kamelets/src/main/resources/kamelets/set-kafka-key-action.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/set-kafka-key-action.kamelet.yaml
@@ -52,7 +52,7 @@ spec:
       uri: kamelet:source
       steps:
       - setHeader:
-          name: kafka.KEY
+          name: CamelKafkaKey
           simple: "${header.{{headerName}}}"
       - choice:
           precondition: true

--- a/tests/camel-kamelets-itest/src/test/resources/kafka/kafka-router-pipe.it.yaml
+++ b/tests/camel-kamelets-itest/src/test/resources/kafka/kafka-router-pipe.it.yaml
@@ -56,9 +56,9 @@ actions:
         fork: true
         GET:
           parameters:
-            - name: "kafka.TOPIC"
+            - name: "CamelKafkaTopic"
               value: "${kafka.topic}"
-            - name: "kafka.TIMESTAMP"
+            - name: "CamelKafkaTimestamp"
               value: "${timestamp}"
             - name: "message"
               value: "citrus:urlEncode(${kafka.message})"

--- a/tests/camel-kamelets-itest/src/test/resources/kafka/kafka-source-pipe.it.yaml
+++ b/tests/camel-kamelets-itest/src/test/resources/kafka/kafka-source-pipe.it.yaml
@@ -86,11 +86,11 @@ actions:
           headers:
             - name: event-source
               value: "${kafka.source}"
-            - name: kafka.TOPIC
+            - name: CamelKafkaTopic
               value: "${kafka.topic}"
-            - name: kafka.KEY
+            - name: CamelKafkaKey
               value: "${kafka.message.key}"
-            - name: kafka.PARTITION
+            - name: CamelKafkaPartition
               value: "0"
           body:
             data: |


### PR DESCRIPTION
## Summary
- Update Kafka header names from `kafka.*` to `CamelKafka*` prefix (kafka-sink, kafka-apicurio-registry-not-secured-sink, kafka-not-secured-apicurio-registry-sink, kafka-azure-schema-registry-sink, set-kafka-key-action)
- Update Elasticsearch header names from `indexId`/`indexName` to `CamelElasticsearchIndexId`/`CamelElasticsearchIndexName`
- Update Opensearch header names from `indexId`/`indexName` to `CamelOpensearchIndexId`/`CamelOpensearchIndexName`
- Update Salesforce header names from `sObjectId`/`sObjectName` to `CamelSalesforceSObjectId`/`CamelSalesforceSObjectName` in setHeader/removeHeader (endpoint options unchanged)
- Update Kafka header names in integration test files

Follows the header renames documented in the [4.18.x upgrade guide](https://camel.apache.org/manual/camel-4x-upgrade-guide-4_18.html) (4.18.1 → 4.18.3 section). Complements #2876 which only covered the SMT kamelets.

## Test plan
- [ ] Verify kamelets/ and library/ copies are identical
- [ ] Verify no old header names remain in kamelet definitions
- [ ] Integration tests pass with updated header names