### PR TITLE
fix: Fix AWS DDB update sink test

### DIFF
--- a/tests/camel-kamelets-itest/src/test/resources/aws/ddb/aws-ddb-sink-route.yaml
+++ b/tests/camel-kamelets-itest/src/test/resources/aws/ddb/aws-ddb-sink-route.yaml
@@ -24,6 +24,9 @@
       steps:
       - setBody:
           constant: "{{aws.ddb.json.data}}"
+      - setProperty:
+          name: operation
+          constant: "{{aws.ddb.operation}}"
       - log: "${body}"
       - to:
           uri: "kamelet:aws-ddb-sink"

--- a/tests/camel-kamelets-itest/src/test/resources/aws/ddb/aws-ddb-sink-update-item.citrus.it.yaml
+++ b/tests/camel-kamelets-itest/src/test/resources/aws/ddb/aws-ddb-sink-update-item.citrus.it.yaml
@@ -16,7 +16,6 @@
 # ---------------------------------------------------------------------------
 
 name: aws-ddb-sink-update-item-test
-status: DISABLED
 variables:
   - name: "maxRetryAttempts"
     value: "20"
@@ -107,9 +106,9 @@ actions:
   - createVariables:
       variables:
         - name: "aws.ddb.item.directors"
-          value: "[Ernest B. Schoedsack, Merian C. Cooper]"
+          value: "[Merian C. Cooper, Ernest B. Schoedsack]"
         - name: "aws.ddb.item"
-          value: "[id:AttributeValue(N=${aws.ddb.item.id}), title:AttributeValue(S=${aws.ddb.item.title.new}), year:AttributeValue(N=${aws.ddb.item.year}), directors:AttributeValue(SS=${aws.ddb.item.directors})]"
+          value: "[directors:AttributeValue(SS=${aws.ddb.item.directors}), id:AttributeValue(N=${aws.ddb.item.id}), title:AttributeValue(S=${aws.ddb.item.title.new}), year:AttributeValue(N=${aws.ddb.item.year})]"
 
   - repeatOnError:
       until: "i > ${maxRetryAttempts}"


### PR DESCRIPTION
- Reactivate Citrus test for AWS Dynamo DB update operation
- Fix expected DDB items verification
- Fix UpdateItem operation set as Exchange property