### PR TITLE
Fix #542: add a Citrus integration test for couchbase-source

### DIFF
--- a/tests/camel-kamelets-itest/src/test/java/CouchbaseIT.java
+++ b/tests/camel-kamelets-itest/src/test/java/CouchbaseIT.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import java.util.stream.Stream;
+
+import org.citrusframework.api.common.TestLoader;
+import org.citrusframework.junit.jupiter.CitrusSupport;
+import org.citrusframework.junit.jupiter.CitrusTestFactory;
+import org.citrusframework.junit.jupiter.CitrusTestFactorySupport;
+import org.junit.jupiter.api.DynamicTest;
+
+@CitrusSupport
+public class CouchbaseIT {
+
+    @CitrusTestFactory
+    public Stream<DynamicTest> couchbase() {
+        return CitrusTestFactorySupport.factory(TestLoader.YAML).packageScan("couchbase");
+    }
+}

--- a/tests/camel-kamelets-itest/src/test/resources/couchbase/application.properties
+++ b/tests/camel-kamelets-itest/src/test/resources/couchbase/application.properties
@@ -1,0 +1,24 @@
+# ---------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ---------------------------------------------------------------------------
+
+couchbase.protocol=http
+couchbase.hostname=localhost
+couchbase.port=8091
+couchbase.bucket=kamelets
+couchbase.username=Administrator
+couchbase.password=password
+couchbase.statement=SELECT META().id AS __id, * FROM _default

--- a/tests/camel-kamelets-itest/src/test/resources/couchbase/couchbase-source-route.citrus.it.yaml
+++ b/tests/camel-kamelets-itest/src/test/resources/couchbase/couchbase-source-route.citrus.it.yaml
@@ -1,0 +1,60 @@
+# ---------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ---------------------------------------------------------------------------
+
+name: couchbase-source-route-test
+actions:
+  # Create Couchbase infrastructure.
+  #
+  # Citrus has no built-in Couchbase container type, so this uses the generic
+  # one. The ports are bound one-to-one on purpose: the Couchbase SDK bootstraps
+  # from the management port and then reconnects using the addresses the cluster
+  # advertises, so a remapped host port makes the client unable to reach the
+  # data service.
+  - testcontainers:
+      start:
+        container:
+          name: "couchbase"
+          image: "couchbase/server:community-7.6.2"
+          startUpTimeout: 300
+          portBindings:
+            - "8091:8091"
+            - "8093:8093"
+            - "11210:11210"
+          waitFor:
+            logMessage: ".*Starting Couchbase Server.*"
+
+  # Initialise the cluster, create the bucket and seed one document
+  - groovy:
+      script:
+        file: "couchbase/initCluster.groovy"
+
+  # Create Camel JBang integration (source)
+  - camel:
+      cli:
+        run:
+          waitForRunningState: false
+          integration:
+            file: "couchbase/couchbase-source-route.yaml"
+            systemProperties:
+              file: "couchbase/application.properties"
+
+  # Verify the Couchbase source picked up the seeded document
+  - camel:
+      cli:
+        verify:
+          integration: "couchbase-source-route"
+          logMessage: "hello-from-couchbase"

--- a/tests/camel-kamelets-itest/src/test/resources/couchbase/couchbase-source-route.yaml
+++ b/tests/camel-kamelets-itest/src/test/resources/couchbase/couchbase-source-route.yaml
@@ -1,0 +1,32 @@
+# ---------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ---------------------------------------------------------------------------
+
+- route:
+    from:
+      uri: "kamelet:couchbase-source"
+      parameters:
+        protocol: "{{couchbase.protocol}}"
+        couchbaseHostname: "{{couchbase.hostname}}"
+        couchbasePort: "{{couchbase.port}}"
+        bucket: "{{couchbase.bucket}}"
+        username: "{{couchbase.username}}"
+        password: "{{couchbase.password}}"
+        statement: "{{couchbase.statement}}"
+        delay: 2000
+      steps:
+      - to:
+          uri: "kamelet:log-sink"

--- a/tests/camel-kamelets-itest/src/test/resources/couchbase/initCluster.groovy
+++ b/tests/camel-kamelets-itest/src/test/resources/couchbase/initCluster.groovy
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Brings a freshly started Couchbase container to the point where the
+// couchbase-source Kamelet can poll it: initialise the cluster, create a
+// bucket, add a primary index and seed one document.
+//
+// Two deliberate constraints:
+//  - plain HTTP rather than the Couchbase SDK, so the test module does not need
+//    the SDK on its classpath
+//  - string concatenation rather than Groovy GStrings, because Citrus resolves
+//    dollar-brace expressions in these scripts as its own test variables
+
+def admin = 'http://localhost:8091'
+def query = 'http://localhost:8093/query/service'
+def user = 'Administrator'
+def pass = 'password'
+def bucket = 'kamelets'
+def basic = 'Basic ' + (user + ':' + pass).bytes.encodeBase64().toString()
+
+def call = { String url, String body, boolean auth ->
+    def conn = new URL(url).openConnection()
+    conn.requestMethod = 'POST'
+    conn.doOutput = true
+    conn.connectTimeout = 10000
+    conn.readTimeout = 60000
+    conn.setRequestProperty('Content-Type', 'application/x-www-form-urlencoded')
+    if (auth) {
+        conn.setRequestProperty('Authorization', basic)
+    }
+    conn.outputStream.withWriter { it << body }
+    def code = conn.responseCode
+    if (code >= 400) {
+        throw new IllegalStateException('POST ' + url + ' failed with ' + code)
+    }
+    return code
+}
+
+// The container logs "Starting Couchbase Server" well before the management
+// port serves requests, so wait for readiness here rather than in the container
+// wait strategy.
+def ready = false
+for (int i = 0; i < 60 && !ready; i++) {
+    try {
+        def conn = new URL(admin + '/pools').openConnection()
+        conn.connectTimeout = 2000
+        conn.readTimeout = 2000
+        ready = conn.responseCode == 200
+    } catch (Exception ignored) {
+        // not up yet
+    }
+    if (!ready) {
+        sleep(2000)
+    }
+}
+if (!ready) {
+    throw new IllegalStateException('Couchbase management port did not become available at ' + admin)
+}
+
+call(admin + '/pools/default', 'memoryQuota=512&indexMemoryQuota=512', false)
+call(admin + '/node/controller/setupServices', 'services=kv%2Cn1ql%2Cindex', false)
+call(admin + '/settings/web', 'port=SAME&username=' + user + '&password=' + pass, false)
+call(admin + '/settings/indexes', 'storageMode=forestdb', true)
+call(admin + '/pools/default/buckets', 'name=' + bucket + '&ramQuota=128&bucketType=couchbase', true)
+
+// The bucket is created asynchronously and the query service only sees the
+// keyspace once it has warmed up, so retry the index creation until it lands.
+def indexed = false
+for (int i = 0; i < 30 && !indexed; i++) {
+    try {
+        call(query, 'statement=' + URLEncoder.encode('CREATE PRIMARY INDEX ON `' + bucket + '`', 'UTF-8'), true)
+        indexed = true
+    } catch (Exception ignored) {
+        sleep(2000)
+    }
+}
+if (!indexed) {
+    throw new IllegalStateException('Could not create the primary index on ' + bucket)
+}
+
+def insert = 'INSERT INTO `' + bucket + '` (KEY, VALUE) VALUES ("doc1", {"message":"hello-from-couchbase"})'
+call(query, 'statement=' + URLEncoder.encode(insert, 'UTF-8'), true)


### PR DESCRIPTION
Follow-up to #3007, which shipped `couchbase-source` without a test on the grounds that the project's Citrus toolchain had no Couchbase container. That was true only in the sense that there is no *built-in* one — the generic container works fine, it just needs setting up by hand.

## The test

```
testcontainers: start: container (couchbase/server:community-7.6.2)
  -> initCluster.groovy   (cluster init, bucket, primary index, seed one document)
  -> camel: cli: run      (couchbase-source -> log-sink)
  -> camel: cli: verify   (logMessage: "hello-from-couchbase")
```

Same shape as the existing `mongodb-source-route` test, so it should read familiarly.

## Three things that were not optional

Recording these because each cost a full run to find, and the next person adding a container-based test will hit at least one.

**Ports are bound one-to-one.** The Couchbase SDK bootstraps from the management port and then reconnects using the addresses the *cluster* advertises. With a remapped host port the client bootstraps and then cannot reach the data service. Hence explicit `8091:8091`, `8093:8093`, `11210:11210` rather than `exposedPorts`.

**The wait strategy needs a full-line regex.** Testcontainers matches log wait patterns against the entire line, so `"Starting Couchbase Server"` never matches the actual line and the container times out after five minutes. It has to be `".*Starting Couchbase Server.*"`.

**No Groovy GStrings in the script.** Citrus resolves dollar-brace expressions in these scripts as its own test variables, so a GString fails with `Unknown variable 'user'`. The script uses string concatenation throughout — including, eventually, in the comment that explains why.

## Why the statement looks the way it does

```properties
couchbase.statement=SELECT META().id AS __id, * FROM _default
```

Not the obvious `SELECT * FROM <bucket>`, because both halves matter:

- `CouchbaseConsumer` reads `row.getString("__id")` and **skips any row without it**, logging a warning rather than failing. A query without `META().id AS __id` yields a source that polls happily and emits nothing.
- The consumer runs the query through `scope.query(...)`, so the keyspace is resolved as `<bucket>._default.<what-you-wrote>`. `FROM <bucket>` becomes `<bucket>._default.<bucket>` and fails with `Keyspace not found`.

I found both by running the Kamelet against a live cluster, and they mean **the example currently shipped in `couchbase-source` is wrong** — `SELECT * FROM \`travel-sample\` LIMIT 10` would silently return nothing. That is my error from #3007. I am fixing it in a separate PR rather than folding a Kamelet change into a test PR.

## Verification

Passes locally, twice through (test and verify phases), about 35 seconds each:

```
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0 -- in CouchbaseIT
  ✔ SUCCESS (38088ms) couchbase-source-route-test
```

`mvn clean install` passes with tests from the repository root.

## For reviewers

**The image is large** — `couchbase/server:community-7.6.2` is about 1.7 GB, materially bigger than redpanda or floci. On a cold CI cache that is a real cost for one test, and worth weighing against the value of covering this Kamelet.

**I did not add `camel.apache.org/kamelet.verified: "true"`.** The contributor guide ties that label to having passing behaviour tests, but it is applied to only 21 Kamelets and notably not to `mongodb-source`, which does have a test — so it looks like a curation decision rather than an automatic consequence. Happy to add it if you want it applied here.

---
_Claude Code on behalf of Andrea Cosentino_
