### PR TITLE
chore: Mark AWS kamelets with integration tests as verified

### DIFF
--- a/kamelets/aws-eventbridge-sink.kamelet.yaml
+++ b/kamelets/aws-eventbridge-sink.kamelet.yaml
@@ -28,6 +28,7 @@ metadata:
     camel.apache.org/kamelet.namespace: "AWS"
   labels:
     camel.apache.org/kamelet.type: "sink"
+    camel.apache.org/kamelet.verified: "true"
 spec:
   definition:
     title: "AWS Eventbridge Sink"

--- a/kamelets/aws-kinesis-sink.kamelet.yaml
+++ b/kamelets/aws-kinesis-sink.kamelet.yaml
@@ -28,6 +28,7 @@ metadata:
     camel.apache.org/kamelet.namespace: "AWS"
   labels:
     camel.apache.org/kamelet.type: "sink"
+    camel.apache.org/kamelet.verified: "true"
 spec:
   definition:
     title: "AWS Kinesis Sink"

--- a/kamelets/aws-kinesis-source.kamelet.yaml
+++ b/kamelets/aws-kinesis-source.kamelet.yaml
@@ -28,6 +28,7 @@ metadata:
     camel.apache.org/kamelet.namespace: "AWS"
   labels:
     camel.apache.org/kamelet.type: "source"
+    camel.apache.org/kamelet.verified: "true"
 spec:
   definition:
     title: "AWS Kinesis Source"

--- a/kamelets/aws-s3-sink.kamelet.yaml
+++ b/kamelets/aws-s3-sink.kamelet.yaml
@@ -28,6 +28,7 @@ metadata:
     camel.apache.org/kamelet.namespace: "AWS"
   labels:
     camel.apache.org/kamelet.type: "sink"
+    camel.apache.org/kamelet.verified: "true"
 spec:
   definition:
     title: "AWS S3 Sink"

--- a/kamelets/aws-s3-source.kamelet.yaml
+++ b/kamelets/aws-s3-source.kamelet.yaml
@@ -28,6 +28,7 @@ metadata:
     camel.apache.org/kamelet.namespace: "AWS"
   labels:
     camel.apache.org/kamelet.type: "source"
+    camel.apache.org/kamelet.verified: "true"
 spec:
   definition:
     title: "AWS S3 Source"

--- a/kamelets/aws-sns-sink.kamelet.yaml
+++ b/kamelets/aws-sns-sink.kamelet.yaml
@@ -28,6 +28,7 @@ metadata:
     camel.apache.org/kamelet.namespace: "AWS"
   labels:
     camel.apache.org/kamelet.type: "sink"
+    camel.apache.org/kamelet.verified: "true"
 spec:
   definition:
     title: "AWS SNS Sink"

--- a/kamelets/aws-sqs-sink.kamelet.yaml
+++ b/kamelets/aws-sqs-sink.kamelet.yaml
@@ -28,6 +28,7 @@ metadata:
     camel.apache.org/kamelet.namespace: "AWS"
   labels:
     camel.apache.org/kamelet.type: "sink"
+    camel.apache.org/kamelet.verified: "true"
 spec:
   definition:
     title: "AWS SQS Sink"

--- a/kamelets/aws-sqs-source.kamelet.yaml
+++ b/kamelets/aws-sqs-source.kamelet.yaml
@@ -28,6 +28,7 @@ metadata:
     camel.apache.org/kamelet.namespace: "AWS"
   labels:
     camel.apache.org/kamelet.type: "source"
+    camel.apache.org/kamelet.verified: "true"
 spec:
   definition:
     title: "AWS SQS Source"


### PR DESCRIPTION
## Summary

Adds the `camel.apache.org/kamelet.verified: "true"` label to the 8 AWS kamelets that have active Citrus integration tests:

| Kamelet | Type |
|---------|------|
| `aws-s3-source` | source |
| `aws-s3-sink` | sink |
| `aws-sqs-source` | source |
| `aws-sqs-sink` | sink |
| `aws-sns-sink` | sink |
| `aws-kinesis-source` | source |
| `aws-kinesis-sink` | sink |
| `aws-eventbridge-sink` | sink |

This brings the total verified kamelets from 3 to 11.

Depends on #2913 (which adds the S3/SQS/SNS sink tests and migrates existing tests to Floci + Camel route format).

## Test plan

- [x] Validator passes: `cd script/validator && go run . ../../kamelets/`
- [x] No doc regeneration needed (verified label is not rendered in generated docs)

_Claude Code on behalf of Andrea Cosentino_

🤖 Generated with [Claude Code](https://claude.com/claude-code)