### PR TITLE
fix: Citrus integration tests

### DIFF
--- a/tests/camel-kamelets-itest/src/test/java/AwsIT.java
+++ b/tests/camel-kamelets-itest/src/test/java/AwsIT.java
@@ -60,8 +60,28 @@ public class AwsIT {
     }
 
     @CitrusTestFactory
-    public Stream<DynamicTest> aws() {
-        return CitrusTestFactorySupport.factory(TestLoader.YAML).packageScan("aws");
+    public Stream<DynamicTest> awsS3() {
+        return CitrusTestFactorySupport.factory(TestLoader.YAML).packageScan("aws.s3");
+    }
+
+    @CitrusTestFactory
+    public Stream<DynamicTest> awsSqs() {
+        return CitrusTestFactorySupport.factory(TestLoader.YAML).packageScan("aws.sqs");
+    }
+
+    @CitrusTestFactory
+    public Stream<DynamicTest> awsDdb() {
+        return CitrusTestFactorySupport.factory(TestLoader.YAML).packageScan("aws.ddb");
+    }
+
+    @CitrusTestFactory
+    public Stream<DynamicTest> awsKinesis() {
+        return CitrusTestFactorySupport.factory(TestLoader.YAML).packageScan("aws.kinesis");
+    }
+
+    @CitrusTestFactory
+    public Stream<DynamicTest> awsEventBridge() {
+        return CitrusTestFactorySupport.factory(TestLoader.YAML).packageScan("aws.eventbridge");
     }
 
 }

--- a/tests/camel-kamelets-itest/src/test/resources/avro/jbang.properties
+++ b/tests/camel-kamelets-itest/src/test/resources/avro/jbang.properties
@@ -1,0 +1,19 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Declare required additional dependencies
+run.deps=org.apache.camel:camel-jackson-avro:LATEST

--- a/tests/camel-kamelets-itest/src/test/resources/kafka/kafka-router-pipe.yaml
+++ b/tests/camel-kamelets-itest/src/test/resources/kafka/kafka-router-pipe.yaml
@@ -35,6 +35,7 @@ spec:
       properties:
         topicFormat: $[topic]_$[timestamp]
         timestampFormat: YYYY-MM-dd
+        timestampHeaderName: kafka.TIMESTAMP
         topicHeaderName: kafka.TOPIC
     - ref:
         kind: Kamelet

--- a/tests/camel-kamelets-itest/src/test/resources/protobuf/jbang.properties
+++ b/tests/camel-kamelets-itest/src/test/resources/protobuf/jbang.properties
@@ -16,5 +16,4 @@
 #
 
 # Declare required additional dependencies
-run.deps=org.apache.camel:camel-jackson-avro:${camel.version},\
-org.apache.camel:camel-jackson-protobuf:${camel.version}
+run.deps=org.apache.camel:camel-jackson-protobuf:LATEST


### PR DESCRIPTION
## fix: Avro/Protobuf run dependencies in JBang properties

- JBang 139+ fails to read multiple Maven GAV dependencies from jbang.properties
- Move jbang.properties to individual tests and use LATEST version placeholder as a workaround

## fix: Fix Kafka timestamp router properties

- Action Kamelet was missing timestamp header name property

## Use individual AWS test factories for each sub-folder

- Gives users the opportunity to run only a subfolder of the AWS test suite (e.g. via Java IDE)