### PR TITLE
Fix #1938: add an AWS Bedrock Agent sink Kamelet

### DIFF
--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -2,6 +2,7 @@
 * xref:avro-deserialize-action.adoc[]
 * xref:avro-serialize-action.adoc[]
 * xref:aws-bedrock-agent-runtime-sink.adoc[]
+* xref:aws-bedrock-agent-sink.adoc[]
 * xref:aws-bedrock-text-sink.adoc[]
 * xref:aws-cloudtrail-source.adoc[]
 * xref:aws-cloudwatch-sink.adoc[]

--- a/kamelets/aws-bedrock-agent-sink.kamelet.yaml
+++ b/kamelets/aws-bedrock-agent-sink.kamelet.yaml
@@ -1,0 +1,142 @@
+# ---------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ---------------------------------------------------------------------------
+apiVersion: camel.apache.org/v1
+kind: Kamelet
+metadata:
+  name: aws-bedrock-agent-sink
+  annotations:
+    camel.apache.org/kamelet.support.level: "Preview"
+    camel.apache.org/catalog.version: "4.22.1-SNAPSHOT"
+    camel.apache.org/kamelet.icon: "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiA/PjxzdmcgZGF0YS1uYW1lPSJMYXllciAxIiBpZD0iTGF5ZXJfMSIgdmlld0JveD0iMCAwIDUxMiA1MTIiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PHBhdGggZD0iTTQzMC40MiwxOTYuMzJjOC0xMS4zOSwyMS4xNS0zOC4zMywwLTcyLjEzYTUyLjc5LDUyLjc5LDAsMCwwLTE3LjA2LTE3LjMxYy0xLjUzLTgtNy41NC0yNy4yNi0zMS40Mi00My45MUMzNTksNDcsMzI1LjUyLDQ5LjUzLDMxOS40NCw1MC4xNmE2NC4yNyw2NC4yNywwLDAsMC0xNi4wNy0yLjk0Yy0xNy4xNy0uODEtMzAuMzcsMy44OS0zOS43OCwxNC4wNUE0Ni4zLDQ2LjMsMCwwLDAsMjU2LDcyLjg5YTQ2LjA2LDQ2LjA2LDAsMCwwLTcuNi0xMS42MmMtOS40LTEwLjE2LTIyLjg2LTE0Ljg2LTM5Ljc2LTE0LjA1YTY0LjczLDY0LjczLDAsMCwwLTE2LjA3LDIuOTRDMTg2LjUyLDQ5LjUzLDE1Myw0NywxMzAsNjNjLTIzLjksMTYuNjYtMjkuOTEsMzYtMzEuNDMsNDMuOTJhNTIuOSw1Mi45LDAsMCwwLTE3LDE3LjNjLTIxLjEzLDMzLjgtNy45NCw2MC43NCwwLDcyLjE0LTkuNzUsOC4zNC0yNy44OCwyNy44OC0yMy4wNiw1NC42NiwzLjI4LDE4LjIsMTMuODQsMzIuMTksMjguNjgsMzguNjIsNS4yNiw0LjI3LDMzLjczLDI0LjYxLDk2LjM4LDI1LjIzdjUwLjM3SDE2MS4zN2EzMy4yMiwzMy4yMiwwLDEsMCwwLDEzLjM3aDI4LjkxQTYuNjgsNi42OCwwLDAsMCwxOTcsMzcxLjlWMzE0LjcyaC4yOGMuMjQsMCwuNDQtLjEzLjY3LS4xNmE1MSw1MSwwLDAsMCw2LjM0LjcyYzIyLjU0LDAsMzYuMjYtNi44Miw0NC43LTE2Ljg2VjM5OS4yM2EzMy4yMiwzMy4yMiwwLDEsMCwxMy4zOC0uMTVWMjk3LjQ3YzguMzYsMTAuNTUsMjIuMTksMTcuODEsNDUuNDEsMTcuODFhNTEuMyw1MS4zLDAsMCwwLDYuMzYtLjcyYy4yMywwLC40My4xNS42Ny4xNkgzMTVWMzcxLjlhNi42OCw2LjY4LDAsMCwwLDYuNjksNi42OGgyOC45YTMzLjIyLDMzLjIyLDAsMSwwLDAtMTMuMzdIMzI4LjQxVjMxNC44NGM2Mi42MS0uNjIsOTEuMDgtMjAuOTQsOTYuMzctMjUuMjIsMTQuODUtNi40MiwyNS40LTIwLjQzLDI4LjY4LTM4LjYzQzQ1OC4zLDIyNC4yMSw0NDAuMTcsMjA0LjY3LDQzMC40MiwxOTYuMzJaTTEyOC44MywzOTEuNzRhMTkuODUsMTkuODUsMCwxLDEsMTkuODQtMTkuODRBMTkuODcsMTkuODcsMCwwLDEsMTI4LjgzLDM5MS43NFptMjU0LjMzLTM5LjY5YTE5Ljg1LDE5Ljg1LDAsMSwxLTE5Ljg0LDE5Ljg1QTE5Ljg2LDE5Ljg2LDAsMCwxLDM4My4xNiwzNTIuMDVabTE0LjE4LTI1MS41OWMtMTUuMzItMy40Mi0zMS41OC0uNS00NC4wOSw0LC4yOS0xMC43OS0xLjI5LTI2Ljc5LTExLTM5LjI4LS41Mi0uNjctMS4yMS0xLjE1LTEuNzYtMS43OCwxMC43Ny44OCwyMy44LDMuNTIsMzMuODQsMTAuNTJDMzg3LjYxLDgzLjIxLDM5NC4wOCw5My4xMSwzOTcuMzQsMTAwLjQ2Wk0xMzcuNjksNzMuOTRjMTAtNywyMy05LjYsMzMuODItMTAuNDktLjU1LjYyLTEuMjMsMS4wOS0xLjc0LDEuNzYtOS43MiwxMi40OS0xMS4zLDI4LjQ4LTExLDM5LjI3LTEyLjUtNC41Mi0yOC43Ny03LjQzLTQ0LjExLTRDMTE3LjkxLDkzLjEyLDEyNC4zOCw4My4yMiwxMzcuNjksNzMuOTRabTY2LjU2LDIyOGMtMTEuOTIsMC0yMC4yNC00LjQ1LTIzLjQyLTEyLjUzLTMuMDgtNy44My0uNzktMTgsNS4zMy0yMy43MSw1LjQxLTUsMTIuNjEtNS42MSwyMC44LTEuNjhhNi42OSw2LjY5LDAsMCwwLDUuOC0xMi4wNiwzNy4zNSwzNy4zNSwwLDAsMC0xMy40Mi0zLjQ2LDM2LjUxLDM2LjUxLDAsMCwwLDQuMTItMTEuNDEsNi42OCw2LjY4LDAsMSwwLTEzLjIyLTJjLTEuMDksNy4xOS05LDE2LjcyLTExLjkyLDE5Ljc5LS4wNi4wNy0uMDguMTYtLjE1LjI0LS4zNS4zLS43OC40NC0xLjEzLjc2LTEwLjA4LDkuMzctMTMuNzEsMjUuNTItOC42NiwzOC40YTMxLDMxLDAsMCwwLDQuMTIsNi44N2MtMjMuNjUtMS4yOC00MS4yOS01LjU5LTUzLjY5LTEwLjFhNDMsNDMsMCwwLDAsMTguNzEtMTIuMzgsNi42OCw2LjY4LDAsMCwwLTEwLTguODQsMjkuOTQsMjkuOTQsMCwwLDEtMzAuODMsOWMtMTIuODctMy41OC0yMi4xOS0xNC44OS0yNS0zMC4yNC0zLjY2LTIwLjMsMTEuMzgtMzUuOTQsMTguOTItNDIuMzYsMy45MywzLjQyLDEwLDguMDcsMTYuNzUsMTAuNjZhNi44NSw2Ljg1LDAsMCwwLDIuNDEuNDUsNi42OSw2LjY5LDAsMCwwLDIuNC0xMi45M0MxMDMuODMsMjAxLjIyLDk2LDE5Myw5NS45LDE5Mi44OHMtLjA4LDAtLjExLS4wOGEuNDcuNDcsMCwwLDAtLjA2LS4wOWMtMS0xLTI1LjEtMjUuNzktMi44My02MS40MywyMS45Mi0zNS4wOCw2OC41Mi0xMS4yMyw3MC41MS0xMC4yYTYuNjksNi42OSwwLDAsMCw5LjY2LTcuMjVjMC0uMjUtNC44Ni0yNC44NSw3LjI1LTQwLjQyLDYuMTMtNy44NywxNS44Ny0xMi4xOCwyOS0xMi44MywxMi42NC0uNywyMi42NSwyLjY0LDI5LjI4LDkuNzRDMjQ3LDc5LjM4LDI0OSw5MywyNDkuMjUsMTAyLjE3YTYuODgsNi44OCwwLDAsMC0uMywxLjVjMCwxMi4xMi0zLjM4LDIwLjQ3LTkuNzcsMjQuMTUtNS43MiwzLjMyLTEzLjMxLDIuNDktMTcuNTQsMC02LjU3LTMuOC0xMC4zMi03Ljg0LTEwLjg0LTExLjY3LS41NS00LjExLDIuNzEtNy41OSwyLjg4LTcuNzZhNi42OSw2LjY5LDAsMCwwLTkuMzYtOS41NmMtLjg0LjgyLTguMTEsOC4yMy02LjgxLDE4Ljg3LDEsOC4yOSw2Ljg5LDE1LjU5LDE3LjQzLDIxLjY5YTMyLDMyLDAsMCwwLDE1LjY1LDMuOTQsMzAuNDYsMzAuNDYsMCwwLDAsMTUuMjgtNCwyNy44MiwyNy44MiwwLDAsMCwzLjA4LTIuMDh2NjMuMWE1My43NCw1My43NCwwLDAsMC00LjcxLTQuNzJjLTE0LjItMTIuMjUtMzQuNjYtMTcuNDQtNjEtMTUuNGE1Mi40OSw1Mi40OSwwLDAsMC0yMy41OCw3LjI5LDYuNzEsNi43MSwwLDAsMC0xLjEtLjIzYy0uMTcsMC0xNi41Ni0uNDEtMjYuOC0xNy40My01LjQyLTksLjMtMjIsLjM1LTIyLjE0QTYuNjksNi42OSwwLDAsMCwxMjAsMTQyLjI2Yy0uMzUuNzktOC43MywxOS41MS4zNSwzNC41OGE0OC4zNyw0OC4zNywwLDAsMCwyNywyMS43MWMtMTEuMTEsMTQtMTQsMzIuNzctMTMuMzUsNDQuODlhNi42OSw2LjY5LDAsMCwwLDYuNjcsNi4zMUgxNDFhNi42OCw2LjY4LDAsMCwwLDYuMzEtNy4wNWMtLjExLTEuODctMi4xLTQ2LDM3LTQ5LjA1QzI0NC4yMiwxODksMjQ4Ljc0LDIyNy45MiwyNDksMjMwLjN2MTAuMTVDMjQ5LDI3Ny41NywyNDUuODQsMzAxLjkxLDIwNC4yNSwzMDEuOTFabTcxLjYsMTI5Ljc0QTE5Ljg1LDE5Ljg1LDAsMSwxLDI1Niw0MTEuODEsMTkuODcsMTkuODcsMCwwLDEsMjc1Ljg1LDQzMS42NVptMTY0LjQ1LTE4M2MtMi43NiwxNS4zNC0xMi4wOSwyNi42NC0yNC45NSwzMC4yM2EzMCwzMCwwLDAsMS0zMC44NC05LDYuNjgsNi42OCwwLDAsMC0xMCw4Ljg0QTQzLjE3LDQzLjE3LDAsMCwwLDM5My4xNiwyOTFjLTEyLjQxLDQuNS0zMC4wNSw4LjgxLTUzLjY2LDEwLjA5YTMwLjY3LDMwLjY3LDAsMCwwLDQuMTEtNi44NmM1LjA2LTEyLjg4LDEuNDMtMjktOC42Ni0zOC40LS4zNC0uMzItLjc3LS40Ni0xLjEyLS43Ni0uMDctLjA4LS4wOS0uMTctLjE2LS4yNC0yLjk1LTMuMDctMTAuODMtMTIuNi0xMS45MS0xOS43OWE2Ljc5LDYuNzksMCwwLDAtNy42LTUuNjMsNi42OSw2LjY5LDAsMCwwLTUuNjIsNy42MSwzNi40OSwzNi40OSwwLDAsMCw0LjExLDExLjQxLDM3LjEsMzcuMSwwLDAsMC0xMy40MSwzLjQ2QTYuNjksNi42OSwwLDAsMCwzMDUsMjY0YzguMTgtMy45MywxNS4zOS0zLjM2LDIwLjc5LDEuNjgsNi4xMyw1LjY4LDguNDIsMTUuODgsNS4zMywyMy43MS0zLjE3LDguMDgtMTEuNDksMTIuNTMtMjMuNDIsMTIuNTMtNDEuNTcsMC00NC42OC0yNC4zNC00NC42OC02MS40NnYtMTAuMWE0MC4xLDQwLjEsMCwwLDEsMTMuNDctMjQuNTJjMTEuNC05Ljg0LDI4LjU3LTEzLjkzLDUxLjE0LTEyLjE5LDM4LjkzLDMsMzcuMSw0Ny4xOSwzNyw0OS4wN2E2LjY4LDYuNjgsMCwwLDAsNi4zMiw3bC4zNywwYTYuNjgsNi42OCwwLDAsMCw2LjY2LTYuMzFjLjY3LTEyLjEyLTIuMjQtMzAuOTEtMTMuMzYtNDQuODlhNDguMzUsNDguMzUsMCwwLDAsMjctMjEuNzFjOS4wOC0xNS4wNy43LTMzLjc5LjM1LTM0LjU4YTYuNjksNi42OSwwLDAsMC0xMi4xNyw1LjU2Yy4wNi4xMyw1Ljc2LDEzLjE3LjM2LDIyLjEyLTEwLjEyLDE2Ljc3LTI2LjE3LDE3LjQxLTI2LjgxLDE3LjQzYTUuNzYsNS43NiwwLDAsMC0xLjExLjI0LDUyLjM2LDUyLjM2LDAsMCwwLTIzLjU4LTcuM2MtMjYuMjgtMi4wNS00Ni43NCwzLjE1LTYwLjk0LDE1LjRhNTIuNzYsNTIuNzYsMCwwLDAtNC43Myw0LjczbDAtNjMuMTRhMzAuMSwzMC4xLDAsMCwwLDMuMTIsMi4xMSwzMC40NiwzMC40NiwwLDAsMCwxNS4yOCw0LDMyLjA4LDMyLjA4LDAsMCwwLDE1LjY2LTMuOTRjMTAuNTMtNi4xLDE2LjM4LTEzLjQsMTcuNDItMjEuNjksMS4zLTEwLjY0LTYtMTgtNi44MS0xOC44N2E2LjY5LDYuNjksMCwwLDAtOS4zMyw5LjZzMy4zNiwzLjU0LDIuODUsNy42M2MtLjQ3LDMuODYtNC4yMiw3LjkyLTEwLjgzLDExLjc2LTQuMjUsMi40NS0xMS44MywzLjI3LTE3LjU1LDAtNi4zOS0zLjY4LTkuNzctMTItOS43Ny0yNC4xNWE2LjQ0LDYuNDQsMCwwLDAtLjMyLTEuNTdjLjI4LTksMi4yMy0yMi42NywxMC43LTMxLjc3LDYuNi03LjExLDE2LjYtMTAuNDUsMjkuMjctOS43NSwxMy4wOC42NCwyMi44MSw1LDI4LjkyLDEyLjc4LDEyLjA5LDE1LjQ3LDcuMzYsNDAuMjMsNy4zMSw0MC40OGE2LjcsNi43LDAsMCwwLDkuNjYsNy4yNGMyLTEsNDguNTctMjQuOTIsNzAuNTEsMTAuMiwyMi4yNiwzNS42NC0xLjgsNjAuMzktMi44Miw2MS40LDAsMCwwLC4wOS0uMDguMTJzLS4wNywwLS4xLjA4Yy0yLjE3LDIuMzEtOS4zLDguODYtMTYuMjgsMTEuNTVhNi42OSw2LjY5LDAsMCwwLDIuNCwxMi45Myw2Ljg1LDYuODUsMCwwLDAsMi40MS0uNDVjNi43Mi0yLjU5LDEyLjgyLTcuMjQsMTYuNzQtMTAuNjZDNDI4LjkyLDIxMi42Nyw0NDQsMjI4LjMxLDQ0MC4zLDI0OC42MloiLz48L3N2Zz4="
+    camel.apache.org/provider: "Apache Software Foundation"
+    camel.apache.org/kamelet.group: "AWS Bedrock"
+    camel.apache.org/kamelet.namespace: "AWS"
+  labels:
+    camel.apache.org/kamelet.type: "sink"
+spec:
+  definition:
+    title: "AWS Bedrock Agent Sink"
+    description: |-
+      Manage the data source ingestion jobs of an AWS Bedrock knowledge base.
+
+      Use startIngestionJob to kick off an ingestion of the configured data source, listIngestionJobs to list the jobs of a knowledge base, or getIngestionJob to look one up. For getIngestionJob the job id is taken from the CamelAwsBedrockAgentIngestionJobId header.
+    required:
+      - knowledgeBaseId
+      - region
+    type: object
+    properties:
+      knowledgeBaseId:
+        title: Knowledge Base Id
+        description: The Knowledge Base the ingestion job belongs to.
+        type: string
+      dataSourceId:
+        title: Data Source Id
+        description: The data source to ingest. Required by the startIngestionJob operation.
+        type: string
+      operation:
+        title: Operation
+        description: The ingestion job operation to perform.
+        type: string
+        default: startIngestionJob
+        enum: ["startIngestionJob", "listIngestionJobs", "getIngestionJob"]
+      accessKey:
+        title: Access Key
+        description: The access key obtained from AWS.
+        type: string
+        format: password
+        x-descriptors:
+        - urn:camel:group:credentials
+      secretKey:
+        title: Secret Key
+        description: The secret key obtained from AWS.
+        type: string
+        format: password
+        x-descriptors:
+        - urn:camel:group:credentials
+      region:
+        title: AWS Region
+        description: The AWS region to access.
+        type: string
+        enum: ["us-east-1", "us-east-2", "us-west-2", "us-gov-west-1", "ap-northeast-1", "ap-northeast-2", "ap-south-1", "ap-southeast-1", "ap-southeast-2", "ca-central-1", "eu-central-1", "eu-central-2", "eu-west-1", "eu-west-2", "eu-west-3", "sa-east-1"]
+      useDefaultCredentialsProvider:
+        title: Default Credentials Provider
+        description: If true, the SDK looks for credentials through the default provider chain rather than the accessKey and secretKey properties.
+        type: boolean
+        default: false
+      useProfileCredentialsProvider:
+        title: Profile Credentials Provider
+        description: Set whether the Bedrock client should expect to load credentials through a profile credentials provider.
+        type: boolean
+        default: false
+      useSessionCredentials:
+        title: Session Credentials
+        description: Set whether the Bedrock client should expect to use session credentials. This is useful in a session token scenario.
+        type: boolean
+        default: false
+      sessionToken:
+        title: Session Token
+        description: Amazon AWS Session Token used when the user needs to assume an IAM role.
+        type: string
+        format: password
+        x-descriptors:
+        - urn:camel:group:credentials
+      profileCredentialsName:
+        title: Profile Credentials Name
+        description: If using a profile credentials provider, this parameter states the profile name.
+        type: string
+      uriEndpointOverride:
+        title: Overwrite Endpoint URI
+        description: The overriding endpoint URI. To use this option, you must also select the `overrideEndpoint` option.
+        type: string
+      overrideEndpoint:
+        title: Endpoint Overwrite
+        description: Select this option to override the endpoint URI. To use this option, you must also provide a URI for the `uriEndpointOverride` option.
+        type: boolean
+        default: false
+  dependencies:
+    - "camel:core"
+    - "camel:aws-bedrock"
+    - "camel:kamelet"
+  template:
+    from:
+      uri: "kamelet:source"
+      steps:
+      # Strip the camel-aws-bedrock-agent header family up-front, before the
+      # endpoint below is reached: the operation, knowledge base and data source
+      # are all pinned by the properties above, and every one of them is
+      # overridable by an inbound CamelAwsBedrockAgent* header. The ingestion job
+      # id is the one input this Kamelet deliberately takes from the message, so
+      # it is excluded. A pattern also covers keys the component may add later.
+      - removeHeaders:
+          pattern: "CamelAwsBedrockAgent*"
+          excludePattern: "CamelAwsBedrockAgentIngestionJobId"
+      - to:
+          uri: "aws-bedrock-agent:bedrock-agent"
+          parameters:
+            secretKey: "{{?secretKey}}"
+            accessKey: "{{?accessKey}}"
+            region: "{{region}}"
+            operation: "{{operation}}"
+            knowledgeBaseId: "{{knowledgeBaseId}}"
+            dataSourceId: "{{?dataSourceId}}"
+            useDefaultCredentialsProvider: "{{useDefaultCredentialsProvider}}"
+            useProfileCredentialsProvider: "{{useProfileCredentialsProvider}}"
+            useSessionCredentials: "{{useSessionCredentials}}"
+            uriEndpointOverride: "{{?uriEndpointOverride}}"
+            profileCredentialsName: "{{?profileCredentialsName}}"
+            sessionToken: "{{?sessionToken}}"
+            overrideEndpoint: "{{overrideEndpoint}}"

--- a/library/camel-kamelets-catalog/src/test/java/org/apache/camel/kamelets/catalog/KameletsCatalogTest.java
+++ b/library/camel-kamelets-catalog/src/test/java/org/apache/camel/kamelets/catalog/KameletsCatalogTest.java
@@ -121,7 +121,7 @@ public class KameletsCatalogTest {
     void testGetKameletsByNamespace() throws Exception {
         List<Kamelet> c = catalog.getKameletsByNamespace("AWS");
         assertFalse(c.isEmpty());
-        assertEquals(31, c.size());
+        assertEquals(32, c.size());
         c = catalog.getKameletsByGroups("Not-existing-group");
         assertTrue(c.isEmpty());
     }

--- a/library/camel-kamelets/src/main/resources/kamelets/aws-bedrock-agent-sink.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/aws-bedrock-agent-sink.kamelet.yaml
@@ -1,0 +1,142 @@
+# ---------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ---------------------------------------------------------------------------
+apiVersion: camel.apache.org/v1
+kind: Kamelet
+metadata:
+  name: aws-bedrock-agent-sink
+  annotations:
+    camel.apache.org/kamelet.support.level: "Preview"
+    camel.apache.org/catalog.version: "4.22.1-SNAPSHOT"
+    camel.apache.org/kamelet.icon: "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiA/PjxzdmcgZGF0YS1uYW1lPSJMYXllciAxIiBpZD0iTGF5ZXJfMSIgdmlld0JveD0iMCAwIDUxMiA1MTIiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PHBhdGggZD0iTTQzMC40MiwxOTYuMzJjOC0xMS4zOSwyMS4xNS0zOC4zMywwLTcyLjEzYTUyLjc5LDUyLjc5LDAsMCwwLTE3LjA2LTE3LjMxYy0xLjUzLTgtNy41NC0yNy4yNi0zMS40Mi00My45MUMzNTksNDcsMzI1LjUyLDQ5LjUzLDMxOS40NCw1MC4xNmE2NC4yNyw2NC4yNywwLDAsMC0xNi4wNy0yLjk0Yy0xNy4xNy0uODEtMzAuMzcsMy44OS0zOS43OCwxNC4wNUE0Ni4zLDQ2LjMsMCwwLDAsMjU2LDcyLjg5YTQ2LjA2LDQ2LjA2LDAsMCwwLTcuNi0xMS42MmMtOS40LTEwLjE2LTIyLjg2LTE0Ljg2LTM5Ljc2LTE0LjA1YTY0LjczLDY0LjczLDAsMCwwLTE2LjA3LDIuOTRDMTg2LjUyLDQ5LjUzLDE1Myw0NywxMzAsNjNjLTIzLjksMTYuNjYtMjkuOTEsMzYtMzEuNDMsNDMuOTJhNTIuOSw1Mi45LDAsMCwwLTE3LDE3LjNjLTIxLjEzLDMzLjgtNy45NCw2MC43NCwwLDcyLjE0LTkuNzUsOC4zNC0yNy44OCwyNy44OC0yMy4wNiw1NC42NiwzLjI4LDE4LjIsMTMuODQsMzIuMTksMjguNjgsMzguNjIsNS4yNiw0LjI3LDMzLjczLDI0LjYxLDk2LjM4LDI1LjIzdjUwLjM3SDE2MS4zN2EzMy4yMiwzMy4yMiwwLDEsMCwwLDEzLjM3aDI4LjkxQTYuNjgsNi42OCwwLDAsMCwxOTcsMzcxLjlWMzE0LjcyaC4yOGMuMjQsMCwuNDQtLjEzLjY3LS4xNmE1MSw1MSwwLDAsMCw2LjM0LjcyYzIyLjU0LDAsMzYuMjYtNi44Miw0NC43LTE2Ljg2VjM5OS4yM2EzMy4yMiwzMy4yMiwwLDEsMCwxMy4zOC0uMTVWMjk3LjQ3YzguMzYsMTAuNTUsMjIuMTksMTcuODEsNDUuNDEsMTcuODFhNTEuMyw1MS4zLDAsMCwwLDYuMzYtLjcyYy4yMywwLC40My4xNS42Ny4xNkgzMTVWMzcxLjlhNi42OCw2LjY4LDAsMCwwLDYuNjksNi42OGgyOC45YTMzLjIyLDMzLjIyLDAsMSwwLDAtMTMuMzdIMzI4LjQxVjMxNC44NGM2Mi42MS0uNjIsOTEuMDgtMjAuOTQsOTYuMzctMjUuMjIsMTQuODUtNi40MiwyNS40LTIwLjQzLDI4LjY4LTM4LjYzQzQ1OC4zLDIyNC4yMSw0NDAuMTcsMjA0LjY3LDQzMC40MiwxOTYuMzJaTTEyOC44MywzOTEuNzRhMTkuODUsMTkuODUsMCwxLDEsMTkuODQtMTkuODRBMTkuODcsMTkuODcsMCwwLDEsMTI4LjgzLDM5MS43NFptMjU0LjMzLTM5LjY5YTE5Ljg1LDE5Ljg1LDAsMSwxLTE5Ljg0LDE5Ljg1QTE5Ljg2LDE5Ljg2LDAsMCwxLDM4My4xNiwzNTIuMDVabTE0LjE4LTI1MS41OWMtMTUuMzItMy40Mi0zMS41OC0uNS00NC4wOSw0LC4yOS0xMC43OS0xLjI5LTI2Ljc5LTExLTM5LjI4LS41Mi0uNjctMS4yMS0xLjE1LTEuNzYtMS43OCwxMC43Ny44OCwyMy44LDMuNTIsMzMuODQsMTAuNTJDMzg3LjYxLDgzLjIxLDM5NC4wOCw5My4xMSwzOTcuMzQsMTAwLjQ2Wk0xMzcuNjksNzMuOTRjMTAtNywyMy05LjYsMzMuODItMTAuNDktLjU1LjYyLTEuMjMsMS4wOS0xLjc0LDEuNzYtOS43MiwxMi40OS0xMS4zLDI4LjQ4LTExLDM5LjI3LTEyLjUtNC41Mi0yOC43Ny03LjQzLTQ0LjExLTRDMTE3LjkxLDkzLjEyLDEyNC4zOCw4My4yMiwxMzcuNjksNzMuOTRabTY2LjU2LDIyOGMtMTEuOTIsMC0yMC4yNC00LjQ1LTIzLjQyLTEyLjUzLTMuMDgtNy44My0uNzktMTgsNS4zMy0yMy43MSw1LjQxLTUsMTIuNjEtNS42MSwyMC44LTEuNjhhNi42OSw2LjY5LDAsMCwwLDUuOC0xMi4wNiwzNy4zNSwzNy4zNSwwLDAsMC0xMy40Mi0zLjQ2LDM2LjUxLDM2LjUxLDAsMCwwLDQuMTItMTEuNDEsNi42OCw2LjY4LDAsMSwwLTEzLjIyLTJjLTEuMDksNy4xOS05LDE2LjcyLTExLjkyLDE5Ljc5LS4wNi4wNy0uMDguMTYtLjE1LjI0LS4zNS4zLS43OC40NC0xLjEzLjc2LTEwLjA4LDkuMzctMTMuNzEsMjUuNTItOC42NiwzOC40YTMxLDMxLDAsMCwwLDQuMTIsNi44N2MtMjMuNjUtMS4yOC00MS4yOS01LjU5LTUzLjY5LTEwLjFhNDMsNDMsMCwwLDAsMTguNzEtMTIuMzgsNi42OCw2LjY4LDAsMCwwLTEwLTguODQsMjkuOTQsMjkuOTQsMCwwLDEtMzAuODMsOWMtMTIuODctMy41OC0yMi4xOS0xNC44OS0yNS0zMC4yNC0zLjY2LTIwLjMsMTEuMzgtMzUuOTQsMTguOTItNDIuMzYsMy45MywzLjQyLDEwLDguMDcsMTYuNzUsMTAuNjZhNi44NSw2Ljg1LDAsMCwwLDIuNDEuNDUsNi42OSw2LjY5LDAsMCwwLDIuNC0xMi45M0MxMDMuODMsMjAxLjIyLDk2LDE5Myw5NS45LDE5Mi44OHMtLjA4LDAtLjExLS4wOGEuNDcuNDcsMCwwLDAtLjA2LS4wOWMtMS0xLTI1LjEtMjUuNzktMi44My02MS40MywyMS45Mi0zNS4wOCw2OC41Mi0xMS4yMyw3MC41MS0xMC4yYTYuNjksNi42OSwwLDAsMCw5LjY2LTcuMjVjMC0uMjUtNC44Ni0yNC44NSw3LjI1LTQwLjQyLDYuMTMtNy44NywxNS44Ny0xMi4xOCwyOS0xMi44MywxMi42NC0uNywyMi42NSwyLjY0LDI5LjI4LDkuNzRDMjQ3LDc5LjM4LDI0OSw5MywyNDkuMjUsMTAyLjE3YTYuODgsNi44OCwwLDAsMC0uMywxLjVjMCwxMi4xMi0zLjM4LDIwLjQ3LTkuNzcsMjQuMTUtNS43MiwzLjMyLTEzLjMxLDIuNDktMTcuNTQsMC02LjU3LTMuOC0xMC4zMi03Ljg0LTEwLjg0LTExLjY3LS41NS00LjExLDIuNzEtNy41OSwyLjg4LTcuNzZhNi42OSw2LjY5LDAsMCwwLTkuMzYtOS41NmMtLjg0LjgyLTguMTEsOC4yMy02LjgxLDE4Ljg3LDEsOC4yOSw2Ljg5LDE1LjU5LDE3LjQzLDIxLjY5YTMyLDMyLDAsMCwwLDE1LjY1LDMuOTQsMzAuNDYsMzAuNDYsMCwwLDAsMTUuMjgtNCwyNy44MiwyNy44MiwwLDAsMCwzLjA4LTIuMDh2NjMuMWE1My43NCw1My43NCwwLDAsMC00LjcxLTQuNzJjLTE0LjItMTIuMjUtMzQuNjYtMTcuNDQtNjEtMTUuNGE1Mi40OSw1Mi40OSwwLDAsMC0yMy41OCw3LjI5LDYuNzEsNi43MSwwLDAsMC0xLjEtLjIzYy0uMTcsMC0xNi41Ni0uNDEtMjYuOC0xNy40My01LjQyLTksLjMtMjIsLjM1LTIyLjE0QTYuNjksNi42OSwwLDAsMCwxMjAsMTQyLjI2Yy0uMzUuNzktOC43MywxOS41MS4zNSwzNC41OGE0OC4zNyw0OC4zNywwLDAsMCwyNywyMS43MWMtMTEuMTEsMTQtMTQsMzIuNzctMTMuMzUsNDQuODlhNi42OSw2LjY5LDAsMCwwLDYuNjcsNi4zMUgxNDFhNi42OCw2LjY4LDAsMCwwLDYuMzEtNy4wNWMtLjExLTEuODctMi4xLTQ2LDM3LTQ5LjA1QzI0NC4yMiwxODksMjQ4Ljc0LDIyNy45MiwyNDksMjMwLjN2MTAuMTVDMjQ5LDI3Ny41NywyNDUuODQsMzAxLjkxLDIwNC4yNSwzMDEuOTFabTcxLjYsMTI5Ljc0QTE5Ljg1LDE5Ljg1LDAsMSwxLDI1Niw0MTEuODEsMTkuODcsMTkuODcsMCwwLDEsMjc1Ljg1LDQzMS42NVptMTY0LjQ1LTE4M2MtMi43NiwxNS4zNC0xMi4wOSwyNi42NC0yNC45NSwzMC4yM2EzMCwzMCwwLDAsMS0zMC44NC05LDYuNjgsNi42OCwwLDAsMC0xMCw4Ljg0QTQzLjE3LDQzLjE3LDAsMCwwLDM5My4xNiwyOTFjLTEyLjQxLDQuNS0zMC4wNSw4LjgxLTUzLjY2LDEwLjA5YTMwLjY3LDMwLjY3LDAsMCwwLDQuMTEtNi44NmM1LjA2LTEyLjg4LDEuNDMtMjktOC42Ni0zOC40LS4zNC0uMzItLjc3LS40Ni0xLjEyLS43Ni0uMDctLjA4LS4wOS0uMTctLjE2LS4yNC0yLjk1LTMuMDctMTAuODMtMTIuNi0xMS45MS0xOS43OWE2Ljc5LDYuNzksMCwwLDAtNy42LTUuNjMsNi42OSw2LjY5LDAsMCwwLTUuNjIsNy42MSwzNi40OSwzNi40OSwwLDAsMCw0LjExLDExLjQxLDM3LjEsMzcuMSwwLDAsMC0xMy40MSwzLjQ2QTYuNjksNi42OSwwLDAsMCwzMDUsMjY0YzguMTgtMy45MywxNS4zOS0zLjM2LDIwLjc5LDEuNjgsNi4xMyw1LjY4LDguNDIsMTUuODgsNS4zMywyMy43MS0zLjE3LDguMDgtMTEuNDksMTIuNTMtMjMuNDIsMTIuNTMtNDEuNTcsMC00NC42OC0yNC4zNC00NC42OC02MS40NnYtMTAuMWE0MC4xLDQwLjEsMCwwLDEsMTMuNDctMjQuNTJjMTEuNC05Ljg0LDI4LjU3LTEzLjkzLDUxLjE0LTEyLjE5LDM4LjkzLDMsMzcuMSw0Ny4xOSwzNyw0OS4wN2E2LjY4LDYuNjgsMCwwLDAsNi4zMiw3bC4zNywwYTYuNjgsNi42OCwwLDAsMCw2LjY2LTYuMzFjLjY3LTEyLjEyLTIuMjQtMzAuOTEtMTMuMzYtNDQuODlhNDguMzUsNDguMzUsMCwwLDAsMjctMjEuNzFjOS4wOC0xNS4wNy43LTMzLjc5LjM1LTM0LjU4YTYuNjksNi42OSwwLDAsMC0xMi4xNyw1LjU2Yy4wNi4xMyw1Ljc2LDEzLjE3LjM2LDIyLjEyLTEwLjEyLDE2Ljc3LTI2LjE3LDE3LjQxLTI2LjgxLDE3LjQzYTUuNzYsNS43NiwwLDAsMC0xLjExLjI0LDUyLjM2LDUyLjM2LDAsMCwwLTIzLjU4LTcuM2MtMjYuMjgtMi4wNS00Ni43NCwzLjE1LTYwLjk0LDE1LjRhNTIuNzYsNTIuNzYsMCwwLDAtNC43Myw0LjczbDAtNjMuMTRhMzAuMSwzMC4xLDAsMCwwLDMuMTIsMi4xMSwzMC40NiwzMC40NiwwLDAsMCwxNS4yOCw0LDMyLjA4LDMyLjA4LDAsMCwwLDE1LjY2LTMuOTRjMTAuNTMtNi4xLDE2LjM4LTEzLjQsMTcuNDItMjEuNjksMS4zLTEwLjY0LTYtMTgtNi44MS0xOC44N2E2LjY5LDYuNjksMCwwLDAtOS4zMyw5LjZzMy4zNiwzLjU0LDIuODUsNy42M2MtLjQ3LDMuODYtNC4yMiw3LjkyLTEwLjgzLDExLjc2LTQuMjUsMi40NS0xMS44MywzLjI3LTE3LjU1LDAtNi4zOS0zLjY4LTkuNzctMTItOS43Ny0yNC4xNWE2LjQ0LDYuNDQsMCwwLDAtLjMyLTEuNTdjLjI4LTksMi4yMy0yMi42NywxMC43LTMxLjc3LDYuNi03LjExLDE2LjYtMTAuNDUsMjkuMjctOS43NSwxMy4wOC42NCwyMi44MSw1LDI4LjkyLDEyLjc4LDEyLjA5LDE1LjQ3LDcuMzYsNDAuMjMsNy4zMSw0MC40OGE2LjcsNi43LDAsMCwwLDkuNjYsNy4yNGMyLTEsNDguNTctMjQuOTIsNzAuNTEsMTAuMiwyMi4yNiwzNS42NC0xLjgsNjAuMzktMi44Miw2MS40LDAsMCwwLC4wOS0uMDguMTJzLS4wNywwLS4xLjA4Yy0yLjE3LDIuMzEtOS4zLDguODYtMTYuMjgsMTEuNTVhNi42OSw2LjY5LDAsMCwwLDIuNCwxMi45Myw2Ljg1LDYuODUsMCwwLDAsMi40MS0uNDVjNi43Mi0yLjU5LDEyLjgyLTcuMjQsMTYuNzQtMTAuNjZDNDI4LjkyLDIxMi42Nyw0NDQsMjI4LjMxLDQ0MC4zLDI0OC42MloiLz48L3N2Zz4="
+    camel.apache.org/provider: "Apache Software Foundation"
+    camel.apache.org/kamelet.group: "AWS Bedrock"
+    camel.apache.org/kamelet.namespace: "AWS"
+  labels:
+    camel.apache.org/kamelet.type: "sink"
+spec:
+  definition:
+    title: "AWS Bedrock Agent Sink"
+    description: |-
+      Manage the data source ingestion jobs of an AWS Bedrock knowledge base.
+
+      Use startIngestionJob to kick off an ingestion of the configured data source, listIngestionJobs to list the jobs of a knowledge base, or getIngestionJob to look one up. For getIngestionJob the job id is taken from the CamelAwsBedrockAgentIngestionJobId header.
+    required:
+      - knowledgeBaseId
+      - region
+    type: object
+    properties:
+      knowledgeBaseId:
+        title: Knowledge Base Id
+        description: The Knowledge Base the ingestion job belongs to.
+        type: string
+      dataSourceId:
+        title: Data Source Id
+        description: The data source to ingest. Required by the startIngestionJob operation.
+        type: string
+      operation:
+        title: Operation
+        description: The ingestion job operation to perform.
+        type: string
+        default: startIngestionJob
+        enum: ["startIngestionJob", "listIngestionJobs", "getIngestionJob"]
+      accessKey:
+        title: Access Key
+        description: The access key obtained from AWS.
+        type: string
+        format: password
+        x-descriptors:
+        - urn:camel:group:credentials
+      secretKey:
+        title: Secret Key
+        description: The secret key obtained from AWS.
+        type: string
+        format: password
+        x-descriptors:
+        - urn:camel:group:credentials
+      region:
+        title: AWS Region
+        description: The AWS region to access.
+        type: string
+        enum: ["us-east-1", "us-east-2", "us-west-2", "us-gov-west-1", "ap-northeast-1", "ap-northeast-2", "ap-south-1", "ap-southeast-1", "ap-southeast-2", "ca-central-1", "eu-central-1", "eu-central-2", "eu-west-1", "eu-west-2", "eu-west-3", "sa-east-1"]
+      useDefaultCredentialsProvider:
+        title: Default Credentials Provider
+        description: If true, the SDK looks for credentials through the default provider chain rather than the accessKey and secretKey properties.
+        type: boolean
+        default: false
+      useProfileCredentialsProvider:
+        title: Profile Credentials Provider
+        description: Set whether the Bedrock client should expect to load credentials through a profile credentials provider.
+        type: boolean
+        default: false
+      useSessionCredentials:
+        title: Session Credentials
+        description: Set whether the Bedrock client should expect to use session credentials. This is useful in a session token scenario.
+        type: boolean
+        default: false
+      sessionToken:
+        title: Session Token
+        description: Amazon AWS Session Token used when the user needs to assume an IAM role.
+        type: string
+        format: password
+        x-descriptors:
+        - urn:camel:group:credentials
+      profileCredentialsName:
+        title: Profile Credentials Name
+        description: If using a profile credentials provider, this parameter states the profile name.
+        type: string
+      uriEndpointOverride:
+        title: Overwrite Endpoint URI
+        description: The overriding endpoint URI. To use this option, you must also select the `overrideEndpoint` option.
+        type: string
+      overrideEndpoint:
+        title: Endpoint Overwrite
+        description: Select this option to override the endpoint URI. To use this option, you must also provide a URI for the `uriEndpointOverride` option.
+        type: boolean
+        default: false
+  dependencies:
+    - "camel:core"
+    - "camel:aws-bedrock"
+    - "camel:kamelet"
+  template:
+    from:
+      uri: "kamelet:source"
+      steps:
+      # Strip the camel-aws-bedrock-agent header family up-front, before the
+      # endpoint below is reached: the operation, knowledge base and data source
+      # are all pinned by the properties above, and every one of them is
+      # overridable by an inbound CamelAwsBedrockAgent* header. The ingestion job
+      # id is the one input this Kamelet deliberately takes from the message, so
+      # it is excluded. A pattern also covers keys the component may add later.
+      - removeHeaders:
+          pattern: "CamelAwsBedrockAgent*"
+          excludePattern: "CamelAwsBedrockAgentIngestionJobId"
+      - to:
+          uri: "aws-bedrock-agent:bedrock-agent"
+          parameters:
+            secretKey: "{{?secretKey}}"
+            accessKey: "{{?accessKey}}"
+            region: "{{region}}"
+            operation: "{{operation}}"
+            knowledgeBaseId: "{{knowledgeBaseId}}"
+            dataSourceId: "{{?dataSourceId}}"
+            useDefaultCredentialsProvider: "{{useDefaultCredentialsProvider}}"
+            useProfileCredentialsProvider: "{{useProfileCredentialsProvider}}"
+            useSessionCredentials: "{{useSessionCredentials}}"
+            uriEndpointOverride: "{{?uriEndpointOverride}}"
+            profileCredentialsName: "{{?profileCredentialsName}}"
+            sessionToken: "{{?sessionToken}}"
+            overrideEndpoint: "{{overrideEndpoint}}"


### PR DESCRIPTION
Fixes #1938.

The issue asks for Bedrock Agent support. Two thirds of it already shipped — this closes the remaining gap.

| Camel component | Kamelet | status |
|---|---|---|
| `aws-bedrock` | `aws-bedrock-text-sink` | already in the catalog |
| `aws-bedrock-agent-runtime` | `aws-bedrock-agent-runtime-sink` | already in the catalog |
| **`aws-bedrock-agent`** | **`aws-bedrock-agent-sink`** | **added here** |

`aws-bedrock-agent` is the knowledge-base management component. Its three operations are all about data source ingestion jobs:

```
enum=['startIngestionJob', 'listIngestionJobs', 'getIngestionJob']
```

A **sink** is the right and only shape — the component is producer-oriented, so the "and Source" half of the issue title has nothing to map onto. Say the word if you disagree and I will look again.

## Properties

`knowledgeBaseId` and `region` are required; `operation` defaults to `startIngestionJob`.

| property | notes |
|---|---|
| `knowledgeBaseId` | **required** |
| `dataSourceId` | required by `startIngestionJob` |
| `operation` | `startIngestionJob` (default) / `listIngestionJobs` / `getIngestionJob` |
| `region` | **required**, enum matching the component |
| `accessKey` / `secretKey` / `sessionToken` | `format: password` + credentials descriptor |
| the usual credentials-provider and endpoint-override options | mirroring `aws-bedrock-agent-runtime-sink` |

## The header strip, and why it is not optional here

`BedrockAgentProducer.determineOperation` reads the header before the endpoint:

```java
private BedrockAgentOperations determineOperation(Exchange exchange) {
    ... = exchange.getIn().getHeader(BedrockAgentConstants.OPERATION, BedrockAgentOperations.class);
```

and `knowledgeBaseId` / `dataSourceId` are header-overridable the same way. Without a strip, an inbound message could point a sink configured for one knowledge base at another, or turn a `startIngestionJob` into something else — the exact pattern addressed for `aws-ec2-sink` in #2978.

```yaml
      - removeHeaders:
          pattern: "CamelAwsBedrockAgent*"
          excludePattern: "CamelAwsBedrockAgentIngestionJobId"
```

`CamelAwsBedrockAgentIngestionJobId` is excluded deliberately — `getIngestionJob` has to name a job, so that one header is the Kamelet's intended message-level input rather than something it never asked for.

## Verification

`script/validator` reports no errors, `script/generator` adds the `nav.adoc` entry, `mvn clean install` passes from the repository root.

**Parameter binding** against the real component with `camel run` — the route starts with everything bound:

```
Routes startup (total:1 started:1 kamelets:1)
    Started bed-real (timer://t)
```

**The strip**, checked by swapping the terminal endpoint for a log so the surviving headers are visible. Sending every overridable header plus an unrelated one:

```
in:  CamelAwsBedrockAgentOperation=listIngestionJobs
     CamelAwsBedrockAgentKnowledgeBaseId=attacker-kb
     CamelAwsBedrockAgentDataSourceId=attacker-ds
     CamelAwsBedrockAgentIngestionJobId=job-42
     keepMe=yes

out: {CamelAwsBedrockAgentIngestionJobId=job-42, keepMe=yes}
```

The three dispatch-controlling headers are gone, the deliberate input survives, unrelated headers are untouched.

**No Citrus test** — this needs a real Bedrock knowledge base and there is no emulator for it in the project's Citrus/Testcontainers toolchain, so it ships `Preview` without `kamelet.verified=true`.

## Note

The catalog's `headers` block for `aws-bedrock-agent` lists `CamelAwsBedrockAgentRuntime*` names, but the component's own `BedrockAgentConstants` uses `CamelAwsBedrockAgent*` (`OPERATION = "CamelAwsBedrockAgentOperation"`). I went with the constants, which is what the producer actually reads and what the probe above confirms. The catalog metadata looks like it has the runtime component's headers copied into it — worth a separate look upstream, but it does not affect this Kamelet.

---
_Claude Code on behalf of Andrea Cosentino_
