### PR TITLE
Fix #1059: add an SMPP sink Kamelet

### DIFF
--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -220,6 +220,7 @@
 * xref:simple-filter-action.adoc[]
 * xref:slack-sink.adoc[]
 * xref:slack-source.adoc[]
+* xref:smpp-sink.adoc[]
 * xref:snowflake-sink.adoc[]
 * xref:snowflake-source.adoc[]
 * xref:solr-sink.adoc[]

--- a/kamelets/smpp-sink.kamelet.yaml
+++ b/kamelets/smpp-sink.kamelet.yaml
@@ -1,0 +1,113 @@
+# ---------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ---------------------------------------------------------------------------
+apiVersion: camel.apache.org/v1
+kind: Kamelet
+metadata:
+  name: smpp-sink
+  annotations:
+    camel.apache.org/kamelet.support.level: "Preview"
+    camel.apache.org/catalog.version: "4.22.1-SNAPSHOT"
+    camel.apache.org/kamelet.icon: "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA2NCA2NCI+PHBhdGggZmlsbD0iIzVjOGFjNCIgZD0iTTU0IDhIMTBhNiA2IDAgMCAwLTYgNnYyNmE2IDYgMCAwIDAgNiA2aDZ2MTBsMTMtMTBoMjVhNiA2IDAgMCAwIDYtNlYxNGE2IDYgMCAwIDAtNi02eiIvPjxnIGZpbGw9IiNmZmZmZmYiPjxjaXJjbGUgY3g9IjIwIiBjeT0iMjciIHI9IjMuNSIvPjxjaXJjbGUgY3g9IjMyIiBjeT0iMjciIHI9IjMuNSIvPjxjaXJjbGUgY3g9IjQ0IiBjeT0iMjciIHI9IjMuNSIvPjwvZz48L3N2Zz4K"
+    camel.apache.org/provider: "Apache Software Foundation"
+    camel.apache.org/kamelet.group: "SMPP"
+    camel.apache.org/kamelet.namespace: "Messaging"
+  labels:
+    camel.apache.org/kamelet.type: "sink"
+spec:
+  definition:
+    title: "SMPP Sink"
+    description: |-
+      Send SMS messages through a SMSC (Short Message Service Center) using the SMPP protocol.
+
+      The message body is sent as the short message text.
+    required:
+    - host
+    type: object
+    properties:
+      host:
+        title: Host
+        description: The hostname of the SMSC server to connect to.
+        type: string
+        example: "smsc.example.com"
+      port:
+        title: Port
+        description: The port of the SMSC server to connect to.
+        type: integer
+        default: 2775
+      systemId:
+        title: System ID
+        description: The system id (username) for connecting to the SMSC server.
+        type: string
+        default: smppclient
+        x-descriptors:
+        - urn:camel:group:credentials
+      password:
+        title: Password
+        description: The password for connecting to the SMSC server.
+        type: string
+        format: password
+        x-descriptors:
+        - urn:camel:group:credentials
+      systemType:
+        title: System Type
+        description: The type of ESME (External Short Message Entity) binding to the SMSC (max. 13 characters).
+        type: string
+        example: "cp"
+      sourceAddr:
+        title: Source Address
+        description: The address of the SME (Short Message Entity) which originated the message.
+        type: string
+        default: "1616"
+      destAddr:
+        title: Destination Address
+        description: The destination SME address. For mobile terminated messages this is the directory number of the recipient.
+        type: string
+        default: "1717"
+      encoding:
+        title: Encoding
+        description: The encoding scheme of the short message user data.
+        type: string
+        default: "ISO-8859-1"
+      splittingPolicy:
+        title: Splitting Policy
+        description: The policy for handling long messages. ALLOW splits long messages into 140 byte parts, TRUNCATE cuts them at 140 bytes, REJECT fails the exchange.
+        type: string
+        default: ALLOW
+        enum: ["ALLOW", "TRUNCATE", "REJECT"]
+      usingSSL:
+        title: Using SSL
+        description: Whether to secure the connection to the SMSC server with TLS (the smpps protocol).
+        type: boolean
+        default: false
+  dependencies:
+    - "camel:smpp"
+    - "camel:kamelet"
+  template:
+    from:
+      uri: "kamelet:source"
+      steps:
+      - to:
+          uri: "smpp:{{host}}:{{port}}"
+          parameters:
+            systemId: "{{systemId}}"
+            password: "{{?password}}"
+            systemType: "{{?systemType}}"
+            sourceAddr: "{{sourceAddr}}"
+            destAddr: "{{destAddr}}"
+            encoding: "{{encoding}}"
+            splittingPolicy: "{{splittingPolicy}}"
+            usingSSL: "{{usingSSL}}"

--- a/library/camel-kamelets/src/main/resources/kamelets/smpp-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/smpp-sink.kamelet.yaml
@@ -1,0 +1,113 @@
+# ---------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ---------------------------------------------------------------------------
+apiVersion: camel.apache.org/v1
+kind: Kamelet
+metadata:
+  name: smpp-sink
+  annotations:
+    camel.apache.org/kamelet.support.level: "Preview"
+    camel.apache.org/catalog.version: "4.22.1-SNAPSHOT"
+    camel.apache.org/kamelet.icon: "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA2NCA2NCI+PHBhdGggZmlsbD0iIzVjOGFjNCIgZD0iTTU0IDhIMTBhNiA2IDAgMCAwLTYgNnYyNmE2IDYgMCAwIDAgNiA2aDZ2MTBsMTMtMTBoMjVhNiA2IDAgMCAwIDYtNlYxNGE2IDYgMCAwIDAtNi02eiIvPjxnIGZpbGw9IiNmZmZmZmYiPjxjaXJjbGUgY3g9IjIwIiBjeT0iMjciIHI9IjMuNSIvPjxjaXJjbGUgY3g9IjMyIiBjeT0iMjciIHI9IjMuNSIvPjxjaXJjbGUgY3g9IjQ0IiBjeT0iMjciIHI9IjMuNSIvPjwvZz48L3N2Zz4K"
+    camel.apache.org/provider: "Apache Software Foundation"
+    camel.apache.org/kamelet.group: "SMPP"
+    camel.apache.org/kamelet.namespace: "Messaging"
+  labels:
+    camel.apache.org/kamelet.type: "sink"
+spec:
+  definition:
+    title: "SMPP Sink"
+    description: |-
+      Send SMS messages through a SMSC (Short Message Service Center) using the SMPP protocol.
+
+      The message body is sent as the short message text.
+    required:
+    - host
+    type: object
+    properties:
+      host:
+        title: Host
+        description: The hostname of the SMSC server to connect to.
+        type: string
+        example: "smsc.example.com"
+      port:
+        title: Port
+        description: The port of the SMSC server to connect to.
+        type: integer
+        default: 2775
+      systemId:
+        title: System ID
+        description: The system id (username) for connecting to the SMSC server.
+        type: string
+        default: smppclient
+        x-descriptors:
+        - urn:camel:group:credentials
+      password:
+        title: Password
+        description: The password for connecting to the SMSC server.
+        type: string
+        format: password
+        x-descriptors:
+        - urn:camel:group:credentials
+      systemType:
+        title: System Type
+        description: The type of ESME (External Short Message Entity) binding to the SMSC (max. 13 characters).
+        type: string
+        example: "cp"
+      sourceAddr:
+        title: Source Address
+        description: The address of the SME (Short Message Entity) which originated the message.
+        type: string
+        default: "1616"
+      destAddr:
+        title: Destination Address
+        description: The destination SME address. For mobile terminated messages this is the directory number of the recipient.
+        type: string
+        default: "1717"
+      encoding:
+        title: Encoding
+        description: The encoding scheme of the short message user data.
+        type: string
+        default: "ISO-8859-1"
+      splittingPolicy:
+        title: Splitting Policy
+        description: The policy for handling long messages. ALLOW splits long messages into 140 byte parts, TRUNCATE cuts them at 140 bytes, REJECT fails the exchange.
+        type: string
+        default: ALLOW
+        enum: ["ALLOW", "TRUNCATE", "REJECT"]
+      usingSSL:
+        title: Using SSL
+        description: Whether to secure the connection to the SMSC server with TLS (the smpps protocol).
+        type: boolean
+        default: false
+  dependencies:
+    - "camel:smpp"
+    - "camel:kamelet"
+  template:
+    from:
+      uri: "kamelet:source"
+      steps:
+      - to:
+          uri: "smpp:{{host}}:{{port}}"
+          parameters:
+            systemId: "{{systemId}}"
+            password: "{{?password}}"
+            systemType: "{{?systemType}}"
+            sourceAddr: "{{sourceAddr}}"
+            destAddr: "{{destAddr}}"
+            encoding: "{{encoding}}"
+            splittingPolicy: "{{splittingPolicy}}"
+            usingSSL: "{{usingSSL}}"


### PR DESCRIPTION
Fixes #1059.

Adds `smpp-sink`, which sends the message body as an SMS short message through a SMSC (Short Message Service Center) using `camel-smpp`.

```yaml
- to:
    uri: "smpp:{{host}}:{{port}}"
    parameters:
      systemId: "{{systemId}}"
      password: "{{?password}}"
      systemType: "{{?systemType}}"
      sourceAddr: "{{sourceAddr}}"
      destAddr: "{{destAddr}}"
      encoding: "{{encoding}}"
      splittingPolicy: "{{splittingPolicy}}"
      usingSSL: "{{usingSSL}}"
```

## Properties

Only `host` is required. Everything else keeps the `camel-smpp` default, so a minimal binding is just the SMSC hostname.

| property | default | notes |
|---|---|---|
| `host` | — | **required** |
| `port` | `2775` | |
| `systemId` | `smppclient` | credentials descriptor |
| `password` | — | `format: password` + credentials descriptor |
| `systemType` | — | ESME type, max 13 chars |
| `sourceAddr` | `1616` | |
| `destAddr` | `1717` | |
| `encoding` | `ISO-8859-1` | |
| `splittingPolicy` | `ALLOW` | enum: `ALLOW` / `TRUNCATE` / `REJECT` |
| `usingSSL` | `false` | |

## Verification

`script/validator` reports no errors, `script/generator` adds the `nav.adoc` entry, and `mvn clean install` passes from the repository root.

Parameter binding was checked against the real component rather than by eye — running the Kamelet with `camel run` resolves the endpoint and fails only on the missing SMSC:

```
Failed to start route: smpp-sink-1 (source: smpp-sink.kamelet.yaml:100)
  because: java.io.IOException: Connection refused
Caused by: java.net.ConnectException: Connection refused
```

That is the endpoint being constructed successfully with every parameter bound. A mistyped option would have failed earlier with `ResolveEndpointFailedException: unknown option` instead.

Worth noting for operators: the SMPP producer binds to the SMSC at **route start**, so a wrong host or an unreachable SMSC fails the route rather than the individual exchange.

## Two things for reviewer judgement

**No Citrus test.** `camel-smpp` needs a live SMSC and there is no SMSC simulator in the project's Citrus/Testcontainers toolchain. I would rather ship without a test than with one that does not exercise the protocol, so this is marked `Preview` and does not carry `kamelet.verified=true`. If there is an SMSC image the project is happy to depend on, I am glad to add the test in a follow-up.

**`usingSSL` defaults to `false`,** matching the `camel-smpp` default and the plain `smpp` scheme. Given the catalog's recent secure-by-default direction (#2954, #2955, #2956), a reviewer may prefer TLS on by default — but SMPP-over-TLS support is far from universal among SMSCs, so defaulting it on would make the Kamelet unusable against most of them. Flagging the choice rather than making it silently.

The icon is a plain SVG glyph authored for this Kamelet, consistent with how other protocol-based Kamelets (`ssh-sink`, `ftp-sink`) use generic glyphs rather than a vendor logo.

---
_Claude Code on behalf of Andrea Cosentino_