### PR TITLE
Fix #2790: expose publisher confirms on spring-rabbitmq-sink

### DIFF
--- a/kamelets/spring-rabbitmq-sink.kamelet.yaml
+++ b/kamelets/spring-rabbitmq-sink.kamelet.yaml
@@ -77,6 +77,28 @@ spec:
         description: Specifies whether the producer should auto declare binding between exchange, queue and routing key when starting
         type: boolean
         default: false
+      publisherConfirmType:
+        title: Publisher Confirm Type
+        description: The publisher confirm mode of the underlying connection factory. Must be SIMPLE or
+          CORRELATED for the confirm option below to have anything to wait on. NONE, the default, leaves
+          publisher confirms switched off.
+        type: string
+        default: "NONE"
+        enum: ["NONE", "SIMPLE", "CORRELATED"]
+      confirm:
+        title: Confirm
+        description: Controls whether to wait for publisher confirms. auto lets Camel detect whether the
+          connection factory is configured for confirms, enabled always waits, disabled never waits.
+          Requires publisherConfirmType to be SIMPLE or CORRELATED.
+        type: string
+        default: "auto"
+        enum: ["auto", "enabled", "disabled"]
+      confirmTimeout:
+        title: Confirm Timeout
+        description: How long in milliseconds to wait for a sent message to be confirmed by RabbitMQ when
+          doing send-only (InOnly) messaging. A negative value waits indefinitely.
+        type: string
+        default: "5000"
       vhost:
         title: Virtual Host
         description: The virtual host
@@ -100,6 +122,7 @@ spec:
           password: '{{?password}}'
           uri: '{{protocol}}://{{host}}:{{port}}'
           virtualHost: "{{vhost}}"
+          publisherConfirmType: "{{publisherConfirmType}}"
     from:
       uri: "kamelet:source"
       steps:
@@ -110,3 +133,5 @@ spec:
             routingKey: "{{?routingKey}}"
             queues: "{{?queues}}"
             autoDeclareProducer: "{{autoDeclareProducer}}"
+            confirm: "{{confirm}}"
+            confirmTimeout: "{{confirmTimeout}}"


### PR DESCRIPTION
Fixes #2790.

Publisher confirms need two things wired together, and `spring-rabbitmq-sink` exposed neither. This adds all three knobs, in the places they actually live.

## Where each option belongs

The issue suggested a `confirmType` property. That one is not an endpoint option — the confirm *mode* is a property of the connection factory, and only `confirm` / `confirmTimeout` exist on the `camel-spring-rabbitmq` endpoint:

```
[properties] confirm:        type=enum default=auto  enum=['auto', 'enabled', 'disabled']
[properties] confirmTimeout: type=duration default=5000
```

Confirmed against Spring's own class, which is what the template already instantiates inline:

```
public void setPublisherConfirmType(CachingConnectionFactory$ConfirmType);
    ConfirmType SIMPLE;  ConfirmType CORRELATED;  ConfirmType NONE;
```

So the split is:

| property | goes to | values |
|---|---|---|
| `publisherConfirmType` | the `CachingConnectionFactory` bean | `NONE` (default), `SIMPLE`, `CORRELATED` |
| `confirm` | the endpoint | `auto` (default), `enabled`, `disabled` |
| `confirmTimeout` | the endpoint | ms, default `5000`, negative waits indefinitely |

I used the name `publisherConfirmType` rather than the issue's `confirmType` because it is the name of the underlying setter — inventing a second name for the same thing would be one more mapping for a reader to hold.

```yaml
    beans:
      - name: connectionFactory
        type: "#class:org.springframework.amqp.rabbit.connection.CachingConnectionFactory"
        properties:
          ...
          publisherConfirmType: "{{publisherConfirmType}}"
```

```yaml
          parameters:
            ...
            confirm: "{{confirm}}"
            confirmTimeout: "{{confirmTimeout}}"
```

## The trap this is worth documenting

Setting `confirm: enabled` while leaving `publisherConfirmType` at `NONE` gives you a sink that looks configured for confirms but has nothing to wait on. Both descriptions say so explicitly, because it is the natural mistake given the options are on two different objects.

## Compatibility

Nothing changes for existing users. `publisherConfirmType` defaults to `NONE`, which is the current behaviour — confirms stay off unless opted into. `confirm` defaults to `auto`, matching the component default, and `auto` with a `NONE` factory means no waiting.

## Verification

`script/validator` reports no errors, `script/generator` produces no doc changes, `mvn clean install` passes from the repository root.

Binding checked against the real component with `camel run`, since a string-to-enum conversion on a bean property is exactly the sort of thing that silently fails:

```
Routes startup (total:1 started:1 kamelets:1)
    Started rmq-probe (timer://t)
... AmqpConnectException: java.net.ConnectException: Connection refused
```

The route starts with `publisherConfirmType: CORRELATED`, `confirm: enabled`, `confirmTimeout: 3000` — the connection factory is constructed and the enum conversion succeeds — and fails only because there is no broker on localhost. A bad enum value or a misnamed bean property would have failed during startup instead. The defaults-only case (none of the three set) also starts cleanly, which is the regression check that matters here.

No Citrus test: exercising confirms needs a live RabbitMQ, and there is no broker in the project's Citrus toolchain for this component.

---
_Claude Code on behalf of Andrea Cosentino_
