### PR TITLE
Fix #542: add a Couchbase source Kamelet

### DIFF
--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -60,6 +60,7 @@
 * xref:chuck-norris-source.adoc[]
 * xref:chunk-template-action.adoc[]
 * xref:couchbase-sink.adoc[]
+* xref:couchbase-source.adoc[]
 * xref:counter-source.adoc[]
 * xref:cron-source.adoc[]
 * xref:crypto-decrypt-action.adoc[]

--- a/kamelets/couchbase-source.kamelet.yaml
+++ b/kamelets/couchbase-source.kamelet.yaml
@@ -1,0 +1,144 @@
+# ---------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ---------------------------------------------------------------------------
+apiVersion: camel.apache.org/v1
+kind: Kamelet
+metadata:
+  name: couchbase-source
+  annotations:
+    camel.apache.org/kamelet.support.level: "Preview"
+    camel.apache.org/catalog.version: "4.22.1-SNAPSHOT"
+    camel.apache.org/kamelet.icon: "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB2aWV3Qm94PSIwIDAgNjguMzQzIDY4LjM0MyIgZmlsbD0iI2ZmZiIgZmlsbC1ydWxlPSJldmVub2RkIiBzdHJva2U9IiMwMDAiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCI+PHVzZSB4bGluazpocmVmPSIjQSIgeD0iMi4xNzEiIHk9IjIuMTcxIi8+PHN5bWJvbCBpZD0iQSIgb3ZlcmZsb3c9InZpc2libGUiPjxwYXRoIGQ9Ik0zMi4wMDIgMEMxNC4zMzEuMDAyLjAwNSAxNC4zMjYgMCAzMS45OThjLjAwNSAxNy42NyAxNC4zMjggMzEuOTkzIDMxLjk5OCAzMS45OTggMTcuNjctLjAwNSAzMS45OTMtMTQuMzI4IDMxLjk5OC0zMS45OThDNjMuOTkxIDE0LjMzIDQ5LjY3LjAwNyAzMi4wMDIgMHptMjEuNjA2IDM3LjYwOWMwIDEuOTMzLTEuMTEyIDMuNjI2LTMuMjg4IDQuMDEzLTMuNzcuNjc4LTExLjcgMS4wNjQtMTguMzE4IDEuMDY0cy0xNC41NDgtLjQzNC0xOC4zMTgtMS4wNjRjLTEuOTY0LS4yOTQtMy4zODUtMi4wMjktMy4yODgtNC4wMTNWMjUuMTM2YzAtMS45MzMgMS40OTgtMy43MjIgMy4yODgtNC4wMTMgMS4xMTItLjE5NSAzLjcyMi0uNDM0IDUuNzU0LS40MzQuNzczIDAgMS40MDMuNTgyIDEuNDAzIDEuNDk4djguNzUxbDExLjIxMy0uMjQzIDExLjIxMy4yNDN2LTguNzAzYzAtLjg2OS42My0xLjQ5OCAxLjQwMy0xLjQ5OCAyLjAyOCAwIDQuNjQ3LjE5NiA1Ljc1NC40MzQgMS44MzcuMjkxIDMuMjg4IDIuMDg1IDMuMjg4IDQuMDEzbC0uMDk2IDEyLjQ3M3oiIHN0cm9rZT0ibm9uZSIgZmlsbD0iI2VkMjIyNiIgZmlsbC1ydWxlPSJub256ZXJvIi8+PC9zeW1ib2w+PC9zdmc+"
+    camel.apache.org/provider: "Apache Software Foundation"
+    camel.apache.org/kamelet.group: "Couchbase"
+    camel.apache.org/kamelet.namespace: "Nosql"
+  labels:
+    camel.apache.org/kamelet.type: "source"
+spec:
+  definition:
+    title: "Couchbase Source"
+    description: |-
+      Poll a Couchbase bucket and emit the results.
+
+      By default the bucket is queried with the N1QL statement given in the statement property. Set useView to true to poll a MapReduce view instead, selected with designDocumentName and viewName.
+    required:
+      - protocol
+      - couchbaseHostname
+      - bucket
+    type: object
+    properties:
+      protocol:
+        title: Protocol
+        description: The protocol to use
+        type: string
+      couchbaseHostname:
+        title: Hostname
+        description: The hostname to use
+        type: string
+      couchbasePort:
+        title: Port
+        description: The port to use
+        type: integer
+        default: 8091
+      bucket:
+        title: Bucket
+        description: The bucket to use
+        type: string
+      username:
+        title: Username
+        description: Username to connect to Couchbase.
+        type: string
+        x-descriptors:
+        - urn:camel:group:credentials
+      password:
+        title: Password
+        description: Password to connect to Couchbase.
+        type: string
+        format: password
+        x-descriptors:
+        - urn:camel:group:credentials
+      connectionString:
+        title: Connection String
+        description: The full Couchbase SDK connection string (e.g. couchbase://host:port). When set, it takes precedence over hostname extraction for the KV service port.
+        type: string
+      statement:
+        title: N1QL Statement
+        description: The N1QL query to run against the bucket on each poll. Used unless useView is true.
+        type: string
+        example: "SELECT * FROM `travel-sample` LIMIT 10"
+      useView:
+        title: Use View
+        description: Poll a MapReduce view instead of running the N1QL statement.
+        type: boolean
+        default: false
+      designDocumentName:
+        title: Design Document Name
+        description: The design document to query. Only used when useView is true.
+        type: string
+        default: beer
+      viewName:
+        title: View Name
+        description: The view to query. Only used when useView is true.
+        type: string
+        default: brewery_beers
+      fullDocument:
+        title: Full Document
+        description: Emit the whole document rather than only the fields the query or view returns.
+        type: boolean
+        default: false
+      limit:
+        title: Limit
+        description: The maximum number of documents to return per poll. A negative value means no limit.
+        type: integer
+        default: -1
+      skip:
+        title: Skip
+        description: How many documents to skip before returning results. A negative value means none.
+        type: integer
+        default: -1
+      descending:
+        title: Descending
+        description: Return the results in descending order.
+        type: boolean
+        default: false
+      delay:
+        title: Delay
+        description: The number of milliseconds between each poll.
+        type: integer
+        default: 500
+  dependencies:
+    - "camel:core"
+    - "camel:couchbase"
+    - "camel:kamelet"
+  template:
+    from:
+      uri: "couchbase:{{protocol}}://{{couchbaseHostname}}:{{couchbasePort}}"
+      parameters:
+        bucket: "{{bucket}}"
+        username: "{{username}}"
+        password: "{{password}}"
+        connectionString: "{{?connectionString}}"
+        statement: "{{?statement}}"
+        useView: "{{useView}}"
+        designDocumentName: "{{designDocumentName}}"
+        viewName: "{{viewName}}"
+        fullDocument: "{{fullDocument}}"
+        limit: "{{limit}}"
+        skip: "{{skip}}"
+        descending: "{{descending}}"
+        delay: "{{delay}}"
+      steps:
+      - to: "kamelet:sink"

--- a/library/camel-kamelets/src/main/resources/kamelets/couchbase-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/couchbase-source.kamelet.yaml
@@ -1,0 +1,144 @@
+# ---------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ---------------------------------------------------------------------------
+apiVersion: camel.apache.org/v1
+kind: Kamelet
+metadata:
+  name: couchbase-source
+  annotations:
+    camel.apache.org/kamelet.support.level: "Preview"
+    camel.apache.org/catalog.version: "4.22.1-SNAPSHOT"
+    camel.apache.org/kamelet.icon: "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB2aWV3Qm94PSIwIDAgNjguMzQzIDY4LjM0MyIgZmlsbD0iI2ZmZiIgZmlsbC1ydWxlPSJldmVub2RkIiBzdHJva2U9IiMwMDAiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCI+PHVzZSB4bGluazpocmVmPSIjQSIgeD0iMi4xNzEiIHk9IjIuMTcxIi8+PHN5bWJvbCBpZD0iQSIgb3ZlcmZsb3c9InZpc2libGUiPjxwYXRoIGQ9Ik0zMi4wMDIgMEMxNC4zMzEuMDAyLjAwNSAxNC4zMjYgMCAzMS45OThjLjAwNSAxNy42NyAxNC4zMjggMzEuOTkzIDMxLjk5OCAzMS45OTggMTcuNjctLjAwNSAzMS45OTMtMTQuMzI4IDMxLjk5OC0zMS45OThDNjMuOTkxIDE0LjMzIDQ5LjY3LjAwNyAzMi4wMDIgMHptMjEuNjA2IDM3LjYwOWMwIDEuOTMzLTEuMTEyIDMuNjI2LTMuMjg4IDQuMDEzLTMuNzcuNjc4LTExLjcgMS4wNjQtMTguMzE4IDEuMDY0cy0xNC41NDgtLjQzNC0xOC4zMTgtMS4wNjRjLTEuOTY0LS4yOTQtMy4zODUtMi4wMjktMy4yODgtNC4wMTNWMjUuMTM2YzAtMS45MzMgMS40OTgtMy43MjIgMy4yODgtNC4wMTMgMS4xMTItLjE5NSAzLjcyMi0uNDM0IDUuNzU0LS40MzQuNzczIDAgMS40MDMuNTgyIDEuNDAzIDEuNDk4djguNzUxbDExLjIxMy0uMjQzIDExLjIxMy4yNDN2LTguNzAzYzAtLjg2OS42My0xLjQ5OCAxLjQwMy0xLjQ5OCAyLjAyOCAwIDQuNjQ3LjE5NiA1Ljc1NC40MzQgMS44MzcuMjkxIDMuMjg4IDIuMDg1IDMuMjg4IDQuMDEzbC0uMDk2IDEyLjQ3M3oiIHN0cm9rZT0ibm9uZSIgZmlsbD0iI2VkMjIyNiIgZmlsbC1ydWxlPSJub256ZXJvIi8+PC9zeW1ib2w+PC9zdmc+"
+    camel.apache.org/provider: "Apache Software Foundation"
+    camel.apache.org/kamelet.group: "Couchbase"
+    camel.apache.org/kamelet.namespace: "Nosql"
+  labels:
+    camel.apache.org/kamelet.type: "source"
+spec:
+  definition:
+    title: "Couchbase Source"
+    description: |-
+      Poll a Couchbase bucket and emit the results.
+
+      By default the bucket is queried with the N1QL statement given in the statement property. Set useView to true to poll a MapReduce view instead, selected with designDocumentName and viewName.
+    required:
+      - protocol
+      - couchbaseHostname
+      - bucket
+    type: object
+    properties:
+      protocol:
+        title: Protocol
+        description: The protocol to use
+        type: string
+      couchbaseHostname:
+        title: Hostname
+        description: The hostname to use
+        type: string
+      couchbasePort:
+        title: Port
+        description: The port to use
+        type: integer
+        default: 8091
+      bucket:
+        title: Bucket
+        description: The bucket to use
+        type: string
+      username:
+        title: Username
+        description: Username to connect to Couchbase.
+        type: string
+        x-descriptors:
+        - urn:camel:group:credentials
+      password:
+        title: Password
+        description: Password to connect to Couchbase.
+        type: string
+        format: password
+        x-descriptors:
+        - urn:camel:group:credentials
+      connectionString:
+        title: Connection String
+        description: The full Couchbase SDK connection string (e.g. couchbase://host:port). When set, it takes precedence over hostname extraction for the KV service port.
+        type: string
+      statement:
+        title: N1QL Statement
+        description: The N1QL query to run against the bucket on each poll. Used unless useView is true.
+        type: string
+        example: "SELECT * FROM `travel-sample` LIMIT 10"
+      useView:
+        title: Use View
+        description: Poll a MapReduce view instead of running the N1QL statement.
+        type: boolean
+        default: false
+      designDocumentName:
+        title: Design Document Name
+        description: The design document to query. Only used when useView is true.
+        type: string
+        default: beer
+      viewName:
+        title: View Name
+        description: The view to query. Only used when useView is true.
+        type: string
+        default: brewery_beers
+      fullDocument:
+        title: Full Document
+        description: Emit the whole document rather than only the fields the query or view returns.
+        type: boolean
+        default: false
+      limit:
+        title: Limit
+        description: The maximum number of documents to return per poll. A negative value means no limit.
+        type: integer
+        default: -1
+      skip:
+        title: Skip
+        description: How many documents to skip before returning results. A negative value means none.
+        type: integer
+        default: -1
+      descending:
+        title: Descending
+        description: Return the results in descending order.
+        type: boolean
+        default: false
+      delay:
+        title: Delay
+        description: The number of milliseconds between each poll.
+        type: integer
+        default: 500
+  dependencies:
+    - "camel:core"
+    - "camel:couchbase"
+    - "camel:kamelet"
+  template:
+    from:
+      uri: "couchbase:{{protocol}}://{{couchbaseHostname}}:{{couchbasePort}}"
+      parameters:
+        bucket: "{{bucket}}"
+        username: "{{username}}"
+        password: "{{password}}"
+        connectionString: "{{?connectionString}}"
+        statement: "{{?statement}}"
+        useView: "{{useView}}"
+        designDocumentName: "{{designDocumentName}}"
+        viewName: "{{viewName}}"
+        fullDocument: "{{fullDocument}}"
+        limit: "{{limit}}"
+        skip: "{{skip}}"
+        descending: "{{descending}}"
+        delay: "{{delay}}"
+      steps:
+      - to: "kamelet:sink"


### PR DESCRIPTION
Fixes #542.

The catalog shipped `couchbase-sink` but nothing on the consuming side, even though `camel-couchbase` supports both. This adds the missing half.

## Two polling modes, both exposed

The component's own description is *"Query Couchbase databases using SQL (N1QL) queries or MapReduce Views with a poll strategy"*, and the Kamelet covers both:

- **N1QL** (default) — the `statement` property runs against the bucket on each poll
- **MapReduce view** — set `useView: true` and select it with `designDocumentName` / `viewName`

Rather than pick one and hide the other, the description says plainly which properties belong to which mode, since `designDocumentName` and `viewName` are inert unless `useView` is on.

## Consistency with the sink

Connection and credential properties mirror `couchbase-sink` exactly — same names (`protocol`, `couchbaseHostname`, `couchbasePort`, `bucket`, `username`, `password`), same `format: password` and credentials descriptor on the password, and the same `connectionString` escape hatch with the same wording. Someone configuring the pair should not have to learn two vocabularies.

The source-only additions are the query options the consumer actually reads: `statement`, `useView`, `designDocumentName`, `viewName`, `fullDocument`, `limit`, `skip`, `descending`, and `delay` for the poll interval. The sink-only `startingId` / `autoStartId` are deliberately absent — they configure insert id generation and have no meaning on a consumer.

## Verification

`script/validator` reports no errors, `script/generator` adds the `nav.adoc` entry, and `mvn clean install` passes **with tests** from the repository root.

Parameter binding checked against the real component with `camel run`. The Couchbase SDK initialises and starts bootstrapping from the configured host:

```
Routes startup (total:1 started:1 kamelets:1)
[com.couchbase.core][CoreCreatedEvent] {"connectionString":"couchbase://localhost", ...}
[com.couchbase.node][NodeCreatedEvent] Node created {"managerPort":"8091","remote":"localhost"}
```

with **zero** unknown-option or endpoint-resolution errors — it then simply cannot reach a cluster that is not running. A mistyped parameter would have failed before any of that.

**No Citrus test**: exercising this needs a live Couchbase and the project's Citrus/Testcontainers toolchain has no Couchbase container, so it ships `Preview` without `kamelet.verified=true`. Happy to add one in a follow-up if there is an image the project is willing to depend on.

The icon is the existing Couchbase icon reused from `couchbase-sink`, so the pair renders consistently.

---
_Claude Code on behalf of Andrea Cosentino_
