### PR TITLE
Fix #2955: default strictHostKeyChecking to yes and expose known_hosts configuration

### DIFF
--- a/kamelets/scp-sink.kamelet.yaml
+++ b/kamelets/scp-sink.kamelet.yaml
@@ -69,9 +69,19 @@ spec:
         - urn:camel:group:credentials
       strictHostKeyChecking:
         title: Strict Host Checking
-        description: Sets whether to use strict host key checking.
+        description: Sets whether to use strict host key checking. One of yes, no or
+          ask. With no, the server host key is accepted without being checked against
+          a known_hosts entry.
         type: string
-        default: no
+        enum: ["yes", "no", "ask"]
+        default: "yes"
+      knownHostsUri:
+        title: Known Hosts URI
+        description: The known_hosts file used to verify the server host key, loaded
+          from the classpath by default. Needed when the process has no
+          $HOME/.ssh/known_hosts to fall back on.
+        type: string
+        pattern: "^(http|https|file|classpath|ref|bean)://.*"
       useUserKnownHostsFile:
         title: Use User Known Hosts File
         description: If knownHostFile has not been explicit configured then use the host file from System.getProperty(user.home)/.ssh/known_hosts.
@@ -93,4 +103,5 @@ spec:
             privateKeyFile: "{{?privateKeyFile}}"
             privateKeyPassphrase: "{{?privateKeyPassphrase}}"
             strictHostKeyChecking: "{{?strictHostKeyChecking}}"
+            knownHostsUri: "{{?knownHostsUri}}"
             useUserKnownHostsFile: "{{?useUserKnownHostsFile}}"

--- a/kamelets/sftp-sink.kamelet.yaml
+++ b/kamelets/sftp-sink.kamelet.yaml
@@ -97,9 +97,19 @@ spec:
         pattern: "^(http|https|file|classpath|ref|bean)://.*"
       strictHostKeyChecking:
         title: Strict Host Checking
-        description: Sets whether to use strict host key checking.
+        description: Sets whether to use strict host key checking. One of yes, no or
+          ask. With no, the server host key is accepted without being checked against
+          a known_hosts entry.
         type: string
-        default: no
+        enum: ["yes", "no", "ask"]
+        default: "yes"
+      knownHostsUri:
+        title: Known Hosts URI
+        description: The known_hosts file used to verify the server host key, loaded
+          from the classpath by default. Needed when the process has no
+          $HOME/.ssh/known_hosts to fall back on.
+        type: string
+        pattern: "^(http|https|file|classpath|ref|bean)://.*"
       useUserKnownHostsFile:
         title: Use User Known Hosts File
         description: If knownHostFile has not been explicit configured then use the host file from System.getProperty(user.home)/.ssh/known_hosts.
@@ -139,6 +149,7 @@ spec:
             privateKeyPassphrase: "{{?privateKeyPassphrase}}"
             privateKeyUri: "{{?privateKeyUri}}"
             strictHostKeyChecking: "{{?strictHostKeyChecking}}"
+            knownHostsUri: "{{?knownHostsUri}}"
             useUserKnownHostsFile: "{{?useUserKnownHostsFile}}"
             passiveMode: "{{passiveMode}}"
             fileExist: "{{fileExist}}"

--- a/kamelets/sftp-source.kamelet.yaml
+++ b/kamelets/sftp-source.kamelet.yaml
@@ -106,9 +106,19 @@ spec:
         pattern: "^(http|https|file|classpath|ref|bean)://.*"
       strictHostKeyChecking:
         title: Strict Host Checking
-        description: Sets whether to use strict host key checking.
+        description: Sets whether to use strict host key checking. One of yes, no or
+          ask. With no, the server host key is accepted without being checked against
+          a known_hosts entry.
         type: string
-        default: no
+        enum: ["yes", "no", "ask"]
+        default: "yes"
+      knownHostsUri:
+        title: Known Hosts URI
+        description: The known_hosts file used to verify the server host key, loaded
+          from the classpath by default. Needed when the process has no
+          $HOME/.ssh/known_hosts to fall back on.
+        type: string
+        pattern: "^(http|https|file|classpath|ref|bean)://.*"
       useUserKnownHostsFile:
         title: Use User Known Hosts File
         description: If knownHostFile has not been explicit configured then use the host file from System.getProperty(user.home)/.ssh/known_hosts.
@@ -138,6 +148,7 @@ spec:
         privateKeyPassphrase: "{{?privateKeyPassphrase}}"
         privateKeyUri: "{{?privateKeyUri}}"
         strictHostKeyChecking: "{{?strictHostKeyChecking}}"
+        knownHostsUri: "{{?knownHostsUri}}"
         useUserKnownHostsFile: "{{?useUserKnownHostsFile}}"
         passiveMode: "{{passiveMode}}"
         recursive: "{{recursive}}"

--- a/kamelets/ssh-sink.kamelet.yaml
+++ b/kamelets/ssh-sink.kamelet.yaml
@@ -60,6 +60,13 @@ spec:
         format: password
         x-descriptors:
         - urn:camel:group:credentials
+      knownHostsResource:
+        title: Known Hosts Resource
+        description: The resource path of a known_hosts file used to verify the SSH
+          server host key. When not set, the client does not verify the server host
+          key against a known_hosts file.
+        type: string
+        pattern: "^(http|https|file|classpath|ref|bean):.*"
   types:
     in:
       mediaType: text/plain
@@ -78,3 +85,4 @@ spec:
           parameters:
             username: "{{username}}"
             password: "{{password}}"
+            knownHostsResource: "{{?knownHostsResource}}"

--- a/kamelets/ssh-source.kamelet.yaml
+++ b/kamelets/ssh-source.kamelet.yaml
@@ -61,6 +61,13 @@ spec:
         format: password
         x-descriptors:
         - urn:camel:group:credentials
+      knownHostsResource:
+        title: Known Hosts Resource
+        description: The resource path of a known_hosts file used to verify the SSH
+          server host key. When not set, the client does not verify the server host
+          key against a known_hosts file.
+        type: string
+        pattern: "^(http|https|file|classpath|ref|bean):.*"
       delay:
         title: Delay
         description: The number of milliseconds before the next poll
@@ -80,6 +87,7 @@ spec:
       parameters:
         username: "{{username}}"
         password: "{{password}}"
+        knownHostsResource: "{{?knownHostsResource}}"
         delay: "{{delay}}"
         pollCommand: "{{pollCommand}}"
       steps:


### PR DESCRIPTION
Fixes #2955

### `strictHostKeyChecking` defaulted to `no`

`sftp-sink`, `sftp-source` and `scp-sink` declared:

```yaml
strictHostKeyChecking:
  type: string
  default: no
```

so the server host key was accepted without being checked against a `known_hosts` entry.

Changed to `default: "yes"`, with an `enum` constraining the value to `yes` / `no` / `ask`, and a description that says what `no` actually means.

### `knownHostsUri` added

`useUserKnownHostsFile` was already declared on all three and defaults to `true`, so with strict checking on the client falls back to `$HOME/.ssh/known_hosts`. That file frequently does not exist in a container, so a `knownHostsUri` property is added and bound, matching the existing `privateKeyUri` shape and `pattern`.

### `ssh-sink` / `ssh-source` had no host-key option at all

`camel-ssh` only installs a host-key verifier when `knownHostsResource` is set — *"When not set, the client does not verify the server host key against a known_hosts file."* Neither Kamelet surfaced it, so host-key verification was unreachable through the Kamelet interface even for an operator who wanted it. Both now declare and bind `knownHostsResource`.

### Behaviour change

This is the disruptive one of the batch. Existing SFTP/SCP deployments that relied on the permissive default will fail to connect until either the host key is in a `known_hosts` file the process can read, `knownHostsUri` is pointed at one, or `strictHostKeyChecking=no` is set explicitly. `camel-kamelets` has no upgrade guide of its own, so the note belongs in the `apache/camel` upgrade guide for the release that picks this up — flagging for a maintainer.

Worth a maintainer's judgement on whether the default flip should ship together with the new property in one release, or whether the property should land first and the default flip follow.

### Verification

- `script/validator` reports no errors
- `mvn verify` passes
- Option names and semantics taken from the Camel 4.22.0 catalog for `sftp` and `ssh`; not exercised against a live SSH server

---
_Claude Code on behalf of Andrea Cosentino_