### PR TITLE
Fix #2958: bind the declared queueURL property; align precondition fallbacks with schema defaults

### DIFF
--- a/kamelets/aws-s3-event-based-source.kamelet.yaml
+++ b/kamelets/aws-s3-event-based-source.kamelet.yaml
@@ -121,7 +121,9 @@ spec:
         default: https
       queueURL:
         title: Queue URL
-        description: The full SQS Queue URL
+        description: The full SQS Queue URL. When set, it is used verbatim and every
+          other property that would otherwise determine the queue URL is ignored.
+          Intended for connecting to a mock SQS implementation.
         type: string
       uriEndpointOverride:
         title: Overwrite Endpoint URI
@@ -174,6 +176,7 @@ spec:
         amazonAWSHost: '{{?amazonAWSHost}}'
         protocol: '{{?protocol}}'
         uriEndpointOverride: '{{?uriEndpointOverride}}'
+        queueUrl: '{{?queueURL}}'
         overrideEndpoint: '{{overrideEndpoint}}'
         delay: '{{delay}}'
         greedy: '{{greedy}}'
@@ -181,7 +184,7 @@ spec:
         - choice:
             precondition: true
             when:
-              - simple: '${properties:getObject:true}'
+              - simple: '${properties:getObject:false}'
                 steps:
                   - unmarshal:
                       json:

--- a/kamelets/aws-sqs-source.kamelet.yaml
+++ b/kamelets/aws-sqs-source.kamelet.yaml
@@ -84,7 +84,9 @@ spec:
         default: https
       queueURL:
         title: Queue URL
-        description: The full SQS Queue URL.
+        description: The full SQS Queue URL. When set, it is used verbatim and every
+          other property that would otherwise determine the queue URL is ignored.
+          Intended for connecting to a mock SQS implementation.
         type: string
       useDefaultCredentialsProvider:
         title: Default Credentials Provider
@@ -222,6 +224,7 @@ spec:
         useProfileCredentialsProvider: "{{useProfileCredentialsProvider}}"
         useSessionCredentials: "{{useSessionCredentials}}"
         uriEndpointOverride: "{{?uriEndpointOverride}}"
+        queueUrl: "{{?queueURL}}"
         profileCredentialsName: "{{?profileCredentialsName}}"
         sessionToken: "{{?sessionToken}}"
         overrideEndpoint: "{{overrideEndpoint}}"

--- a/kamelets/azure-storage-blob-event-based-source.kamelet.yaml
+++ b/kamelets/azure-storage-blob-event-based-source.kamelet.yaml
@@ -132,7 +132,7 @@ spec:
         - choice:
             precondition: true
             when:
-              - simple: '${properties:getBlob:true}'
+              - simple: '${properties:getBlob:false}'
                 steps:
                   - setBody:
                       simple: ${body.toString()}

--- a/kamelets/azure-storage-blob-source.kamelet.yaml
+++ b/kamelets/azure-storage-blob-source.kamelet.yaml
@@ -179,7 +179,7 @@ spec:
         - choice:
             precondition: true
             when:
-              - simple: '${properties:deleteAfterRead:true}'
+              - simple: '${properties:deleteAfterRead:false}'
                 steps:
                   - to:
                       uri: "azure-storage-blob:{{accountName}}/{{containerName}}"

--- a/kamelets/google-storage-event-based-source.kamelet.yaml
+++ b/kamelets/google-storage-event-based-source.kamelet.yaml
@@ -96,7 +96,7 @@ spec:
         - choice:
             precondition: true
             when:
-              - simple: '${properties:getObject:true}'
+              - simple: '${properties:getObject:false}'
                 steps:
                   - setProperty:
                       name: google-storage-event-type

--- a/kamelets/set-kafka-key-action.kamelet.yaml
+++ b/kamelets/set-kafka-key-action.kamelet.yaml
@@ -57,7 +57,7 @@ spec:
       - choice:
           precondition: true
           when:
-            - simple: '${properties:forceHeaderDeletion:true}'
+            - simple: '${properties:forceHeaderDeletion:false}'
               steps:
               - removeHeader:
                   name: "{{headerName}}" 


### PR DESCRIPTION
Fixes #2958

Two cases where `spec.definition` and the template disagreed.

### 1. `queueURL` was declared but never used

`aws-sqs-source` and `aws-s3-event-based-source` both declared a `queueURL` property, but neither template referenced it — `grep -c '{{queueURL}}'` returned 0 in both. The `from:` URIs bound only `queueNameOrArn`. An operator setting `queueURL` got no effect and no warning.

Bound to the component option:

```yaml
uriEndpointOverride: "{{?uriEndpointOverride}}"
queueUrl: "{{?queueURL}}"
```

The `aws2-sqs` `queueUrl` option is documented as *"To define the queueUrl explicitly. All other parameters, which would influence the queueUrl, are ignored. This parameter is intended to be used to connect to a mock implementation of SQS, for testing purposes."* — the property descriptions now say that, since "The full SQS Queue URL" did not convey that it overrides everything else.

### 2. Precondition fallbacks inverted the declared schema defaults

Five templates used `${properties:X:true}` as the precondition fallback while the schema declared `default: false` for the same property:

| file | property | schema default | fallback (before) |
|---|---|---|---|
| `azure-storage-blob-source` | `deleteAfterRead` | `false` | `true` |
| `aws-s3-event-based-source` | `getObject` | `false` | `true` |
| `azure-storage-blob-event-based-source` | `getBlob` | `false` | `true` |
| `google-storage-event-based-source` | `getObject` | `false` | `true` |
| `set-kafka-key-action` | `forceHeaderDeletion` | `false` | `true` |

(`cassandra-sink` uses the same idiom but is already consistent — schema default `true`.)

Whether the fallback is ever reached depends on whether the consuming runtime materialises `spec.definition` defaults before evaluating preconditions. For the Camel Kamelet loader it appears not to be, but that is not obviously guaranteed for every supported consumer (camel-k operator, camel-kafka-connector, Camel JBang). The `azure-storage-blob-source` case is the one worth caring about — the fallback direction there is "delete the blob".

Aligning each fallback with its declared default is a no-op where the loader already materialises defaults, and the correct behaviour where it does not.

### Verification

- `script/validator` reports no errors
- `mvn verify` passes
- The `queueUrl` binding was checked against the Camel 4.22.0 catalog for `aws2-sqs`, not against a live or mock SQS endpoint

---
_Claude Code on behalf of Andrea Cosentino_