### PR TITLE
Fix #2973: strip the query headers in the SQL and CQL sinks

### DIFF
--- a/kamelets/aws-redshift-sink.kamelet.yaml
+++ b/kamelets/aws-redshift-sink.kamelet.yaml
@@ -99,6 +99,10 @@ spec:
       - unmarshal:
           json: 
             library: Jackson
+      - removeHeader:
+          name: CamelSqlQuery
+      - removeHeader:
+          name: CamelSqlParameters
       - to: 
           uri: "{{local-sql-redshift-sink}}:{{query}}"
           parameters:

--- a/kamelets/cassandra-sink.kamelet.yaml
+++ b/kamelets/cassandra-sink.kamelet.yaml
@@ -117,6 +117,8 @@ spec:
                     json: 
                       library: Jackson
                       useList: true
+      - removeHeader:
+          name: CamelCqlQuery
       - to: 
           uri: "{{local-sql-cassandraql-sink}}://{{connectionHost}}:{{connectionPort}}/{{keyspace}}"
           parameters:

--- a/kamelets/databricks-sink.kamelet.yaml
+++ b/kamelets/databricks-sink.kamelet.yaml
@@ -97,6 +97,10 @@ spec:
       - unmarshal:
           json:
             library: Jackson
+      - removeHeader:
+          name: CamelSqlQuery
+      - removeHeader:
+          name: CamelSqlParameters
       - to:
           uri: "{{local-sql-databricks-sink}}:{{query}}"
           parameters:

--- a/kamelets/mariadb-sink.kamelet.yaml
+++ b/kamelets/mariadb-sink.kamelet.yaml
@@ -98,6 +98,10 @@ spec:
       - unmarshal:
           json: 
             library: Jackson
+      - removeHeader:
+          name: CamelSqlQuery
+      - removeHeader:
+          name: CamelSqlParameters
       - to: 
           uri: "{{local-sql-mariadb-sink}}:{{query}}"
           parameters:

--- a/kamelets/mysql-sink.kamelet.yaml
+++ b/kamelets/mysql-sink.kamelet.yaml
@@ -98,6 +98,10 @@ spec:
       - unmarshal:
           json: 
             library: Jackson
+      - removeHeader:
+          name: CamelSqlQuery
+      - removeHeader:
+          name: CamelSqlParameters
       - to: 
           uri: "{{local-sql-mysql-sink}}:{{query}}"
           parameters:

--- a/kamelets/oracle-database-sink.kamelet.yaml
+++ b/kamelets/oracle-database-sink.kamelet.yaml
@@ -98,6 +98,10 @@ spec:
       - unmarshal:
           json: 
             library: Jackson
+      - removeHeader:
+          name: CamelSqlQuery
+      - removeHeader:
+          name: CamelSqlParameters
       - to: 
           uri: "{{local-sql-oracle-sink}}:{{query}}"
           parameters:

--- a/kamelets/postgresql-sink.kamelet.yaml
+++ b/kamelets/postgresql-sink.kamelet.yaml
@@ -99,6 +99,10 @@ spec:
       - unmarshal:
           json: 
             library: Jackson
+      - removeHeader:
+          name: CamelSqlQuery
+      - removeHeader:
+          name: CamelSqlParameters
       - to: 
           uri: "{{local-sql-postgres-sink}}:{{query}}"
           parameters:

--- a/kamelets/snowflake-sink.kamelet.yaml
+++ b/kamelets/snowflake-sink.kamelet.yaml
@@ -93,6 +93,10 @@ spec:
       - unmarshal:
           json: 
             library: Jackson
+      - removeHeader:
+          name: CamelSqlQuery
+      - removeHeader:
+          name: CamelSqlParameters
       - to: 
           uri: "{{local-sql-snowflake-sink}}:{{query}}"
           parameters:

--- a/kamelets/sqlserver-sink.kamelet.yaml
+++ b/kamelets/sqlserver-sink.kamelet.yaml
@@ -108,6 +108,10 @@ spec:
       - unmarshal:
           json:
             library: Jackson
+      - removeHeader:
+          name: CamelSqlQuery
+      - removeHeader:
+          name: CamelSqlParameters
       - to:
           uri: "{{local-sqlserver-sink}}:{{query}}"
           parameters:


### PR DESCRIPTION
Partially addresses #2973 — the tier-1 SQL/CQL slice. HTTP is in a sibling PR (#2976); broker sinks and the tier-3 mixed cases (`exec-sink`, `kafka-sink`, `aws-ec2-sink`) are still open.

The nine SQL/CQL sinks dispatch an operator-bound `{{query}}` while passing every inbound header straight through to the producer:

`aws-redshift-sink`, `databricks-sink`, `mariadb-sink`, `mysql-sink`, `oracle-database-sink`, `postgresql-sink`, `snowflake-sink`, `sqlserver-sink`, `cassandra-sink`

`camel-sql` documents `CamelSqlQuery` as *"Query to execute. This query takes precedence over the query specified in the endpoint URI"*, and `camel-cassandraql` documents `CamelCqlQuery` the same way.

```diff
       - unmarshal:
           json:
             library: Jackson
+      - removeHeader:
+          name: CamelSqlQuery
+      - removeHeader:
+          name: CamelSqlParameters
       - to:
           uri: "{{local-sql-postgres-sink}}:{{query}}"
```

`cassandra-sink` gets `CamelCqlQuery`; the other eight get `CamelSqlQuery` and `CamelSqlParameters`.

### Verified against H2

A route whose endpoint query asked for `intended`, with a `CamelSqlQuery` header asking for `secret`:

| template shape | result |
|---|---|
| as shipped | `[{NAME=secret}]` |
| with the removeHeader steps | `[{NAME=intended}]` |

The override is wholesale — the header replaces the operator's query rather than augmenting it.

### Tier

Tier 1 in #2973's taxonomy, and the clearest case in the set: these templates map **no** headers of their own and declare no `types.*.headers:` interface. The query is exposed solely as an operator-bound `{{query}}` property, so nothing about the template invites a wire-supplied query and no contract is being removed.

### Scope note

Sinks only. `CamelSqlQuery` is a producer header, so the SQL *sources* are unaffected.

This does not change what the security model says about SQL Kamelets — an operator binding `{{query}}` to untrusted data remains route-author responsibility and out of scope. This is about the separate case where the template never asked for a wire query at all.

### Verification

- `script/validator` reports no errors
- `mvn verify` passes
- Override and fix verified with `camel run` against an in-memory H2 database as tabulated

---
_Claude Code on behalf of Andrea Cosentino_


### Framing

Please read this as defence in depth, not as closing an open hole. Every dispatch-override header in these families is `Camel`-prefixed and therefore subject to source-side ingest filtering — see the corrected *Reachability* section of #2973. This PR closes the "if the header arrives, it redirects the sink" half; the "can it arrive" half is already handled at the source for the common topologies.
