### PR TITLE
Fix #2959: mark 13 credential properties format: password; stop duplicating the Databricks token into the JDBC URL

### DIFF
--- a/kamelets/databricks-sink.kamelet.yaml
+++ b/kamelets/databricks-sink.kamelet.yaml
@@ -88,8 +88,9 @@ spec:
       - name: dsBean
         type: "#class:org.apache.commons.dbcp2.BasicDataSource"
         properties:
+          username: 'token'
           password: '{{accessToken}}'
-          url: 'jdbc:databricks://{{serverHostname}}:{{serverPort}};httpPath={{httpPath}};AuthMech=3;transportMode=http;ssl=1;UID=token;PWD={{accessToken}}{{extraOptions}}'
+          url: 'jdbc:databricks://{{serverHostname}}:{{serverPort}};httpPath={{httpPath}};AuthMech=3;transportMode=http;ssl=1{{extraOptions}}'
           driverClassName: 'com.databricks.client.jdbc.Driver'
     from:
       uri: "kamelet:source"

--- a/kamelets/databricks-source.kamelet.yaml
+++ b/kamelets/databricks-source.kamelet.yaml
@@ -98,8 +98,9 @@ spec:
       - name: dsBean
         type: "#class:org.apache.commons.dbcp2.BasicDataSource"
         properties:
+          username: 'token'
           password: '{{accessToken}}'
-          url: 'jdbc:databricks://{{serverHostname}}:{{serverPort}};httpPath={{httpPath}};AuthMech=3;transportMode=http;ssl=1;UID=token;PWD={{accessToken}}{{extraOptions}}'
+          url: 'jdbc:databricks://{{serverHostname}}:{{serverPort}};httpPath={{httpPath}};AuthMech=3;transportMode=http;ssl=1{{extraOptions}}'
           driverClassName: 'com.databricks.client.jdbc.Driver'
     from:
       uri: "{{local-sql-databricks-source}}:{{query}}"

--- a/kamelets/google-bigquery-sink.kamelet.yaml
+++ b/kamelets/google-bigquery-sink.kamelet.yaml
@@ -54,6 +54,7 @@ spec:
         title: Service Account Key
         description: The service account key to use as credentials for the BigQuery Service. You must encode this value in base64.
         type: binary
+        format: password
         x-descriptors:
         - urn:camel:group:credentials
   types:

--- a/kamelets/google-functions-sink.kamelet.yaml
+++ b/kamelets/google-functions-sink.kamelet.yaml
@@ -54,6 +54,7 @@ spec:
         title: Service Account Key
         description: The path to the service account key file that provides credentials for the Google Cloud Functions platform. You must encode this value in base64.
         type: binary
+        format: password
         x-descriptors:
         - urn:camel:group:credentials
   dependencies:

--- a/kamelets/google-pubsub-sink.kamelet.yaml
+++ b/kamelets/google-pubsub-sink.kamelet.yaml
@@ -48,6 +48,7 @@ spec:
         title: Service Account Key
         description: The service account key to use as credentials for the Pub/Sub publisher/subscriber. You must encode this value in base64.
         type: binary
+        format: password
         x-descriptors:
         - urn:camel:group:credentials
   dependencies:

--- a/kamelets/google-pubsub-source.kamelet.yaml
+++ b/kamelets/google-pubsub-source.kamelet.yaml
@@ -48,6 +48,7 @@ spec:
         title: Service Account Key
         description: The service account key to use as credentials for the Pub/Sub publisher/subscriber. You must encode this value in base64.
         type: binary
+        format: password
         x-descriptors:
         - urn:camel:group:credentials
       synchronousPull:

--- a/kamelets/google-storage-event-based-source.kamelet.yaml
+++ b/kamelets/google-storage-event-based-source.kamelet.yaml
@@ -50,6 +50,7 @@ spec:
         title: Service Account Key
         description: The service account key to use as credentials for the Pub/Sub publisher/subscriber. You must encode this value in base64.
         type: binary
+        format: password
         x-descriptors:
         - urn:camel:group:credentials
       synchronousPull:

--- a/kamelets/google-storage-sink.kamelet.yaml
+++ b/kamelets/google-storage-sink.kamelet.yaml
@@ -43,6 +43,7 @@ spec:
         title: Service Account Key
         description: The service account key to use as credentials for Google Cloud Storage access. You must encode this value in base64.
         type: binary
+        format: password
         x-descriptors:
         - urn:camel:group:credentials
       autoCreateBucket:

--- a/kamelets/google-storage-source.kamelet.yaml
+++ b/kamelets/google-storage-source.kamelet.yaml
@@ -43,6 +43,7 @@ spec:
         title: Service Account Key
         description: The service account key to use as credentials for Google Cloud Storage access. You must encode this value in base64.
         type: binary
+        format: password
         x-descriptors:
         - urn:camel:group:credentials
       deleteAfterRead:

--- a/kamelets/google-vertexai-sink.kamelet.yaml
+++ b/kamelets/google-vertexai-sink.kamelet.yaml
@@ -53,6 +53,7 @@ spec:
         title: Service Account Key
         description: The service account key to use as credentials for the Vertex AI client. You must encode this value in base64.
         type: binary
+        format: password
         x-descriptors:
         - urn:camel:group:credentials
       operation:

--- a/kamelets/jira-add-comment-sink.kamelet.yaml
+++ b/kamelets/jira-add-comment-sink.kamelet.yaml
@@ -58,6 +58,7 @@ spec:
         title: Personal Token
         description: Personal Token
         type: string
+        format: password
         x-descriptors:
         - urn:camel:group:credentials
   types:

--- a/kamelets/jira-add-issue-sink.kamelet.yaml
+++ b/kamelets/jira-add-issue-sink.kamelet.yaml
@@ -58,6 +58,7 @@ spec:
         title: Personal Token
         description: Personal Token
         type: string
+        format: password
         x-descriptors:
         - urn:camel:group:credentials
   types:

--- a/kamelets/jira-source.kamelet.yaml
+++ b/kamelets/jira-source.kamelet.yaml
@@ -58,6 +58,7 @@ spec:
         title: Personal Token
         description: Personal Token
         type: string
+        format: password
         x-descriptors:
         - urn:camel:group:credentials
       jql:

--- a/kamelets/jira-transition-issue-sink.kamelet.yaml
+++ b/kamelets/jira-transition-issue-sink.kamelet.yaml
@@ -58,6 +58,7 @@ spec:
         title: Personal Token
         description: Personal Token
         type: string
+        format: password
         x-descriptors:
         - urn:camel:group:credentials
   types:

--- a/kamelets/jira-update-issue-sink.kamelet.yaml
+++ b/kamelets/jira-update-issue-sink.kamelet.yaml
@@ -58,6 +58,7 @@ spec:
         title: Personal Token
         description: Personal Token
         type: string
+        format: password
         x-descriptors:
         - urn:camel:group:credentials
   types:


### PR DESCRIPTION
Fixes #2959

Two credential-metadata cleanups.

### 1. `format: password` on 13 declarations

The authoring convention is `format: password` **plus** `x-descriptors: [urn:camel:group:credentials]`. These 13 had the descriptor but not the format:

- `serviceAccountKey` (8): `google-bigquery-sink`, `google-functions-sink`, `google-pubsub-sink`, `google-pubsub-source`, `google-storage-sink`, `google-storage-source`, `google-storage-event-based-source`, `google-vertexai-sink`
- `personal-token` (5): `jira-add-comment-sink`, `jira-add-issue-sink`, `jira-source`, `jira-transition-issue-sink`, `jira-update-issue-sink`

Sibling `password` properties in the same files were already marked, so this looks like drift.

> **One point for a reviewer:** the 8 `serviceAccountKey` properties are `type: binary`, and there is no existing `type: binary` + `format: password` pairing anywhere in the catalog. I applied it because the documented convention states it without a type carve-out and the value is a secret either way — but if `binary` is meant to be handled differently by tooling, say so and I will drop those 8 and keep only the 5 `type: string` jira ones.

### 2. Databricks token no longer duplicated into the URL

Both Kamelets already set `password: '{{accessToken}}'` on the `BasicDataSource`. The token was carried a second time inside `url`, which is an ordinary non-secret string that surfaces in JMX and in connection-failure messages.

```diff
+          username: 'token'
           password: '{{accessToken}}'
-          url: '...;ssl=1;UID=token;PWD={{accessToken}}{{extraOptions}}'
+          url: '...;ssl=1{{extraOptions}}'
```

`UID=token` moves to a `username` property so the driver still gets it.

> **Not verified against a live instance:** I have not confirmed that the Databricks JDBC driver picks up DataSource-level user/password under `AuthMech=3` rather than requiring `UID`/`PWD` in the URL. This needs a check against a real endpoint before merge. If the driver requires them in the URL, the alternative is to leave the URL alone and drop the redundant `password` property instead.

### Verification

- `script/validator` reports no errors
- `mvn verify` passes
- No live-endpoint testing performed

A co-occurrence check in `kamelets-maven-plugin` would stop the `format`/`x-descriptors` drift recurring; happy to add it as a follow-up.

---
_Claude Code on behalf of Andrea Cosentino_