### PR TITLE
Fix #1060: add an SMPP source Kamelet

### DIFF
--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -220,6 +220,7 @@
 * xref:simple-filter-action.adoc[]
 * xref:slack-sink.adoc[]
 * xref:slack-source.adoc[]
+* xref:smpp-source.adoc[]
 * xref:snowflake-sink.adoc[]
 * xref:snowflake-source.adoc[]
 * xref:solr-sink.adoc[]

--- a/kamelets/smpp-source.kamelet.yaml
+++ b/kamelets/smpp-source.kamelet.yaml
@@ -1,0 +1,98 @@
+# ---------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ---------------------------------------------------------------------------
+apiVersion: camel.apache.org/v1
+kind: Kamelet
+metadata:
+  name: smpp-source
+  annotations:
+    camel.apache.org/kamelet.support.level: "Preview"
+    camel.apache.org/catalog.version: "4.22.1-SNAPSHOT"
+    camel.apache.org/kamelet.icon: "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA2NCA2NCI+PHBhdGggZmlsbD0iIzVjOGFjNCIgZD0iTTU0IDhIMTBhNiA2IDAgMCAwLTYgNnYyNmE2IDYgMCAwIDAgNiA2aDZ2MTBsMTMtMTBoMjVhNiA2IDAgMCAwIDYtNlYxNGE2IDYgMCAwIDAtNi02eiIvPjxnIGZpbGw9IiNmZmZmZmYiPjxjaXJjbGUgY3g9IjIwIiBjeT0iMjciIHI9IjMuNSIvPjxjaXJjbGUgY3g9IjMyIiBjeT0iMjciIHI9IjMuNSIvPjxjaXJjbGUgY3g9IjQ0IiBjeT0iMjciIHI9IjMuNSIvPjwvZz48L3N2Zz4K"
+    camel.apache.org/provider: "Apache Software Foundation"
+    camel.apache.org/kamelet.group: "SMPP"
+    camel.apache.org/kamelet.namespace: "Messaging"
+  labels:
+    camel.apache.org/kamelet.type: "source"
+spec:
+  definition:
+    title: "SMPP Source"
+    description: |-
+      Receive SMS messages and delivery receipts from a SMSC (Short Message Service Center) using the SMPP protocol.
+
+      The short message text is emitted as the message body. Details of the received PDU are available in the CamelSmpp* headers.
+    required:
+    - host
+    type: object
+    properties:
+      host:
+        title: Host
+        description: The hostname of the SMSC server to connect to.
+        type: string
+        example: "smsc.example.com"
+      port:
+        title: Port
+        description: The port of the SMSC server to connect to.
+        type: integer
+        default: 2775
+      systemId:
+        title: System ID
+        description: The system id (username) for connecting to the SMSC server.
+        type: string
+        default: smppclient
+        x-descriptors:
+        - urn:camel:group:credentials
+      password:
+        title: Password
+        description: The password for connecting to the SMSC server.
+        type: string
+        format: password
+        x-descriptors:
+        - urn:camel:group:credentials
+      systemType:
+        title: System Type
+        description: The type of ESME (External Short Message Entity) binding to the SMSC (max. 13 characters).
+        type: string
+        example: "cp"
+      addressRange:
+        title: Address Range
+        description: The address range the consumer binds with, as defined in section 5.2.7 of the SMPP 3.4 specification. The SMSC uses it to route messages to this ESME.
+        type: string
+      encoding:
+        title: Encoding
+        description: The encoding scheme of the short message user data.
+        type: string
+        default: "ISO-8859-1"
+      usingSSL:
+        title: Using SSL
+        description: Whether to secure the connection to the SMSC server with TLS (the smpps protocol).
+        type: boolean
+        default: false
+  dependencies:
+    - "camel:smpp"
+    - "camel:kamelet"
+  template:
+    from:
+      uri: "smpp:{{host}}:{{port}}"
+      parameters:
+        systemId: "{{systemId}}"
+        password: "{{?password}}"
+        systemType: "{{?systemType}}"
+        addressRange: "{{?addressRange}}"
+        encoding: "{{encoding}}"
+        usingSSL: "{{usingSSL}}"
+      steps:
+      - to: "kamelet:sink"

--- a/library/camel-kamelets/src/main/resources/kamelets/smpp-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/smpp-source.kamelet.yaml
@@ -1,0 +1,98 @@
+# ---------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ---------------------------------------------------------------------------
+apiVersion: camel.apache.org/v1
+kind: Kamelet
+metadata:
+  name: smpp-source
+  annotations:
+    camel.apache.org/kamelet.support.level: "Preview"
+    camel.apache.org/catalog.version: "4.22.1-SNAPSHOT"
+    camel.apache.org/kamelet.icon: "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA2NCA2NCI+PHBhdGggZmlsbD0iIzVjOGFjNCIgZD0iTTU0IDhIMTBhNiA2IDAgMCAwLTYgNnYyNmE2IDYgMCAwIDAgNiA2aDZ2MTBsMTMtMTBoMjVhNiA2IDAgMCAwIDYtNlYxNGE2IDYgMCAwIDAtNi02eiIvPjxnIGZpbGw9IiNmZmZmZmYiPjxjaXJjbGUgY3g9IjIwIiBjeT0iMjciIHI9IjMuNSIvPjxjaXJjbGUgY3g9IjMyIiBjeT0iMjciIHI9IjMuNSIvPjxjaXJjbGUgY3g9IjQ0IiBjeT0iMjciIHI9IjMuNSIvPjwvZz48L3N2Zz4K"
+    camel.apache.org/provider: "Apache Software Foundation"
+    camel.apache.org/kamelet.group: "SMPP"
+    camel.apache.org/kamelet.namespace: "Messaging"
+  labels:
+    camel.apache.org/kamelet.type: "source"
+spec:
+  definition:
+    title: "SMPP Source"
+    description: |-
+      Receive SMS messages and delivery receipts from a SMSC (Short Message Service Center) using the SMPP protocol.
+
+      The short message text is emitted as the message body. Details of the received PDU are available in the CamelSmpp* headers.
+    required:
+    - host
+    type: object
+    properties:
+      host:
+        title: Host
+        description: The hostname of the SMSC server to connect to.
+        type: string
+        example: "smsc.example.com"
+      port:
+        title: Port
+        description: The port of the SMSC server to connect to.
+        type: integer
+        default: 2775
+      systemId:
+        title: System ID
+        description: The system id (username) for connecting to the SMSC server.
+        type: string
+        default: smppclient
+        x-descriptors:
+        - urn:camel:group:credentials
+      password:
+        title: Password
+        description: The password for connecting to the SMSC server.
+        type: string
+        format: password
+        x-descriptors:
+        - urn:camel:group:credentials
+      systemType:
+        title: System Type
+        description: The type of ESME (External Short Message Entity) binding to the SMSC (max. 13 characters).
+        type: string
+        example: "cp"
+      addressRange:
+        title: Address Range
+        description: The address range the consumer binds with, as defined in section 5.2.7 of the SMPP 3.4 specification. The SMSC uses it to route messages to this ESME.
+        type: string
+      encoding:
+        title: Encoding
+        description: The encoding scheme of the short message user data.
+        type: string
+        default: "ISO-8859-1"
+      usingSSL:
+        title: Using SSL
+        description: Whether to secure the connection to the SMSC server with TLS (the smpps protocol).
+        type: boolean
+        default: false
+  dependencies:
+    - "camel:smpp"
+    - "camel:kamelet"
+  template:
+    from:
+      uri: "smpp:{{host}}:{{port}}"
+      parameters:
+        systemId: "{{systemId}}"
+        password: "{{?password}}"
+        systemType: "{{?systemType}}"
+        addressRange: "{{?addressRange}}"
+        encoding: "{{encoding}}"
+        usingSSL: "{{usingSSL}}"
+      steps:
+      - to: "kamelet:sink"


### PR DESCRIPTION
Fixes #1060. Companion to #2988 (`smpp-sink`, #1059) — same component, same connection surface, reviewable independently.

Adds `smpp-source`, which receives SMS messages and delivery receipts from a SMSC using `camel-smpp`. The short message text becomes the body; the received PDU details stay in the `CamelSmpp*` headers the component already sets (`CamelSmppMessageType`, `CamelSmppStatus`, `CamelSmppDelivered`, `CamelSmppSubmitDate`, `CamelSmppOptionalParameters`, …), so nothing is remapped or hidden.

```yaml
from:
  uri: "smpp:{{host}}:{{port}}"
  parameters:
    systemId: "{{systemId}}"
    password: "{{?password}}"
    systemType: "{{?systemType}}"
    addressRange: "{{?addressRange}}"
    encoding: "{{encoding}}"
    usingSSL: "{{usingSSL}}"
  steps:
  - to: "kamelet:sink"
```

## Properties

Only `host` is required.

| property | default | notes |
|---|---|---|
| `host` | — | **required** |
| `port` | `2775` | |
| `systemId` | `smppclient` | credentials descriptor |
| `password` | — | `format: password` + credentials descriptor |
| `systemType` | — | ESME type, max 13 chars |
| `addressRange` | — | consumer-side; tells the SMSC which messages to route to this ESME (SMPP 3.4 §5.2.7) |
| `encoding` | `ISO-8859-1` | |
| `usingSSL` | `false` | |

`addressRange` is the one option that differs from the sink — it is the consumer-labelled option in the component and has no meaning on the producer side. Conversely the sink's `sourceAddr` / `destAddr` / `splittingPolicy` are producer-only and are deliberately absent here.

## Verification

`script/validator` reports no errors, `script/generator` adds the `nav.adoc` entry, `mvn clean install` passes from the repository root.

Parameter binding checked against the real component with `camel run` rather than by eye — the consumer endpoint is constructed and startup fails only on the missing SMSC:

```
Error starting CamelContext (smpp-src-probe) due to exception thrown:
  java.io.IOException: Connection refused
Caused by: java.net.ConnectException: Connection refused
```

A mistyped option would have failed earlier with `unknown option` instead.

## Same two caveats as the sink

**No Citrus test** — `camel-smpp` needs a live SMSC and the project's Citrus/Testcontainers toolchain has no SMSC simulator. Marked `Preview`, no `kamelet.verified=true`. Happy to add the test in a follow-up if there is an SMSC image the project will depend on.

**`usingSSL` defaults to `false`,** matching the component default and the plain `smpp` scheme. Worth a reviewer's eye given the catalog's secure-by-default direction (#2954, #2955, #2956), but SMPP-over-TLS is not widely supported by SMSCs, so defaulting it on would make the Kamelet unusable against most of them.

This is a source Kamelet, so the usual operator note applies: it binds outward to the SMSC you configure, and the SMSC decides what to deliver to it via `addressRange`.

---
_Claude Code on behalf of Andrea Cosentino_