### PR TITLE
Upgrade to Camel 4.22.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-dependencies</artifactId>
-        <version>4.21.0</version>
+        <version>4.22.0</version>
     </parent>
 
     <groupId>org.apache.camel.kamelets</groupId>
@@ -73,7 +73,7 @@
         <apache-rat-plugin.version>0.18</apache-rat-plugin.version>
         <cyclonedx-maven-plugin-version>2.9.3</cyclonedx-maven-plugin-version>
 
-        <camel.version>4.21.0</camel.version>
+        <camel.version>4.22.0</camel.version>
 
         <citrus.version>5.0.0</citrus.version>
         <jose4j.version>0.9.6</jose4j.version>


### PR DESCRIPTION
Bumps the catalog to Apache Camel **4.22.0** (released 2026-08-17).

## Changes

Two lines in the root `pom.xml`:

- `org.apache.camel:camel-dependencies` parent: `4.21.0` → `4.22.0`
- `camel.version`: `4.21.0` → `4.22.0`

## Why nothing else changed

Diffing `camel-dependencies` 4.21.0 vs 4.22.0 against the version properties this
repo manages itself, all of them already match 4.22.0 and need no bump:

| Property | Value | Camel 4.22.0 |
|---|---|---|
| Azure SDK BOM (`azure-identity`, `azure-data-schemaregistry-apacheavro`, `azure-schemaregistry-kafka-avro`) | 1.18.1 / 1.1.30 / 1.1.4 | BOM still 1.3.3 — unchanged |
| `version.org.messaginghub.pooled-jms` | 3.2.3 | 3.2.3 |
| `version.org.postgresql.postgresql` | 42.7.13 | 42.7.13 |
| `version.org.apache.activemq.artemis-jakarta-client-all` | 2.55.0 | 2.55.0 |
| `version.org.apache.commons.commons-dbcp2` | 2.14.0 | 2.14.0 |
| `citrus.version` | 5.0.0 | 5.0.0 |

Unlike the 4.18.0 bump, the Azure SDK BOM did not move, so the
`kafka-azure-schema-registry-*` Kamelets need no edits. Doc regeneration
(`script/generator`) and the YAML validator (`script/validator`) both produce
zero diffs.

## Kamelet impact review (4.21 → 4.22 upgrade guide)

Checked every breaking entry touching a component this catalog ships:

- `queueBufferingMaxMessages` (deprecated), `forceWrites` (deprecated),
  `metadataMaxAgeMs`, `preSort`, `sslEndpointAlgorithm` — not used by any Kamelet.
- **camel-kafka — manual commit no longer auto-commits offsets.** Nine source
  Kamelets expose `allowManualCommit`, but it defaults to `false`, so no default
  behaviour changes. An operator setting it to `true` now gets true manual-commit
  semantics — that is the upstream contract they opted into, not a catalog defect.
- **camel-azure — component-specific `CredentialType` enums removed.** Java
  import-level only; endpoint URI option values are unchanged, so the ten Kamelets
  using `credentialType` are unaffected. Same for the minio 9.0.3 breakage, which
  is entirely Java API.
- **camel-spring-rabbitmq — queue `durable` now defaults to `true`.** Neither
  Kamelet sets `arg.queue.durable`, so both inherit the intentional upstream
  alignment.

No Kamelet YAML changes are required for this upgrade.

## Verification

- `./mvnw clean install` from the repository root — BUILD SUCCESS, all 7 modules.
- `KameletsCatalogTest` — 18/18 passing. No header-count adjustments were needed
  this cycle (the 4.21.0 bump had required them in 69acf1c9c).
- Citrus integration tests exercising Camel JBang at the new version:
  `./mvnw verify -pl :camel-kamelets-itest -Denable.integration.tests -Dit.test=CommonIT`
  — 28/28 passing.

---
_Generated by Claude Code on behalf of Andrea Cosentino (@oscerd). The analysis,
build and test runs above were performed by the agent; please review accordingly._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
