### PR TITLE
Fix #2972: quote the password in the Azure schema-registry Kamelets' JAAS config

### DIFF
--- a/kamelets/kafka-azure-schema-registry-sink.kamelet.yaml
+++ b/kamelets/kafka-azure-schema-registry-sink.kamelet.yaml
@@ -122,7 +122,7 @@ spec:
             brokers: "{{bootstrapServers}}"
             securityProtocol: "{{securityProtocol}}"
             saslMechanism: "{{saslMechanism}}"
-            saslJaasConfig: 'org.apache.kafka.common.security.plain.PlainLoginModule required username="$ConnectionString" password={{password}};'
+            saslJaasConfig: 'org.apache.kafka.common.security.plain.PlainLoginModule required username="$ConnectionString" password="{{password}}";'
             valueSerializer: "{{valueSerializer}}"
             additionalProperties.schema.registry.url: "{{azureRegistryUrl}}"
             additionalProperties.schema.group: avro

--- a/kamelets/kafka-azure-schema-registry-source.kamelet.yaml
+++ b/kamelets/kafka-azure-schema-registry-source.kamelet.yaml
@@ -134,7 +134,7 @@ spec:
         brokers: "{{bootstrapServers}}"
         securityProtocol: "{{securityProtocol}}"
         saslMechanism: "{{saslMechanism}}"
-        saslJaasConfig: 'org.apache.kafka.common.security.plain.PlainLoginModule required username="$ConnectionString" password={{password}};'
+        saslJaasConfig: 'org.apache.kafka.common.security.plain.PlainLoginModule required username="$ConnectionString" password="{{password}}";'
         autoCommitEnable: "{{autoCommitEnable}}"
         allowManualCommit: "{{allowManualCommit}}"
         pollOnError: "{{pollOnError}}"

--- a/kamelets/kafka-batch-azure-schema-registry-source.kamelet.yaml
+++ b/kamelets/kafka-batch-azure-schema-registry-source.kamelet.yaml
@@ -154,7 +154,7 @@ spec:
         brokers: "{{bootstrapServers}}"
         securityProtocol: "{{securityProtocol}}"
         saslMechanism: "{{saslMechanism}}"
-        saslJaasConfig: 'org.apache.kafka.common.security.plain.PlainLoginModule required username="$ConnectionString" password={{password}};'
+        saslJaasConfig: 'org.apache.kafka.common.security.plain.PlainLoginModule required username="$ConnectionString" password="{{password}}";'
         autoCommitEnable: "{{autoCommitEnable}}"
         allowManualCommit: "{{allowManualCommit}}"
         pollOnError: "{{pollOnError}}"


### PR DESCRIPTION
Partially addresses #2972 (the JAAS item — the URL-`pattern` sweep, the wider `RAW()` work and the redis `serializer` constraint stay open).

`kafka-azure-schema-registry-sink`, `kafka-azure-schema-registry-source` and `kafka-batch-azure-schema-registry-source` build their `sasl.jaas.config` like this:

```
org.apache.kafka.common.security.plain.PlainLoginModule required username="$ConnectionString" password={{password}};
```

`username` is quoted; `password` is not. Because `username="$ConnectionString"`, the password here **is** an Azure Event Hubs connection string, and those always contain semicolons:

```
Endpoint=sb://ns.servicebus.windows.net/;SharedAccessKeyName=k;SharedAccessKey=abc123=
```

JAAS terminates an unquoted value at the first `;`.

### This is a functional break, not hardening

I filed it under #2972 as credential-shape hardening. Running it through Kafka's own parser shows it is stronger than that — the Kamelets cannot work as shipped for their primary documented use case:

```
UNQUOTED (as shipped) -> PARSE ERROR: IllegalArgumentException: Value not specified for key 'null' in JAAS config
QUOTED   (proposed)   -> password=[Endpoint=sb://ns.servicebus.windows.net/;SharedAccessKeyName=k;SharedAccessKey=abc123=]
```

Checked against `JaasContext.loadClientContext` from `kafka-clients` 4.3.1, feeding it the exact string each template produces.

```diff
- ... username="$ConnectionString" password={{password}};
+ ... username="$ConnectionString" password="{{password}}";
```

### Worth a follow-up

Quoting fixes the semicolon case and every other separator, but a password containing a literal `"` would still break the entry. Using the `kafka` component's `saslUsername` / `saslPassword` options instead of hand-building a JAAS string would sidestep the quoting question entirely — larger change, better left to its own issue if maintainers want it.

### Verification

- `script/validator` reports no errors
- `mvn verify` passes
- JAAS parse behaviour verified against `kafka-clients` 4.3.1 as above; no live Event Hubs or Kafka broker involved

---
_Claude Code on behalf of Andrea Cosentino_