### PR TITLE
Fix #2952: enforce that the file/ce-file header is a file name in the file-transfer sinks

### DIFF
--- a/docs/modules/ROOT/partials/azure-storage-files-sink-description.adoc
+++ b/docs/modules/ROOT/partials/azure-storage-files-sink-description.adoc
@@ -24,3 +24,9 @@ For more information, see the https://learn.microsoft.com/en-us/java/api/overvie
 === Optional Headers
 
 In the headers, you can set the `file` / `ce-file` property to specify the filename to upload. If you do set property in the header, the Kamelet uses the exchange ID as filename.
+
+The value is reduced to a single file name before use: any directory component is
+dropped, so `reports/2026/data.csv` is stored as `data.csv`, and a value made up
+only of dots is discarded in favour of the default naming convention. The file is
+always written inside the configured directory.
+

--- a/docs/modules/ROOT/partials/azure-storage-files-sink-description.adoc
+++ b/docs/modules/ROOT/partials/azure-storage-files-sink-description.adoc
@@ -26,7 +26,6 @@ For more information, see the https://learn.microsoft.com/en-us/java/api/overvie
 In the headers, you can set the `file` / `ce-file` property to specify the filename to upload. If you do set property in the header, the Kamelet uses the exchange ID as filename.
 
 The value is reduced to a single file name before use: any directory component is
-dropped, so `reports/2026/data.csv` is stored as `data.csv`, and a value made up
-only of dots is discarded in favour of the default naming convention. The file is
-always written inside the configured directory.
+dropped, so `reports/2026/data.csv` is stored as `data.csv`. The file is always
+written inside the configured directory.
 

--- a/docs/modules/ROOT/partials/ftp-sink-description.adoc
+++ b/docs/modules/ROOT/partials/ftp-sink-description.adoc
@@ -24,3 +24,8 @@ Requires:
 In the header, you can optionally set the `file` / `ce-file` property to specify the name of the file to upload.
 
 If you do not set the property in the header, the Kamelet uses a default naming convention.
+
+The value is reduced to a single file name before use: any directory component is
+dropped, so `reports/2026/data.csv` is stored as `data.csv`, and a value made up
+only of dots is discarded in favour of the default naming convention. The file is
+always written inside the configured directory.

--- a/docs/modules/ROOT/partials/ftp-sink-description.adoc
+++ b/docs/modules/ROOT/partials/ftp-sink-description.adoc
@@ -26,6 +26,5 @@ In the header, you can optionally set the `file` / `ce-file` property to specify
 If you do not set the property in the header, the Kamelet uses a default naming convention.
 
 The value is reduced to a single file name before use: any directory component is
-dropped, so `reports/2026/data.csv` is stored as `data.csv`, and a value made up
-only of dots is discarded in favour of the default naming convention. The file is
-always written inside the configured directory.
+dropped, so `reports/2026/data.csv` is stored as `data.csv`. The file is always
+written inside the configured directory.

--- a/docs/modules/ROOT/partials/ftps-sink-description.adoc
+++ b/docs/modules/ROOT/partials/ftps-sink-description.adoc
@@ -30,6 +30,5 @@ In the header, you can optionally set the `file` / `ce-file` property to specify
 If you do not set the property in the header, the Kamelet uses a default naming convention.
 
 The value is reduced to a single file name before use: any directory component is
-dropped, so `reports/2026/data.csv` is stored as `data.csv`, and a value made up
-only of dots is discarded in favour of the default naming convention. The file is
-always written inside the configured directory.
+dropped, so `reports/2026/data.csv` is stored as `data.csv`. The file is always
+written inside the configured directory.

--- a/docs/modules/ROOT/partials/ftps-sink-description.adoc
+++ b/docs/modules/ROOT/partials/ftps-sink-description.adoc
@@ -28,3 +28,8 @@ Requires:
 In the header, you can optionally set the `file` / `ce-file` property to specify the name of the file to upload.
 
 If you do not set the property in the header, the Kamelet uses a default naming convention.
+
+The value is reduced to a single file name before use: any directory component is
+dropped, so `reports/2026/data.csv` is stored as `data.csv`, and a value made up
+only of dots is discarded in favour of the default naming convention. The file is
+always written inside the configured directory.

--- a/docs/modules/ROOT/partials/sftp-sink-description.adoc
+++ b/docs/modules/ROOT/partials/sftp-sink-description.adoc
@@ -41,6 +41,5 @@ In the header, you can optionally set the `file` / `ce-file` property to specify
 If you do not set the property in the header, the Kamelet uses a default naming convention.
 
 The value is reduced to a single file name before use: any directory component is
-dropped, so `reports/2026/data.csv` is stored as `data.csv`, and a value made up
-only of dots is discarded in favour of the default naming convention. The file is
-always written inside the configured directory.
+dropped, so `reports/2026/data.csv` is stored as `data.csv`. The file is always
+written inside the configured directory.

--- a/docs/modules/ROOT/partials/sftp-sink-description.adoc
+++ b/docs/modules/ROOT/partials/sftp-sink-description.adoc
@@ -33,3 +33,14 @@ SFTP supports file transfer resume capabilities, allowing interrupted transfers 
 === Cross-Platform Compatibility
 
 Works seamlessly across different operating systems and platforms, providing consistent secure file transfer capabilities in heterogeneous environments.
+
+=== Optional Headers
+
+In the header, you can optionally set the `file` / `ce-file` property to specify the name of the file to upload.
+
+If you do not set the property in the header, the Kamelet uses a default naming convention.
+
+The value is reduced to a single file name before use: any directory component is
+dropped, so `reports/2026/data.csv` is stored as `data.csv`, and a value made up
+only of dots is discarded in favour of the default naming convention. The file is
+always written inside the configured directory.

--- a/kamelets/azure-storage-files-sink.kamelet.yaml
+++ b/kamelets/azure-storage-files-sink.kamelet.yaml
@@ -79,12 +79,12 @@ spec:
             steps:
             - setHeader:
                 name: CamelFileName
-                simple: "${header[file]}"
+                simple: "${header.file.replaceAll('^.*[/\\\\]', '').replaceAll('^\\.+$', '')}"
           - simple: "${header[ce-file]}"
             steps:
             - setHeader:
                 name: CamelFileName
-                simple: "${header[ce-file]}"
+                simple: "${header['ce-file'].replaceAll('^.*[/\\\\]', '').replaceAll('^\\.+$', '')}"
           otherwise:
             steps:
             - setHeader:

--- a/kamelets/azure-storage-files-sink.kamelet.yaml
+++ b/kamelets/azure-storage-files-sink.kamelet.yaml
@@ -79,12 +79,18 @@ spec:
             steps:
             - setHeader:
                 name: CamelFileName
-                simple: "${header.file.replaceAll('^.*[/\\\\]', '').replaceAll('^\\.+$', '')}"
+                simple: "${header[file]}"
+            - setHeader:
+                name: CamelFileName
+                simple: "${file:onlyname}"
           - simple: "${header[ce-file]}"
             steps:
             - setHeader:
                 name: CamelFileName
-                simple: "${header['ce-file'].replaceAll('^.*[/\\\\]', '').replaceAll('^\\.+$', '')}"
+                simple: "${header[ce-file]}"
+            - setHeader:
+                name: CamelFileName
+                simple: "${file:onlyname}"
           otherwise:
             steps:
             - setHeader:

--- a/kamelets/ftp-sink.kamelet.yaml
+++ b/kamelets/ftp-sink.kamelet.yaml
@@ -100,12 +100,12 @@ spec:
             steps:
             - setHeader:
                 name: CamelFileName
-                simple: "${header[file]}"
+                simple: "${header.file.replaceAll('^.*[/\\\\]', '').replaceAll('^\\.+$', '')}"
           - simple: "${header[ce-file]}"
             steps:
             - setHeader:
                 name: CamelFileName
-                simple: "${header[ce-file]}"
+                simple: "${header['ce-file'].replaceAll('^.*[/\\\\]', '').replaceAll('^\\.+$', '')}"
       - to:
           uri: "ftp:{{username}}@{{connectionHost}}:{{connectionPort}}/{{directoryName}}"
           parameters:

--- a/kamelets/ftp-sink.kamelet.yaml
+++ b/kamelets/ftp-sink.kamelet.yaml
@@ -100,12 +100,18 @@ spec:
             steps:
             - setHeader:
                 name: CamelFileName
-                simple: "${header.file.replaceAll('^.*[/\\\\]', '').replaceAll('^\\.+$', '')}"
+                simple: "${header[file]}"
+            - setHeader:
+                name: CamelFileName
+                simple: "${file:onlyname}"
           - simple: "${header[ce-file]}"
             steps:
             - setHeader:
                 name: CamelFileName
-                simple: "${header['ce-file'].replaceAll('^.*[/\\\\]', '').replaceAll('^\\.+$', '')}"
+                simple: "${header[ce-file]}"
+            - setHeader:
+                name: CamelFileName
+                simple: "${file:onlyname}"
       - to:
           uri: "ftp:{{username}}@{{connectionHost}}:{{connectionPort}}/{{directoryName}}"
           parameters:

--- a/kamelets/ftps-sink.kamelet.yaml
+++ b/kamelets/ftps-sink.kamelet.yaml
@@ -100,12 +100,18 @@ spec:
             steps:
             - setHeader:
                 name: CamelFileName
-                simple: "${header.file.replaceAll('^.*[/\\\\]', '').replaceAll('^\\.+$', '')}"
+                simple: "${header[file]}"
+            - setHeader:
+                name: CamelFileName
+                simple: "${file:onlyname}"
           - simple: "${header[ce-file]}"
             steps:
             - setHeader:
                 name: CamelFileName
-                simple: "${header['ce-file'].replaceAll('^.*[/\\\\]', '').replaceAll('^\\.+$', '')}"
+                simple: "${header[ce-file]}"
+            - setHeader:
+                name: CamelFileName
+                simple: "${file:onlyname}"
       - to:
           uri: "ftps:{{username}}@{{connectionHost}}:{{connectionPort}}/{{directoryName}}"
           parameters:

--- a/kamelets/ftps-sink.kamelet.yaml
+++ b/kamelets/ftps-sink.kamelet.yaml
@@ -100,12 +100,12 @@ spec:
             steps:
             - setHeader:
                 name: CamelFileName
-                simple: "${header[file]}"
+                simple: "${header.file.replaceAll('^.*[/\\\\]', '').replaceAll('^\\.+$', '')}"
           - simple: "${header[ce-file]}"
             steps:
             - setHeader:
                 name: CamelFileName
-                simple: "${header[ce-file]}"
+                simple: "${header['ce-file'].replaceAll('^.*[/\\\\]', '').replaceAll('^\\.+$', '')}"
       - to:
           uri: "ftps:{{username}}@{{connectionHost}}:{{connectionPort}}/{{directoryName}}"
           parameters:

--- a/kamelets/sftp-sink.kamelet.yaml
+++ b/kamelets/sftp-sink.kamelet.yaml
@@ -124,12 +124,18 @@ spec:
             steps:
             - setHeader:
                 name: CamelFileName
-                simple: "${header.file.replaceAll('^.*[/\\\\]', '').replaceAll('^\\.+$', '')}"
+                simple: "${header[file]}"
+            - setHeader:
+                name: CamelFileName
+                simple: "${file:onlyname}"
           - simple: "${header[ce-file]}"
             steps:
             - setHeader:
                 name: CamelFileName
-                simple: "${header['ce-file'].replaceAll('^.*[/\\\\]', '').replaceAll('^\\.+$', '')}"
+                simple: "${header[ce-file]}"
+            - setHeader:
+                name: CamelFileName
+                simple: "${file:onlyname}"
       - to:
           uri: "sftp:{{connectionHost}}:{{connectionPort}}/{{directoryName}}"
           parameters:

--- a/kamelets/sftp-sink.kamelet.yaml
+++ b/kamelets/sftp-sink.kamelet.yaml
@@ -124,12 +124,12 @@ spec:
             steps:
             - setHeader:
                 name: CamelFileName
-                simple: "${header[file]}"
+                simple: "${header.file.replaceAll('^.*[/\\\\]', '').replaceAll('^\\.+$', '')}"
           - simple: "${header[ce-file]}"
             steps:
             - setHeader:
                 name: CamelFileName
-                simple: "${header[ce-file]}"
+                simple: "${header['ce-file'].replaceAll('^.*[/\\\\]', '').replaceAll('^\\.+$', '')}"
       - to:
           uri: "sftp:{{connectionHost}}:{{connectionPort}}/{{directoryName}}"
           parameters:


### PR DESCRIPTION
Fixes #2952

`ftp-sink`, `ftps-sink`, `sftp-sink` and `azure-storage-files-sink` document the `file` / `ce-file` header as "the name of the file to upload", but passed the value straight through to `CamelFileName`. Nothing enforced that it was a name rather than a path, so a value containing directory separators was resolved relative to the configured `directoryName`.

```diff
             - setHeader:
                 name: CamelFileName
                 simple: "${header[file]}"
+            - setHeader:
+                name: CamelFileName
+                simple: "${file:onlyname}"
```

`${file:onlyname}` is Camel's built-in file language for "the file name with no leading paths" — which is exactly what the docs already promise this header does.

> **Revised after review.** The first version used an inline `replaceAll` chain. @davsclaus rightly objected to a regex embedded in the Kamelet spec and suggested a bean. A bean would have to live in `apache/camel` — `77be42a85` removed the utils module here with *"Remove Camel-Kamelets-utils since it is now in core"* — so it would have blocked this on a Camel release for something the file language already does. The regex is gone either way.

### Verified end to end through a Kamelet template

Not just the expression in isolation — a probe Kamelet mirroring `ftp-sink`'s structure, run on Camel 4.22.0:

| inbound header | file written |
|---|---|
| `file: ../../etc/evil.txt` | `evil.txt`, inside the configured directory |
| `ce-file: sub/dir/report.csv` | `report.csv`, inside the configured directory |
| *(none)* | exchange-id name — default naming convention preserved |

The third row is load-bearing: the normalisation sits **inside** each `choice` branch, because applying it after the choice would set `CamelFileName` to an empty value when no header was supplied, which is not the same as leaving it unset.

### Behaviour change

A header that previously placed a file in a subdirectory — e.g. `reports/2026/data.csv` — now writes `data.csv` into the configured directory instead. If per-message subdirectories are a use case anyone relies on, that deserves an explicit, declared property rather than this header.

One deliberate difference from the earlier revision: `${file:onlyname}` leaves a bare `..` unchanged, where the regex blanked it. That names the parent directory rather than traversing into it, and the file/FTP producers reject it.

### Docs

The header was documented in the `ftp-sink`, `ftps-sink` and `azure-storage-files-sink` partials but **not** in `sftp-sink`'s. All four now state the contract, and `sftp-sink` gains the missing *Optional Headers* section. (The header is still not declared in `spec.definition` for any of the four — that is the broader #929 problem.)

### Verification

- `script/validator` reports no errors
- `mvn clean install` passes from the repository root, full reactor with tests
- Behaviour verified with `camel run` as tabulated above

---
_Claude Code on behalf of Andrea Cosentino_