### PR TITLE
Fix #2973: strip the remaining destination-affecting HTTP headers in the http sinks

### DIFF
--- a/kamelets/http-secured-sink.kamelet.yaml
+++ b/kamelets/http-secured-sink.kamelet.yaml
@@ -105,6 +105,16 @@ spec:
       steps:
       - removeHeader:
           name: CamelHttpUri
+      - removeHeader:
+          name: CamelHttpPath
+      - removeHeader:
+          name: CamelHttpQuery
+      - removeHeader:
+          name: CamelHttpRawQuery
+      - removeHeader:
+          name: CamelRestHttpUri
+      - removeHeader:
+          name: CamelRestHttpQuery
       - setHeader:
           name: CamelHttpMethod
           constant: "{{method}}"

--- a/kamelets/http-sink.kamelet.yaml
+++ b/kamelets/http-sink.kamelet.yaml
@@ -57,6 +57,16 @@ spec:
       steps:
       - removeHeader:
           name: CamelHttpUri
+      - removeHeader:
+          name: CamelHttpPath
+      - removeHeader:
+          name: CamelHttpQuery
+      - removeHeader:
+          name: CamelHttpRawQuery
+      - removeHeader:
+          name: CamelRestHttpUri
+      - removeHeader:
+          name: CamelRestHttpQuery
       - setHeader:
           name: CamelHttpMethod
           constant: "{{method}}"


### PR DESCRIPTION
Partially addresses #2973 — the tier-1 HTTP slice. SQL/CQL is in a sibling PR; broker sinks and the tier-3 mixed cases (`exec-sink`, `kafka-sink`, `aws-ec2-sink`) are still open.

`http-sink` and `http-secured-sink` already removed `CamelHttpUri` before dispatch, and the doc partial states the intent: *"removes any existing CamelHttpUri header to prevent conflicts."* But `camel-http` builds the request URI from several more headers, none of which were stripped.

```diff
       - removeHeader:
           name: CamelHttpUri
+      - removeHeader:
+          name: CamelHttpPath
+      - removeHeader:
+          name: CamelHttpQuery
+      - removeHeader:
+          name: CamelHttpRawQuery
+      - removeHeader:
+          name: CamelRestHttpUri
+      - removeHeader:
+          name: CamelRestHttpQuery
       - setHeader:
           name: CamelHttpMethod
```

### Verified against a local listener

The endpoint was configured for `/intended`, and the route set `CamelHttpPath: /hijacked` plus `CamelHttpQuery: injected=1`:

| template | path the server received |
|---|---|
| current `http-sink` | `/intended/hijacked?injected=1` |
| this PR | `/intended` |

Worth noting these headers **append to** the operator's path rather than replacing it — `CamelHttpPath` is documented as *"used to build the request URI with the HTTP_URI"*. I would have described this wrongly from the documentation alone, which is why it was worth running.

### Why named headers rather than a `CamelHttp*` pattern

The obvious `removeHeaders: pattern: "CamelHttp*"` is wrong in both directions:

- it would also drop `CamelHttpCharacterEncoding` and `CamelHttpProtocolVersion`, which are legitimate things for a route to set;
- it would still miss `CamelRestHttpUri` and `CamelRestHttpQuery`, which do not start with `CamelHttp`.

The named list covers exactly the headers `camel-http` uses to build the request URI. `Content-Type` and `Content-Encoding` are untouched.

### Tier

Tier 1 in #2973's taxonomy: these templates declare no `types.*.headers:` block and map no headers of their own, so nothing is being taken away. The Kamelet's whole point is that `{{url}}` is operator-bound.

### Verification

- `script/validator` reports no errors
- `mvn verify` passes
- Behaviour verified with `camel run` against a local HTTP listener as tabulated

---
_Claude Code on behalf of Andrea Cosentino_


### Framing

Please read this as defence in depth, not as closing an open hole. Every dispatch-override header in these families is `Camel`-prefixed and therefore subject to source-side ingest filtering — see the corrected *Reachability* section of #2973. This PR closes the "if the header arrives, it redirects the sink" half; the "can it arrive" half is already handled at the source for the common topologies.
