### PR TITLE
ci: use Go 1.25.x in validate and regen workflows

### DIFF
--- a/.github/workflows/main-push-regen.yaml
+++ b/.github/workflows/main-push-regen.yaml
@@ -50,7 +50,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
-          go-version: 1.24.x
+          go-version: 1.25.x
       - name: Build catalog 1st Run
         run: ./mvnw clean install -DskipTests
       - name: Build catalog 2nd Run

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -53,7 +53,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
       with:
-        go-version: 1.24.x
+        go-version: 1.25.x
     - name: Run Validator
       run: |
         echo "Running Kamelet validator..."


### PR DESCRIPTION
## CI Fix

**Failed runs:**
- `Build Regen` on `main` (broken since #2909 merged): https://github.com/apache/camel-kamelets/actions/runs/29242574108
- `validate` on PR #2904: https://github.com/apache/camel-kamelets/actions/runs/28943759525/job/85872217216

### Errors Found

```
go: go.mod requires go >= 1.25.0 (running go 1.24.13; GOTOOLCHAIN=local)
go: module ../../crds requires go >= 1.25.0 (running go 1.24.13; GOTOOLCHAIN=local)
```

The Dependabot bumps of `golang.org/x/net` 0.40.0 → 0.55.0 raise the `go` directive to `1.25.0` in each Go module (`script/generator` already on main via #2909; `/crds` pending in #2904; `/script/validator` pending in #2901), but `actions/setup-go` was pinned to `go-version: 1.24.x` and v6 sets `GOTOOLCHAIN=local`, which forbids toolchain auto-upgrade. This currently breaks the `Run Generator` step of `main-push-regen.yaml` on every push to `main`, and the `validate` job on the pending Dependabot PRs.

### Fix Applied

- Bump `go-version: 1.24.x` → `1.25.x` in `.github/workflows/validate.yaml` and `.github/workflows/main-push-regen.yaml`. Go 1.25 still builds the `go 1.24.6` modules, so this is safe to merge ahead of the remaining Dependabot PRs.

Verified locally with a ≥1.25 toolchain and `GOTOOLCHAIN=local`: the generator module on main builds, and `go run . ../../kamelets/` (the exact `validate` command) passes on PR #2904 content once the validator module is aligned by #2901.

### Suggested merge order for the pending Dependabot PRs

1. This PR
2. `@dependabot rebase` #2901 (validator) → merge — its diff already carries the `go 1.25.0` directive and `x/net`/`x/text` bumps the module graph needs
3. `@dependabot rebase` #2904 (crds) → merge — its `validate` only goes green after #2901, because the validator's `go.mod` must record `x/net v0.55.0` selected via the local `../../crds` replace

### Deferred Issues

None — single root cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code) on behalf of Andrea Cosentino (@oscerd)