### PR TITLE
Fix #2957: make the documented mail-sink ce-* headers work; drop dead redis-sink mappings

### DIFF
--- a/kamelets/mail-sink.kamelet.yaml
+++ b/kamelets/mail-sink.kamelet.yaml
@@ -80,6 +80,21 @@ spec:
     from:
       uri: "kamelet:source"
       steps:
+        # Drop any mail headers arriving from upstream. Only the documented
+        # ce-* interface below is allowed to set them, and Bcc / Reply-To are
+        # not part of that interface at all.
+        - removeHeader:
+            name: Subject
+        - removeHeader:
+            name: From
+        - removeHeader:
+            name: To
+        - removeHeader:
+            name: Cc
+        - removeHeader:
+            name: Bcc
+        - removeHeader:
+            name: Reply-To
         - choice:
             when:
             - simple: "${header[ce-subject]}"
@@ -118,4 +133,11 @@ spec:
               to: "{{to}}"
               username: "{{username}}"
               password: "{{password}}"
+              # camel-mail ignores the Subject / From / To / Cc headers unless
+              # these are enabled; without them the ce-* mappings above are
+              # dead code. Reply-To stays disabled - it is not part of the
+              # documented interface.
+              useHeaderSubject: true
+              useHeaderFrom: true
+              useHeaderRecipients: true
 

--- a/kamelets/redis-sink.kamelet.yaml
+++ b/kamelets/redis-sink.kamelet.yaml
@@ -82,30 +82,6 @@ spec:
                 simple: "${header[ce-key]}"
       - choice:
           when:
-          - simple: "${header[value]}"
-            steps:
-            - setHeader:
-                name: CamelRedis.Value
-                simple: "${header[value]}"
-          - simple: "${header[ce-value]}"
-            steps:
-            - setHeader:
-                name: CamelRedis.Value
-                simple: "${header[ce-value]}"
-      - choice:
-          when:
-          - simple: "${header[message]}"
-            steps:
-            - setHeader:
-                name: CamelRedis.Message
-                simple: "${header[message]}"
-          - simple: "${header[ce-message]}"
-            steps:
-            - setHeader:
-                name: CamelRedis.Message
-                simple: "${header[ce-message]}"
-      - choice:
-          when:
           - simple: "${header[channel]}"
             steps:
             - setHeader:
@@ -115,7 +91,7 @@ spec:
             steps:
             - setHeader:
                 name: CamelRedis.Channel
-                simple: "${header[ce-channell]}"
+                simple: "${header[ce-channel]}"
       - setHeader:
           name: CamelRedis.Message
           simple: "${body}"


### PR DESCRIPTION
Fixes #2957

### mail-sink — the documented `ce-*` interface was dead code

`docs/modules/ROOT/partials/mail-sink-description.adoc` documents:

> **Email Headers Support** — `ce-subject`: Override email subject, `ce-from`: Override sender address, `ce-to`: Override recipient address, `ce-cc`: Add CC recipients

The template maps those onto `Subject` / `From` / `To` / `Cc`. But `camel-mail` only honours those headers when the matching option is enabled, and in Camel 4.22.0 all four default to **`false`**:

| option | default |
|---|---|
| `useHeaderSubject` | `false` |
| `useHeaderFrom` | `false` |
| `useHeaderRecipients` | `false` |
| `useHeaderReplyTo` | `false` |

`mail-sink` set none of them, so the endpoint's `{{subject}}` / `{{from}}` / `{{to}}` always won and the documented overrides did nothing.

This PR enables the three options the documented interface needs, and adds the header discipline that then becomes necessary:

- Bare `Subject` / `From` / `To` / `Cc` / `Bcc` / `Reply-To` headers arriving from upstream are stripped **first**, so only the `ce-*` mappings can set them. Without this, turning on `useHeaderRecipients` would also let a bare `Bcc` — which is not part of the documented interface at all — take effect.
- `useHeaderReplyTo` stays off, and `Reply-To` is stripped, since neither is documented.

This follows the same shape as `http-sink`'s existing `removeHeader: CamelHttpUri`.

**Behaviour change:** `ce-subject` / `ce-from` / `ce-to` / `ce-cc` now actually take effect. That is what the docs already promise, but it is a change from what ships today.

### redis-sink — one typo, two dead blocks

1. The branch guarded on `${header[ce-channel]}` read `${header[ce-channell]}` (line 118). Supplying `ce-channel` entered the branch and then set an **empty** channel. `ce-channell` appears nowhere else in the catalog.

2. The `value` and `message` `choice` blocks were followed unconditionally by:

```yaml
- setHeader: {name: CamelRedis.Message, simple: "${body}"}
- setHeader: {name: CamelRedis.Value,   simple: "${body}"}
```

so whatever those blocks set was immediately overwritten — the body always won. Unlike mail-sink, the redis-sink docs promise nothing about a header interface, so rather than silently flipping precedence I removed the dead blocks and left body-wins exactly as it behaves today. If header-overrides-body is wanted here, that is a feature decision worth its own issue.

### Verification

- `script/validator` reports no errors
- `mvn verify` passes
- Not exercised against a live SMTP or Redis server; the `useHeader*` defaults were read from the Camel 4.22.0 component catalog rather than from a running route

---
_Claude Code on behalf of Andrea Cosentino_