### PR TITLE
chore: Mark Tier 1 kamelets with integration tests as verified

### DIFF
--- a/kamelets/cron-source.kamelet.yaml
+++ b/kamelets/cron-source.kamelet.yaml
@@ -27,6 +27,7 @@ metadata:
     camel.apache.org/kamelet.namespace: "Scheduling"
   labels:
     camel.apache.org/kamelet.type: "source"
+    camel.apache.org/kamelet.verified: "true"
 spec:
   definition:
     title: "Cron Source"

--- a/kamelets/delay-action.kamelet.yaml
+++ b/kamelets/delay-action.kamelet.yaml
@@ -27,6 +27,7 @@ metadata:
     camel.apache.org/kamelet.namespace: "EIP"
   labels:
     camel.apache.org/kamelet.type: "action"
+    camel.apache.org/kamelet.verified: "true"
 spec:
   definition:
     title: "Delay Action"

--- a/kamelets/dns-ip-action.kamelet.yaml
+++ b/kamelets/dns-ip-action.kamelet.yaml
@@ -27,6 +27,7 @@ metadata:
     camel.apache.org/kamelet.namespace: "Networking"
   labels:
     camel.apache.org/kamelet.type: "action"
+    camel.apache.org/kamelet.verified: "true"
 spec:
   definition:
     title: "DNS IP Action"

--- a/kamelets/regex-router-action.kamelet.yaml
+++ b/kamelets/regex-router-action.kamelet.yaml
@@ -20,6 +20,7 @@ metadata:
   name: regex-router-action
   labels:
     camel.apache.org/kamelet.type: "action"
+    camel.apache.org/kamelet.verified: "true"
   annotations:
     camel.apache.org/kamelet.support.level: "Stable"
     camel.apache.org/catalog.version: "4.22.0-SNAPSHOT"

--- a/kamelets/set-body-action.kamelet.yaml
+++ b/kamelets/set-body-action.kamelet.yaml
@@ -20,6 +20,7 @@ metadata:
   name: set-body-action
   labels:
     camel.apache.org/kamelet.type: "action"
+    camel.apache.org/kamelet.verified: "true"
   annotations:
     camel.apache.org/kamelet.support.level: "Stable"
     camel.apache.org/catalog.version: "4.22.0-SNAPSHOT"

--- a/kamelets/simple-filter-action.kamelet.yaml
+++ b/kamelets/simple-filter-action.kamelet.yaml
@@ -20,6 +20,7 @@ metadata:
   name: simple-filter-action
   labels:
     camel.apache.org/kamelet.type: "action"
+    camel.apache.org/kamelet.verified: "true"
   annotations:
     camel.apache.org/kamelet.support.level: "Stable"
     camel.apache.org/catalog.version: "4.22.0-SNAPSHOT"

--- a/kamelets/throttle-action.kamelet.yaml
+++ b/kamelets/throttle-action.kamelet.yaml
@@ -20,6 +20,7 @@ metadata:
   name: throttle-action
   labels:
     camel.apache.org/kamelet.type: "action"
+    camel.apache.org/kamelet.verified: "true"
   annotations:
     camel.apache.org/kamelet.support.level: "Stable"
     camel.apache.org/catalog.version: "4.22.0-SNAPSHOT"

--- a/kamelets/timestamp-router-action.kamelet.yaml
+++ b/kamelets/timestamp-router-action.kamelet.yaml
@@ -20,6 +20,7 @@ metadata:
   name: timestamp-router-action
   labels:
     camel.apache.org/kamelet.type: "action"
+    camel.apache.org/kamelet.verified: "true"
   annotations:
     camel.apache.org/kamelet.support.level: "Stable"
     camel.apache.org/catalog.version: "4.22.0-SNAPSHOT"

--- a/kamelets/topic-name-matches-filter-action.kamelet.yaml
+++ b/kamelets/topic-name-matches-filter-action.kamelet.yaml
@@ -20,6 +20,7 @@ metadata:
   name: topic-name-matches-filter-action
   labels:
     camel.apache.org/kamelet.type: "action"
+    camel.apache.org/kamelet.verified: "true"
   annotations:
     camel.apache.org/kamelet.support.level: "Stable"
     camel.apache.org/catalog.version: "4.22.0-SNAPSHOT"

--- a/kamelets/xj-identity-action.kamelet.yaml
+++ b/kamelets/xj-identity-action.kamelet.yaml
@@ -27,6 +27,7 @@ metadata:
     camel.apache.org/kamelet.namespace: "Transformation"
   labels:
     camel.apache.org/kamelet.type: "action"
+    camel.apache.org/kamelet.verified: "true"
 spec:
   definition:
     title: "XJ Identity Action"


### PR DESCRIPTION
## Summary

Adds `camel.apache.org/kamelet.verified: "true"` label to the 10 self-contained kamelets that now have active Citrus integration tests (merged in #2915):

| Kamelet | Type |
|---------|------|
| `cron-source` | source |
| `set-body-action` | action |
| `delay-action` | action |
| `throttle-action` | action |
| `simple-filter-action` | action |
| `xj-identity-action` | action |
| `dns-ip-action` | action |
| `regex-router-action` | action |
| `timestamp-router-action` | action |
| `topic-name-matches-filter-action` | action |

This brings the total verified kamelets from 11 to 21.

## Test plan

- [ ] Validator passes: `cd script/validator && go run . ../../kamelets/`

_Claude Code on behalf of Andrea Cosentino_

🤖 Generated with [Claude Code](https://claude.com/claude-code)