### PR TITLE
Fix #2956: let mail-sink use a TLS-capable SMTP transport, and default to it

### DIFF
--- a/kamelets/mail-sink.kamelet.yaml
+++ b/kamelets/mail-sink.kamelet.yaml
@@ -45,8 +45,16 @@ spec:
       connectionPort:
         description: The mail server port
         title: Port
-        default: 25
+        default: 465
         type: string
+      protocol:
+        title: Protocol
+        description: The mail protocol to use. Use smtps for an implicitly TLS-encrypted
+          connection; smtp connects in the clear, which sends the configured
+          credentials unencrypted.
+        type: string
+        enum: ["smtp", "smtps"]
+        default: "smtps"
       username:
         title: Username
         description: The username to access the mail box
@@ -111,7 +119,7 @@ spec:
         - removeHeaders:
             pattern: "ce-*"
         - to:
-            uri: "smtp:{{connectionHost}}:{{connectionPort}}"
+            uri: "{{protocol}}:{{connectionHost}}:{{connectionPort}}"
             parameters:
               subject: "{{subject}}"
               from: "{{from}}"


### PR DESCRIPTION
Fixes #2956

`mail-sink` hardcoded the plaintext scheme:

```yaml
- to:
    uri: "smtp:{{connectionHost}}:{{connectionPort}}"
```

with no TLS/STARTTLS property anywhere in `spec.definition`, so an operator had no way to select a secure transport — the `username`/`password` always crossed the network unencrypted. The sibling `mail-imap-source` already uses `imaps:`.

```diff
+      protocol:
+        title: Protocol
+        description: The mail protocol to use. Use smtps for an implicitly
+          TLS-encrypted connection; smtp connects in the clear, which sends the
+          configured credentials unencrypted.
+        type: string
+        enum: ["smtp", "smtps"]
+        default: "smtps"

-    uri: "smtp:{{connectionHost}}:{{connectionPort}}"
+    uri: "{{protocol}}:{{connectionHost}}:{{connectionPort}}"
```

Putting the scheme in a property follows `spring-rabbitmq-sink`, which already does `uri: '{{protocol}}://{{host}}:{{port}}'` with an `amqp`/`amqps` enum.

`connectionPort` moves from `25` to `465` to match the new default scheme.

### Verified on the wire

Not just reasoned about — I ran the modified Kamelet with `camel run --local-kamelet-dir` against a socket listener and inspected the first bytes the client sent:

```
VERDICT: TLS ClientHello (implicit TLS) — first bytes: 16030301a1
```

`0x16` = TLS handshake record, `0x0303` = TLS 1.2. The placeholder resolves in scheme position and the connection is genuinely encrypted.

### Behaviour change

Both defaults change. A deployment relying on plaintext SMTP on port 25 must now set `protocol=smtp` and `connectionPort=25` explicitly. Worth noting that the Kamelet's own `example: smtp.gmail.com` never worked on port 25 anyway, so the old default was already unusable for the documented case.

`camel-kamelets` has no upgrade guide of its own, so the note belongs in the `apache/camel` upgrade guide for the release that picks this up — flagging for a maintainer.

### Not covered

STARTTLS on port 587 is a third case this does not address — `smtps` is implicit TLS only. If STARTTLS support is wanted, that is a separate property (`mail.smtp.starttls.enable` via `additionalJavaMailProperties`) and worth its own issue.

### Verification

- `script/validator` reports no errors
- `mvn verify` passes
- TLS handshake confirmed as above

---
_Claude Code on behalf of Andrea Cosentino_