### PR TITLE
Fix #2953: align sqlserver Kamelet encrypt/trustServerCertificate defaults with the JDBC driver

### DIFF
--- a/kamelets/sqlserver-sink.kamelet.yaml
+++ b/kamelets/sqlserver-sink.kamelet.yaml
@@ -75,12 +75,13 @@ spec:
         title: Encrypt Connection
         description: Encrypt the connection to SQL Server.
         type: boolean
-        default: false
+        default: true
       trustServerCertificate:
         title: Trust Server Certificate
-        description: Trust Server Certificate
+        description: Trust the server certificate without validating it against a
+          certificate authority. Intended for development and test environments only.
         type: boolean
-        default: true
+        default: false
   types:
     in:
       mediaType: application/json

--- a/kamelets/sqlserver-source.kamelet.yaml
+++ b/kamelets/sqlserver-source.kamelet.yaml
@@ -80,12 +80,13 @@ spec:
         title: Encrypt Connection
         description: Encrypt the connection to SQL Server.
         type: boolean
-        default: false
+        default: true
       trustServerCertificate:
         title: Trust Server Certificate
-        description: Trust Server Certificate
+        description: Trust the server certificate without validating it against a
+          certificate authority. Intended for development and test environments only.
         type: boolean
-        default: true
+        default: false
       delay:
         title: Delay
         description: The number of milliseconds before the next poll


### PR DESCRIPTION
Fixes #2953

`sqlserver-sink` and `sqlserver-source` declared:

```yaml
encrypt:            default: false
trustServerCertificate: default: true
```

and interpolated both into the JDBC URL. The Microsoft SQL Server JDBC driver has defaulted `encrypt` to `true` since version 10.2, so the Kamelets were overriding the driver's own default in the weaker direction, and pairing it with `trustServerCertificate=true` (which suppresses certificate validation).

This PR flips both to the driver-aligned values and clarifies the `trustServerCertificate` description to say what it actually does.

### Behaviour change

This changes the default for existing deployments. A deployment pointing at a SQL Server without a certificate the client trusts will now need `encrypt=false` or `trustServerCertificate=true` set explicitly. `camel-kamelets` has no upgrade guide of its own, so the note belongs in the `apache/camel` upgrade guide for the release that picks this up — flagging for a maintainer to place it.

### Verification

- `script/validator` reports no errors
- `mvn verify` passes

---
_Claude Code on behalf of Andrea Cosentino_