### PR TITLE
ci: add job timeout-minutes and pin backport checkout to a SHA

### DIFF
--- a/.github/workflows/automatic-changelog-update.yml
+++ b/.github/workflows/automatic-changelog-update.yml
@@ -27,6 +27,7 @@ jobs:
   generate_changelog:
     if: github.repository == 'apache/camel-kamelets'
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     name: Generate changelog for main branch
     steps:
       - name: "Checkout"

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -29,10 +29,11 @@ permissions:
 jobs:
   backport:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     name: Backport
     steps:
       - name: "Checkout Camel Kamelets"
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
           submodules: recursive

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -50,6 +50,7 @@ permissions:  # added using https://github.com/step-security/secure-repo
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
@@ -72,6 +73,7 @@ jobs:
         path: maven-repo-${{ github.run_id }}-${{ github.run_number }}.tgz
   deploy:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     # Run only when pushing to the branches (either main or release), never on merge requests and forks
     if: ${{ github.repository == 'apache/camel-kamelets' && github.event_name == 'push' }}
     env:

--- a/.github/workflows/generate-sbom-main.yml
+++ b/.github/workflows/generate-sbom-main.yml
@@ -31,6 +31,7 @@ jobs:
       pull-requests: write # to create a PR (peter-evans/create-pull-request)
 
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     strategy:
       matrix:
         java: [ '17' ]

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -46,6 +46,7 @@ permissions:  # added using https://github.com/step-security/secure-repo
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     steps:
     - name: Checkout code
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/java-tests.yaml
+++ b/.github/workflows/java-tests.yaml
@@ -37,6 +37,7 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:

--- a/.github/workflows/main-push-regen.yaml
+++ b/.github/workflows/main-push-regen.yaml
@@ -36,6 +36,7 @@ jobs:
       contents: write  # for peter-evans/create-pull-request to create branch
       pull-requests: write  # for peter-evans/create-pull-request to create a PR
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:

--- a/.github/workflows/pr-doc-validation.yml
+++ b/.github/workflows/pr-doc-validation.yml
@@ -34,6 +34,7 @@ jobs:
   check-doc:
     if: github.repository == 'apache/camel-kamelets'
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout camel-quarkus repo
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -46,6 +46,7 @@ permissions:
 jobs:
   validate:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
     - name: Checkout code
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0


### PR DESCRIPTION
## Summary

Small hardening of the GitHub Actions workflows (from a catalog audit). CI config only — no product changes.

- **`timeout-minutes` on every job** — none of the 10 jobs had a timeout, so a hung job (most importantly the Testcontainers/JBang `integration-tests` run) could run up to GitHub's 6-hour default before being killed. Added generous upper bounds: `integration-tests` 90, `java-tests` / `ci-build` 60, the rest 30.
- **Pin `actions/checkout` in `backport.yml` to a commit SHA** (`9c091bb…` — the same pin the other workflows already use) instead of the mutable `v7.0.0` tag, for supply-chain consistency.

## Verification
- All 9 workflow files parse as valid YAML.
- 10 `runs-on` jobs ↔ 10 `timeout-minutes` (1:1).
- No mutable `actions/checkout@v*` tag references remain.

---
_AI-generated by Claude Code on behalf of Andrea Cosentino (@oscerd)._
