### PR TITLE
ci: reject duplicate x-descriptors in the Kamelet validator

### DIFF
--- a/script/validator/validator.go
+++ b/script/validator/validator.go
@@ -121,6 +121,13 @@ func verifyDescriptors(kamelets []KameletInfo) (errors []error) {
 			if hasXDescriptorPrefix(p, deprecatedDescriptorPrefix) {
 				errors = append(errors, fmt.Errorf("property %q in kamelet %q uses the deprecated x-descriptor prefix %q; use %q instead", k, kamelet.Name, deprecatedDescriptorPrefix, credDescriptor))
 			}
+			seenDescriptors := make(map[string]bool)
+			for _, d := range p.XDescriptors {
+				if seenDescriptors[d] {
+					errors = append(errors, fmt.Errorf("property %q in kamelet %q lists the x-descriptor %q more than once", k, kamelet.Name, d))
+				}
+				seenDescriptors[d] = true
+			}
 		}
 	}
 	return errors


### PR DESCRIPTION
## Summary

Adds a regression-guard rule to `script/validator`: a property may not list the same `x-descriptor` more than once.

This closes the loop on #2882 — that fix removed a duplicate `urn:camel:group:credentials` that was introduced when the deprecated `urn:alm:descriptor:com.tectonic.ui:password` descriptor was *converted* (rather than removed) on properties that already carried the canonical descriptor. The validator did not catch it (thanks @apupier for spotting it in review). This rule makes that class of mistake fail fast.

## Verification
- `go vet` / `gofmt`: clean.
- Validator exits `0` on the current catalog (no duplicate descriptors exist after #2882).
- Verified to **fire** on an injected duplicate:
  `ERROR: property "authUsername" in kamelet "http-secured-sink" lists the x-descriptor "urn:camel:group:credentials" more than once`.

---
_AI-generated by Claude Code on behalf of Andrea Cosentino (@oscerd)._
