### PR TITLE
chore: Add Citrus integration tests for 10 self-contained kamelets

### DIFF
--- a/tests/camel-kamelets-itest/src/test/java/CommonIT.java
+++ b/tests/camel-kamelets-itest/src/test/java/CommonIT.java
@@ -103,4 +103,39 @@ public class CommonIT {
     public Stream<DynamicTest> counter() {
         return CitrusTestFactorySupport.factory(TestLoader.YAML).packageScan("counter");
     }
+
+    @CitrusTestFactory
+    public Stream<DynamicTest> cron() {
+        return CitrusTestFactorySupport.factory(TestLoader.YAML).packageScan("cron");
+    }
+
+    @CitrusTestFactory
+    public Stream<DynamicTest> setBody() {
+        return CitrusTestFactorySupport.factory(TestLoader.YAML).packageScan("setbody");
+    }
+
+    @CitrusTestFactory
+    public Stream<DynamicTest> delay() {
+        return CitrusTestFactorySupport.factory(TestLoader.YAML).packageScan("delay");
+    }
+
+    @CitrusTestFactory
+    public Stream<DynamicTest> throttle() {
+        return CitrusTestFactorySupport.factory(TestLoader.YAML).packageScan("throttle");
+    }
+
+    @CitrusTestFactory
+    public Stream<DynamicTest> xj() {
+        return CitrusTestFactorySupport.factory(TestLoader.YAML).packageScan("xj");
+    }
+
+    @CitrusTestFactory
+    public Stream<DynamicTest> dns() {
+        return CitrusTestFactorySupport.factory(TestLoader.YAML).packageScan("dns");
+    }
+
+    @CitrusTestFactory
+    public Stream<DynamicTest> kafkaRouter() {
+        return CitrusTestFactorySupport.factory(TestLoader.YAML).packageScan("kafkarouter");
+    }
 }

--- a/tests/camel-kamelets-itest/src/test/resources/cron/cron-source-route.citrus.it.yaml
+++ b/tests/camel-kamelets-itest/src/test/resources/cron/cron-source-route.citrus.it.yaml
@@ -1,0 +1,30 @@
+# ---------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ---------------------------------------------------------------------------
+
+name: cron-source-route-test
+actions:
+  - camel:
+      jbang:
+        run:
+          waitForRunningState: false
+          integration:
+            file: "cron/cron-source-route.yaml"
+  - camel:
+      jbang:
+        verify:
+          integration: "cron-source-route"
+          logMessage: "cron-test-12345"

--- a/tests/camel-kamelets-itest/src/test/resources/cron/cron-source-route.yaml
+++ b/tests/camel-kamelets-itest/src/test/resources/cron/cron-source-route.yaml
@@ -1,0 +1,28 @@
+# ---------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ---------------------------------------------------------------------------
+
+- route:
+    from:
+      uri: "kamelet:cron-source"
+      parameters:
+        schedule: "0/1 * * * * ?"
+        message: "cron-test-12345"
+      steps:
+      - to:
+          uri: "kamelet:log-sink"
+          parameters:
+            showHeaders: true

--- a/tests/camel-kamelets-itest/src/test/resources/delay/delay-action-route.citrus.it.yaml
+++ b/tests/camel-kamelets-itest/src/test/resources/delay/delay-action-route.citrus.it.yaml
@@ -1,0 +1,44 @@
+# ---------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ---------------------------------------------------------------------------
+
+name: delay-action-route-test
+variables:
+  - name: "test.message"
+    value: "delayed-message-test"
+actions:
+  - camel:
+      jbang:
+        run:
+          integration:
+            file: "delay/delay-action-route.yaml"
+            systemProperties:
+              properties:
+                - name: "test.message"
+                  value: "${test.message}"
+                - name: "http.sink.url"
+                  value: "http://localhost:${http.server.port}"
+  - http:
+      server: "httpServer"
+      receiveRequest:
+        POST:
+          path: "/result"
+          body:
+            data: "${test.message}"
+  - http:
+      server: "httpServer"
+      sendResponse:
+        status: 200

--- a/tests/camel-kamelets-itest/src/test/resources/delay/delay-action-route.citrus.it.yaml
+++ b/tests/camel-kamelets-itest/src/test/resources/delay/delay-action-route.citrus.it.yaml
@@ -41,4 +41,6 @@ actions:
   - http:
       server: "httpServer"
       sendResponse:
-        status: 200
+        response:
+          status: 200
+          reasonPhrase: "OK"

--- a/tests/camel-kamelets-itest/src/test/resources/delay/delay-action-route.yaml
+++ b/tests/camel-kamelets-itest/src/test/resources/delay/delay-action-route.yaml
@@ -1,0 +1,34 @@
+# ---------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ---------------------------------------------------------------------------
+
+- route:
+    from:
+      uri: "timer:tick"
+      parameters:
+        period: "10000"
+        repeatCount: 1
+      steps:
+      - setBody:
+          constant: "{{test.message}}"
+      - to:
+          uri: "kamelet:delay-action"
+          parameters:
+            milliseconds: 100
+      - to:
+          uri: "kamelet:http-sink"
+          parameters:
+            url: "{{http.sink.url}}/result"

--- a/tests/camel-kamelets-itest/src/test/resources/dns/dns-ip-action-route.citrus.it.yaml
+++ b/tests/camel-kamelets-itest/src/test/resources/dns/dns-ip-action-route.citrus.it.yaml
@@ -1,0 +1,30 @@
+# ---------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ---------------------------------------------------------------------------
+
+name: dns-ip-action-route-test
+actions:
+  - camel:
+      jbang:
+        run:
+          waitForRunningState: false
+          integration:
+            file: "dns/dns-ip-action-route.yaml"
+  - camel:
+      jbang:
+        verify:
+          integration: "dns-ip-action-route"
+          logMessage: "127.0.0.1"

--- a/tests/camel-kamelets-itest/src/test/resources/dns/dns-ip-action-route.yaml
+++ b/tests/camel-kamelets-itest/src/test/resources/dns/dns-ip-action-route.yaml
@@ -1,0 +1,30 @@
+# ---------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ---------------------------------------------------------------------------
+
+- route:
+    from:
+      uri: "timer:tick"
+      parameters:
+        period: "10000"
+        repeatCount: 1
+      steps:
+      - setBody:
+          constant: "localhost"
+      - to:
+          uri: "kamelet:dns-ip-action"
+      - to:
+          uri: "kamelet:log-sink"

--- a/tests/camel-kamelets-itest/src/test/resources/filter/simple-filter-action-route.citrus.it.yaml
+++ b/tests/camel-kamelets-itest/src/test/resources/filter/simple-filter-action-route.citrus.it.yaml
@@ -1,0 +1,44 @@
+# ---------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ---------------------------------------------------------------------------
+
+name: simple-filter-action-route-test
+variables:
+  - name: "test.message"
+    value: "passthrough-message"
+actions:
+  - camel:
+      jbang:
+        run:
+          integration:
+            file: "filter/simple-filter-action-route.yaml"
+            systemProperties:
+              properties:
+                - name: "test.message"
+                  value: "${test.message}"
+                - name: "http.sink.url"
+                  value: "http://localhost:${http.server.port}"
+  - http:
+      server: "httpServer"
+      receiveRequest:
+        POST:
+          path: "/result"
+          body:
+            data: "${test.message}"
+  - http:
+      server: "httpServer"
+      sendResponse:
+        status: 200

--- a/tests/camel-kamelets-itest/src/test/resources/filter/simple-filter-action-route.citrus.it.yaml
+++ b/tests/camel-kamelets-itest/src/test/resources/filter/simple-filter-action-route.citrus.it.yaml
@@ -41,4 +41,6 @@ actions:
   - http:
       server: "httpServer"
       sendResponse:
-        status: 200
+        response:
+          status: 200
+          reasonPhrase: "OK"

--- a/tests/camel-kamelets-itest/src/test/resources/filter/simple-filter-action-route.yaml
+++ b/tests/camel-kamelets-itest/src/test/resources/filter/simple-filter-action-route.yaml
@@ -1,0 +1,34 @@
+# ---------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ---------------------------------------------------------------------------
+
+- route:
+    from:
+      uri: "timer:tick"
+      parameters:
+        period: "10000"
+        repeatCount: 1
+      steps:
+      - setBody:
+          constant: "{{test.message}}"
+      - to:
+          uri: "kamelet:simple-filter-action"
+          parameters:
+            expression: "${body} == 'DROP_ME'"
+      - to:
+          uri: "kamelet:http-sink"
+          parameters:
+            url: "{{http.sink.url}}/result"

--- a/tests/camel-kamelets-itest/src/test/resources/kafkarouter/regex-router-action-route.citrus.it.yaml
+++ b/tests/camel-kamelets-itest/src/test/resources/kafkarouter/regex-router-action-route.citrus.it.yaml
@@ -1,0 +1,30 @@
+# ---------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ---------------------------------------------------------------------------
+
+name: regex-router-action-route-test
+actions:
+  - camel:
+      jbang:
+        run:
+          waitForRunningState: false
+          integration:
+            file: "kafkarouter/regex-router-action-route.yaml"
+  - camel:
+      jbang:
+        verify:
+          integration: "regex-router-action-route"
+          logMessage: "prefix-my-topic"

--- a/tests/camel-kamelets-itest/src/test/resources/kafkarouter/regex-router-action-route.yaml
+++ b/tests/camel-kamelets-itest/src/test/resources/kafkarouter/regex-router-action-route.yaml
@@ -1,0 +1,38 @@
+# ---------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ---------------------------------------------------------------------------
+
+- route:
+    from:
+      uri: "timer:tick"
+      parameters:
+        period: "10000"
+        repeatCount: 1
+      steps:
+      - setBody:
+          constant: "test-data"
+      - setHeader:
+          name: CamelKafkaTopic
+          constant: "my-topic"
+      - to:
+          uri: "kamelet:regex-router-action"
+          parameters:
+            regex: "(.*)"
+            replacement: "prefix-$1"
+      - to:
+          uri: "kamelet:log-sink"
+          parameters:
+            showHeaders: true

--- a/tests/camel-kamelets-itest/src/test/resources/kafkarouter/timestamp-router-action-route.citrus.it.yaml
+++ b/tests/camel-kamelets-itest/src/test/resources/kafkarouter/timestamp-router-action-route.citrus.it.yaml
@@ -1,0 +1,30 @@
+# ---------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ---------------------------------------------------------------------------
+
+name: timestamp-router-action-route-test
+actions:
+  - camel:
+      jbang:
+        run:
+          waitForRunningState: false
+          integration:
+            file: "kafkarouter/timestamp-router-action-route.yaml"
+  - camel:
+      jbang:
+        verify:
+          integration: "timestamp-router-action-route"
+          logMessage: "my-topic-20240703"

--- a/tests/camel-kamelets-itest/src/test/resources/kafkarouter/timestamp-router-action-route.yaml
+++ b/tests/camel-kamelets-itest/src/test/resources/kafkarouter/timestamp-router-action-route.yaml
@@ -1,0 +1,41 @@
+# ---------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ---------------------------------------------------------------------------
+
+- route:
+    from:
+      uri: "timer:tick"
+      parameters:
+        period: "10000"
+        repeatCount: 1
+      steps:
+      - setBody:
+          constant: "test-data"
+      - setHeader:
+          name: CamelKafkaTopic
+          constant: "my-topic"
+      - setHeader:
+          name: CamelKafkaTimestamp
+          constant: "1720000000000"
+      - to:
+          uri: "kamelet:timestamp-router-action"
+          parameters:
+            topicFormat: "$[topic]-$[timestamp]"
+            timestampFormat: "yyyyMMdd"
+      - to:
+          uri: "kamelet:log-sink"
+          parameters:
+            showHeaders: true

--- a/tests/camel-kamelets-itest/src/test/resources/kafkarouter/topic-name-matches-filter-action-route.citrus.it.yaml
+++ b/tests/camel-kamelets-itest/src/test/resources/kafkarouter/topic-name-matches-filter-action-route.citrus.it.yaml
@@ -1,0 +1,30 @@
+# ---------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ---------------------------------------------------------------------------
+
+name: topic-name-matches-filter-action-route-test
+actions:
+  - camel:
+      jbang:
+        run:
+          waitForRunningState: false
+          integration:
+            file: "kafkarouter/topic-name-matches-filter-action-route.yaml"
+  - camel:
+      jbang:
+        verify:
+          integration: "topic-name-matches-filter-action-route"
+          logMessage: "topic-filter-test-data"

--- a/tests/camel-kamelets-itest/src/test/resources/kafkarouter/topic-name-matches-filter-action-route.yaml
+++ b/tests/camel-kamelets-itest/src/test/resources/kafkarouter/topic-name-matches-filter-action-route.yaml
@@ -1,0 +1,35 @@
+# ---------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ---------------------------------------------------------------------------
+
+- route:
+    from:
+      uri: "timer:tick"
+      parameters:
+        period: "10000"
+        repeatCount: 1
+      steps:
+      - setBody:
+          constant: "topic-filter-test-data"
+      - setHeader:
+          name: CamelKafkaTopic
+          constant: "orders-topic"
+      - to:
+          uri: "kamelet:topic-name-matches-filter-action"
+          parameters:
+            regex: "orders.*"
+      - to:
+          uri: "kamelet:log-sink"

--- a/tests/camel-kamelets-itest/src/test/resources/setbody/set-body-action-route.citrus.it.yaml
+++ b/tests/camel-kamelets-itest/src/test/resources/setbody/set-body-action-route.citrus.it.yaml
@@ -1,0 +1,44 @@
+# ---------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ---------------------------------------------------------------------------
+
+name: set-body-action-route-test
+variables:
+  - name: "set.body.value"
+    value: "Replaced body content"
+actions:
+  - camel:
+      jbang:
+        run:
+          integration:
+            file: "setbody/set-body-action-route.yaml"
+            systemProperties:
+              properties:
+                - name: "set.body.value"
+                  value: "${set.body.value}"
+                - name: "http.sink.url"
+                  value: "http://localhost:${http.server.port}"
+  - http:
+      server: "httpServer"
+      receiveRequest:
+        POST:
+          path: "/result"
+          body:
+            data: "${set.body.value}"
+  - http:
+      server: "httpServer"
+      sendResponse:
+        status: 200

--- a/tests/camel-kamelets-itest/src/test/resources/setbody/set-body-action-route.citrus.it.yaml
+++ b/tests/camel-kamelets-itest/src/test/resources/setbody/set-body-action-route.citrus.it.yaml
@@ -41,4 +41,6 @@ actions:
   - http:
       server: "httpServer"
       sendResponse:
-        status: 200
+        response:
+          status: 200
+          reasonPhrase: "OK"

--- a/tests/camel-kamelets-itest/src/test/resources/setbody/set-body-action-route.yaml
+++ b/tests/camel-kamelets-itest/src/test/resources/setbody/set-body-action-route.yaml
@@ -1,0 +1,34 @@
+# ---------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ---------------------------------------------------------------------------
+
+- route:
+    from:
+      uri: "timer:tick"
+      parameters:
+        period: "10000"
+        repeatCount: 1
+      steps:
+      - setBody:
+          constant: "original-body"
+      - to:
+          uri: "kamelet:set-body-action"
+          parameters:
+            value: "{{set.body.value}}"
+      - to:
+          uri: "kamelet:http-sink"
+          parameters:
+            url: "{{http.sink.url}}/result"

--- a/tests/camel-kamelets-itest/src/test/resources/throttle/throttle-action-route.citrus.it.yaml
+++ b/tests/camel-kamelets-itest/src/test/resources/throttle/throttle-action-route.citrus.it.yaml
@@ -1,0 +1,44 @@
+# ---------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ---------------------------------------------------------------------------
+
+name: throttle-action-route-test
+variables:
+  - name: "test.message"
+    value: "throttled-message-test"
+actions:
+  - camel:
+      jbang:
+        run:
+          integration:
+            file: "throttle/throttle-action-route.yaml"
+            systemProperties:
+              properties:
+                - name: "test.message"
+                  value: "${test.message}"
+                - name: "http.sink.url"
+                  value: "http://localhost:${http.server.port}"
+  - http:
+      server: "httpServer"
+      receiveRequest:
+        POST:
+          path: "/result"
+          body:
+            data: "${test.message}"
+  - http:
+      server: "httpServer"
+      sendResponse:
+        status: 200

--- a/tests/camel-kamelets-itest/src/test/resources/throttle/throttle-action-route.citrus.it.yaml
+++ b/tests/camel-kamelets-itest/src/test/resources/throttle/throttle-action-route.citrus.it.yaml
@@ -41,4 +41,6 @@ actions:
   - http:
       server: "httpServer"
       sendResponse:
-        status: 200
+        response:
+          status: 200
+          reasonPhrase: "OK"

--- a/tests/camel-kamelets-itest/src/test/resources/throttle/throttle-action-route.yaml
+++ b/tests/camel-kamelets-itest/src/test/resources/throttle/throttle-action-route.yaml
@@ -1,0 +1,34 @@
+# ---------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ---------------------------------------------------------------------------
+
+- route:
+    from:
+      uri: "timer:tick"
+      parameters:
+        period: "10000"
+        repeatCount: 1
+      steps:
+      - setBody:
+          constant: "{{test.message}}"
+      - to:
+          uri: "kamelet:throttle-action"
+          parameters:
+            messages: 5
+      - to:
+          uri: "kamelet:http-sink"
+          parameters:
+            url: "{{http.sink.url}}/result"

--- a/tests/camel-kamelets-itest/src/test/resources/xj/xj-identity-action-route.citrus.it.yaml
+++ b/tests/camel-kamelets-itest/src/test/resources/xj/xj-identity-action-route.citrus.it.yaml
@@ -1,0 +1,42 @@
+# ---------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ---------------------------------------------------------------------------
+
+name: xj-identity-action-route-test
+actions:
+  - camel:
+      jbang:
+        run:
+          integration:
+            file: "xj/xj-identity-action-route.yaml"
+            systemProperties:
+              properties:
+                - name: "http.sink.url"
+                  value: "http://localhost:${http.server.port}"
+  - http:
+      server: "httpServer"
+      receiveRequest:
+        POST:
+          path: "/result"
+  - http:
+      server: "httpServer"
+      sendResponse:
+        status: 200
+  - camel:
+      jbang:
+        verify:
+          integration: "xj-identity-action-route"
+          logMessage: "name"

--- a/tests/camel-kamelets-itest/src/test/resources/xj/xj-identity-action-route.citrus.it.yaml
+++ b/tests/camel-kamelets-itest/src/test/resources/xj/xj-identity-action-route.citrus.it.yaml
@@ -34,7 +34,9 @@ actions:
   - http:
       server: "httpServer"
       sendResponse:
-        status: 200
+        response:
+          status: 200
+          reasonPhrase: "OK"
   - camel:
       jbang:
         verify:

--- a/tests/camel-kamelets-itest/src/test/resources/xj/xj-identity-action-route.yaml
+++ b/tests/camel-kamelets-itest/src/test/resources/xj/xj-identity-action-route.yaml
@@ -1,0 +1,38 @@
+# ---------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ---------------------------------------------------------------------------
+
+- route:
+    from:
+      uri: "timer:tick"
+      parameters:
+        period: "10000"
+        repeatCount: 1
+      steps:
+      - setBody:
+          constant: '{"name":"test","value":"hello"}'
+      - to:
+          uri: "kamelet:xj-identity-action"
+          parameters:
+            direction: "JSON2XML"
+      - to:
+          uri: "kamelet:log-sink"
+          parameters:
+            showHeaders: true
+      - to:
+          uri: "kamelet:http-sink"
+          parameters:
+            url: "{{http.sink.url}}/result"


### PR DESCRIPTION
## Summary

Adds Citrus integration tests for 10 kamelets that require no external services or containers. All tests use **Camel route YAML** format (per #2873) and leverage the existing `CommonIT` HTTP mock server and log verification infrastructure.

### New tests

| Kamelet | Pattern | What is verified |
|---------|---------|-----------------|
| `cron-source` | log-verify | Emits configured message on cron schedule |
| `set-body-action` | http-mock | Message body replaced with configured value |
| `delay-action` | http-mock | Message passes through after configurable delay |
| `throttle-action` | http-mock | Message flows through rate limiter |
| `simple-filter-action` | http-mock | Non-matching message passes through (match = drop) |
| `xj-identity-action` | http-mock + log | JSON-to-XML identity transform |
| `dns-ip-action` | log-verify | `localhost` resolves to `127.0.0.1` |
| `regex-router-action` | log-verify | Kafka topic header modified by regex |
| `timestamp-router-action` | log-verify | Kafka topic header gets timestamp prefix |
| `topic-name-matches-filter-action` | log-verify | Message with matching topic passes through |

### Files

- **20 new files**: 10 Camel route YAML definitions + 10 Citrus test YAML definitions across 7 test directories
- **1 modified file**: `CommonIT.java` — added 7 new `@CitrusTestFactory` methods

## Test plan

- [ ] `mvn compile test-compile -pl :camel-kamelets-itest` passes
- [ ] `mvn verify -pl :camel-kamelets-itest -Denable.integration.tests` — all tests pass
- [ ] No external services or containers required for these tests

_Claude Code on behalf of Andrea Cosentino_

🤖 Generated with [Claude Code](https://claude.com/claude-code)