### PR TITLE
Fix #2954: default enableSSL to true in the opensearch Kamelets

### DIFF
--- a/kamelets/opensearch-index-sink.kamelet.yaml
+++ b/kamelets/opensearch-index-sink.kamelet.yaml
@@ -53,7 +53,7 @@ spec:
         title: Enable SSL
         description: Specifies to connect by using SSL.
         type: boolean
-        default: false
+        default: true
       hostAddresses:
         title: Host Addresses
         description: A comma-separated list of remote transport addresses in `ip:port format`.

--- a/kamelets/opensearch-search-source.kamelet.yaml
+++ b/kamelets/opensearch-search-source.kamelet.yaml
@@ -64,7 +64,7 @@ spec:
         title: Enable SSL
         description: Do we want to connect using SSL?
         type: boolean
-        default: false
+        default: true
       hostAddresses:
         title: Host Addresses
         description: Comma separated list with ip:port formatted remote transport addresses to use.


### PR DESCRIPTION
Fixes #2954

The Elasticsearch and OpenSearch Kamelets declare the same `enableSSL` property at the same position with identical titles and descriptions, but with opposite defaults:

| Kamelet | before | after |
|---|---|---|
| `elasticsearch-index-sink` | `true` | `true` (unchanged) |
| `elasticsearch-search-source` | `true` | `true` (unchanged) |
| `opensearch-index-sink` | `false` | **`true`** |
| `opensearch-search-source` | `false` | **`true`** |

Given the byte-for-byte similarity of the sibling declarations, the divergence looks like drift rather than a deliberate choice.

### Behaviour change

Existing deployments pointing at a plain-HTTP OpenSearch cluster will need `enableSSL=false` set explicitly. `camel-kamelets` has no upgrade guide of its own, so the note belongs in the `apache/camel` upgrade guide for the release that picks this up — flagging for a maintainer.

Related: #2791.

### Verification

- `script/validator` reports no errors
- `mvn verify` passes

---
_Claude Code on behalf of Andrea Cosentino_