### PR TITLE
Fix #2263: add a Salesforce Pub/Sub source Kamelet

### DIFF
--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -212,6 +212,7 @@
 * xref:salesforce-composite-upsert-sink.adoc[]
 * xref:salesforce-create-sink.adoc[]
 * xref:salesforce-delete-sink.adoc[]
+* xref:salesforce-pubsub-source.adoc[]
 * xref:salesforce-source.adoc[]
 * xref:salesforce-update-sink.adoc[]
 * xref:scp-sink.adoc[]

--- a/kamelets/salesforce-pubsub-source.kamelet.yaml
+++ b/kamelets/salesforce-pubsub-source.kamelet.yaml
@@ -1,0 +1,134 @@
+# ---------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ---------------------------------------------------------------------------
+apiVersion: camel.apache.org/v1
+kind: Kamelet
+metadata:
+  name: salesforce-pubsub-source
+  annotations:
+    camel.apache.org/kamelet.support.level: "Preview"
+    camel.apache.org/catalog.version: "4.22.1-SNAPSHOT"
+    camel.apache.org/kamelet.icon: "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz48c3ZnIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHZpZXdCb3g9IjAgMCA0OCA0OCIgdmVyc2lvbj0iMS4xIj48ZyBpZD0ic3VyZmFjZTEiPjxwYXRoIGQ9Ik0zNi41IDEyYy0xLjMyNCAwLTIuNTkuMjU4LTMuNzU4LjcwM0E3Ljk5NCA3Ljk5NCAwIDAgMCAyNiA5Yy0yLjEwNSAwLTQuMDIuODItNS40NDUgMi4xNTJBOS40NjggOS40NjggMCAwIDAgMTMuNSA4QzguMjU0IDggNCAxMi4yNTQgNCAxNy41YzAgLjc5My4xMSAxLjU1OS4yOSAyLjI5M0E4LjQ3MiA4LjQ3MiAwIDAgMCAxIDI2LjVDMSAzMS4xOTUgNC44MDUgMzUgOS41IDM1Yy40MTQgMCAuODE2LS4wNCAxLjIxNS0uMDk4IDEuMzEyIDMgNC4zIDUuMDk4IDcuNzg1IDUuMDk4IDMuMTYgMCA1LjkxNC0xLjczIDcuMzc5LTQuMjkzQTcuOTIzIDcuOTIzIDAgMCAwIDI4IDM2YzIuNjIxIDAgNC45MzgtMS4yNjYgNi4zOTgtMy4yMS42OC4xMzYgMS4zODMuMjEgMi4xMDIuMjFDNDIuMyAzMyA0NyAyOC4zIDQ3IDIyLjVTNDIuMyAxMiAzNi41IDEyeiIgZmlsbD0iIzAzOUJFNSIvPjxwYXRoIGQ9Ik0xNS44MjQgMjVjLjA0MyAwIC4wNzQtLjAzNS4wNzQtLjA4MiAwIC4wNDctLjAzLjA4Mi0uMDc0LjA4MnoiIGZpbGw9IiNGRkYiLz48cGF0aCBkPSJNMjEuNTA0IDIzLjkzNHoiIGZpbGw9IiNGRkYiLz48cGF0aCBkPSJNNy4xMzcgMjMuOTNhLjExNi4xMTYgMCAwIDEgLjAwNCAwaC0uMDA0eiIgZmlsbD0iI0ZGRiIvPjxwYXRoIGQ9Ik0yNC4xMjUgMjEuOTFjLS4wMTYuMDQtLjA0Ny4wNDMtLjA3LjA0M2guMDA4Yy4wMjMgMCAuMDUtLjAwOC4wNjItLjA0M3oiIGZpbGw9IiNGRkYiLz48cGF0aCBkPSJNMTUuODI0IDE5Yy4wNDMgMCAuMDc0LjAzNS4wNzQuMDgyIDAtLjA0Ny0uMDMtLjA4Mi0uMDc0LS4wODJ6IiBmaWxsPSIjRkZGIi8+PHBhdGggZD0iTTIxLjM2IDIyLjE4NGMwIC40MS4yMS42NjQuNTAzLjgzNi0uMjkzLS4xNzItLjUwNC0uNDI2LS41MDQtLjgzNnoiIGZpbGw9IiNGRkYiLz48cGF0aCBkPSJNMzguMTI1IDI0LjczYy4wMjcuMDYtLjAzMS4wODYtLjAzMS4wODZzLjA1OC0uMDI3LjAzMS0uMDg2eiIgZmlsbD0iI0ZGRiIvPjxwYXRoIGQ9Ik04LjU1OSAyMXoiIGZpbGw9IiNGRkYiLz48cGF0aCBkPSJNOS43NjYgMjEuOTFjLS4wMi4wNC0uMDQ3LjA0My0uMDc1LjA0M0g5LjdjLjAyOCAwIC4wNTEtLjAwOC4wNjctLjA0M3oiIGZpbGw9IiNGRkYiLz48cGF0aCBkPSJNMzUuMTk1IDI0LjE2NHoiIGZpbGw9IiNGRkYiLz48cGF0aCBkPSJNMzcuODI4IDIxLjc5N2gtLjAyM3MuMDA4LjAwNC4wMjMuMDA0di0uMDA0eiIgZmlsbD0iI0ZGRiIvPjxwYXRoIGQ9Ik0zNy44MzIgMjQuMTg4cy4wMTYgMCAuMDM1LS4wMDRoLS4wMDRjLS4wMTUgMC0uMDMxLjAwMy0uMDMxLjAwM3oiIGZpbGw9IiNGRkYiLz48cGF0aCBkPSJNNi44ODcgMjQuNDZjLS4wMzIuMDcxLjAwOC4wODcuMDIuMDk5LjA4NS4wNTguMTcxLjA5Ny4yNjEuMTQ0LjQ2OS4yMy45MS4yOTcgMS4zNzUuMjk3Ljk0NSAwIDEuNTMxLS40NiAxLjUzMS0xLjIwN3YtLjAxNmMwLS42ODctLjY2NC0uOTM3LTEuMjg1LTEuMTE3bC0uMDc4LS4wMjNjLS40NjktLjE0LS44NzEtLjI2Mi0uODcxLS41NDd2LS4wMTZjMC0uMjQyLjIzNC0uNDIyLjYwMS0uNDIyLjQwNyAwIC44ODcuMTI1IDEuMi4yODUgMCAwIC4wOS4wNTUuMTI1LS4wMjcuMDE1LS4wNDMuMTc1LS40MzMuMTkxLS40NzYuMDItLjA0My0uMDE2LS4wNzktLjA0Ny0uMDk4QTIuODQ1IDIuODQ1IDAgMCAwIDguNTYgMjFoLS4wOTRjLS44NjMgMC0xLjQ2OS40OC0xLjQ2OSAxLjE3MnYuMDEyYzAgLjcyNi42NjQuOTY0IDEuMjkgMS4xMjhsLjEuMDI4Yy40NTQuMTI5Ljg0NC4yMzguODQ0LjUzMXYuMDE2YzAgLjI3LS4yNTMuNDcyLS42NjQuNDcyLS4xNiAwLS42NjgtLjAwNC0xLjIxNC0uMzI0YTIuNDUgMi40NSAwIDAgMS0uMTU3LS4wOWMtLjAyNy0uMDE1LS4wOTMtLjA0My0uMTI1LjA0eiIgZmlsbD0iI0ZGRiIvPjxwYXRoIGQ9Ik0yMS4yNDYgMjQuNDZjLS4wMjcuMDcxLjAxMi4wODcuMDIuMDk5LjA5LjA1OC4xNzUuMDk3LjI2MS4xNDQuNDcuMjMuOTE0LjI5NyAxLjM4LjI5Ny45NCAwIDEuNTI3LS40NiAxLjUyNy0xLjIwN3YtLjAxNmMwLS42ODctLjY2LS45MzctMS4yODItMS4xMTdsLS4wODItLjAyM2MtLjQ2NS0uMTQtLjg3LS4yNjItLjg3LS41NDd2LS4wMTZjMC0uMjQyLjIzOC0uNDIyLjYwNS0uNDIyLjQwNiAwIC44ODYuMTI1IDEuMTk5LjI4NSAwIDAgLjA5LjA1NS4xMjUtLjAyNy4wMTYtLjA0My4xNzItLjQzMy4xOTEtLjQ3Ni4wMTYtLjA0My0uMDE1LS4wNzktLjA0Ny0uMDk4QTIuODU3IDIuODU3IDAgMCAwIDIyLjkyMiAyMWgtLjA5OGMtLjg2MyAwLTEuNDY1LjQ4LTEuNDY1IDEuMTcydi4wMTJjMCAuNzI2LjY2NC45NjQgMS4yOSAxLjEyOGwuMDk3LjAyOGMuNDU3LjEyOS44NDguMjM4Ljg0OC41MzF2LjAxNmMwIC4yNy0uMjU0LjQ3Mi0uNjY0LjQ3Mi0uMTYgMC0uNjY4LS4wMDQtMS4yMTUtLjMyNGEyLjQ1IDIuNDUgMCAwIDEtLjE1Ni0uMDljLS4wMi0uMDA4LS4wOTgtLjAzOS0uMTI1LjA0eiIgZmlsbD0iI0ZGRiIvPjxwYXRoIGQ9Ik0zMS40NjUgMjIuMjE5YTEuNzE0IDEuNzE0IDAgMCAwLS4zNi0uNjMzIDEuNzQgMS43NCAwIDAgMC0uNjAxLS40MyAyLjE4NyAyLjE4NyAwIDAgMC0uODQ4LS4xNTZjLS4zMTYgMC0uNjAxLjA1NS0uODQzLjE1NmExLjY3IDEuNjcgMCAwIDAtLjYwMi40M2MtLjE2NC4xNzYtLjI4MS4zOS0uMzYuNjMzYTIuNTQ0IDIuNTQ0IDAgMCAwLS4xMTcuNzg1YzAgLjI3Ny4wNC41NDMuMTE4Ljc4NWExLjY5MSAxLjY5MSAwIDAgMCAuOTYgMS4wNTljLjI0My4wOTcuNTI4LjE1Mi44NDQuMTUyLjMyIDAgLjYwNi0uMDUuODQ4LS4xNTIuMjM4LS4xMDIuNDQxLS4yNDYuNjAxLS40MjIuMTYtLjE4LjI4Mi0uMzk1LjM2LS42MzcuMDc4LS4yNDIuMTE3LS41MDQuMTE3LS43ODVzLS4wMzktLjU0My0uMTE3LS43ODVtLS43OS43ODVjMCAuNDIyLS4wODEuNzU4LS4yNS45OTItLjE2Ny4yMzQtLjQxNy4zNDgtLjc2OS4zNDgtLjM0NyAwLS41OTctLjExNC0uNzYxLS4zNDgtLjE2OC0uMjM0LS4yNS0uNTctLjI1LS45OTIgMC0uNDIyLjA4NS0uNzU4LjI1LS45ODguMTY0LS4yMzUuNDE0LS4zNDQuNzYxLS4zNDQuMzUyIDAgLjYwMi4xMS43Ny4zNDQuMTY4LjIzLjI1LjU2Ni4yNS45ODgiIGZpbGw9IiNGRkYiLz48cGF0aCBkPSJNMzcuOTM0IDI0LjIzNGMtLjAyOC0uMDc0LS4xMDItLjA0Ny0uMTAyLS4wNDdhMS43NDMgMS43NDMgMCAwIDEtLjM2Ny4wOTggMi44OCAyLjg4IDAgMCAxLS40My4wMzFjLS4zODMgMC0uNjgzLS4xMDUtLjkwMi0uMzEyLS4yMTUtLjIxMS0uMzM2LS41NDctLjMzNi0xIDAtLjQxNC4xMS0uNzI3LjMtLjk2NS4xOTItLjIzNC40ODUtLjM1NS44NzYtLjM1NS4zMjQgMCAuNTc0LjAzNS44MzIuMTA5IDAgMCAuMDYyLjAyNy4wOS0uMDUuMDctLjE3Ny4xMi0uMzAyLjE5NS0uNDk3LjAyLS4wNTgtLjAzMS0uMDgyLS4wNS0uMDg2YTMuMjQgMy4yNCAwIDAgMC0uNTI0LS4xMjUgNC40MzUgNC40MzUgMCAwIDAtLjU5LS4wMzVjLS4zMzIgMC0uNjI1LjA1NS0uODguMTU2YTEuODQyIDEuODQyIDAgMCAwLS42MzYuNDI2Yy0uMTY4LjE4LS4yOTcuMzk1LS4zODMuNjM3YTIuMzE1IDIuMzE1IDAgMCAwLS4xMjkuNzg1YzAgLjYwNS4xNzYgMS4wOTQuNTI4IDEuNDUzLjM0Ny4zNi44Ny41NDMgMS41NTQuNTQzLjQwMyAwIC44MTctLjA3NCAxLjExNC0uMTg0IDAgMCAuMDU4LS4wMjcuMDM1LS4wODZ6IiBmaWxsPSIjRkZGIi8+PHBhdGggZD0iTTQxLjk2NSAyMi4wODJhMS41MiAxLjUyIDAgMCAwLS4zNDQtLjU3OCAxLjUxNiAxLjUxNiAwIDAgMC0uNTA0LS4zNiAyLjEwNSAyLjEwNSAwIDAgMC0uNzY1LS4xNDRjLS4zMzIgMC0uNjMzLjA1LS44OC4xNi0uMjQ1LjEwNi0uNDUyLjI1LS42MTMuNDM0LS4xNjQuMTgtLjI4NS4zOTgtLjM2My42NGEyLjYwNSAyLjYwNSAwIDAgMC0uMTE3Ljc5YzAgLjI4NS4wNDMuNTUuMTIxLjc5Mi4wODIuMjM5LjIxLjQ1NC4zODcuNjMuMTc1LjE3NS40MDIuMzEyLjY3Mi40MS4yNjUuMDk3LjU5My4xNDguOTY4LjE0NC43NyAwIDEuMTc2LS4xNiAxLjM0LS4yNDYuMDMxLS4wMTYuMDU5LS4wNDMuMDI0LS4xMTdsLS4xNzItLjQ1M2MtLjAyOC0uMDctLjEwMi0uMDQzLS4xMDItLjA0My0uMTkxLjA2Mi0uNDYuMTgzLTEuMDk0LjE4LS40MTQgMC0uNzIyLS4xMS0uOTE0LS4yOS0uMTk1LS4xOC0uMjkzLS40NDUtLjMwOC0uODJoMi42NjRzLjA3IDAgLjA3OC0uMDY2Yy4wMDQtLjAyOC4wOS0uNTA4LS4wNzgtMS4wNjNtLTIuNjUzLjUxNmMuMDM2LS4yMzUuMTA2LS40MzQuMjE1LS41ODIuMTY0LS4yMzUuNDEtLjM2Ljc2Mi0uMzYuMzUyIDAgLjU4Mi4xMjUuNzQ2LjM2LjExLjE1Mi4xNi4zNTUuMTguNTgyeiIgZmlsbD0iI0ZGRiIvPjxwYXRoIGQ9Ik0yMC40NTMgMjIuMDgyYTEuNTE3IDEuNTE3IDAgMCAwLS4zNC0uNTc4IDEuNDkgMS40OSAwIDAgMC0uNTA4LS4zNiAyLjA4MyAyLjA4MyAwIDAgMC0uNzYxLS4xNDRjLS4zMzIgMC0uNjM3LjA1LS44ODMuMTYtLjI0Mi4xMDYtLjQ1LjI1LS42MTMuNDM0YTEuNzggMS43OCAwIDAgMC0uMzYuNjQgMi42MDUgMi42MDUgMCAwIDAtLjExNy43OWMwIC4yODUuMDQuNTUuMTIxLjc5Mi4wNzguMjM5LjIxMS40NTQuMzg3LjYzLjE3Ni4xNzUuMzk4LjMxMi42NjguNDEuMjcuMDk3LjU5NC4xNDguOTY5LjE0NC43NyAwIDEuMTc1LS4xNiAxLjM0My0uMjQ2LjAzMi0uMDE2LjA1NS0uMDQzLjAyNC0uMTE3bC0uMTc2LS40NTNjLS4wMjctLjA3LS4xMDItLjA0My0uMTAyLS4wNDMtLjE5LjA2Mi0uNDYuMTgzLTEuMDkzLjE4LS40MTQgMC0uNzE5LS4xMS0uOTEtLjI5LS4yLS4xOC0uMjk3LS40NDUtLjMxMy0uODJoMi42NjhzLjA3IDAgLjA3OC0uMDY2YzAtLjAyOC4wOS0uNTA4LS4wODItMS4wNjNtLTIuNjUyLjUxNmMuMDM5LS4yMzUuMTEtLjQzNC4yMTUtLjU4Mi4xNjQtLjIzNS40MTQtLjM2Ljc2NS0uMzYuMzQ4IDAgLjU3OC4xMjUuNzQ2LjM2LjExLjE1Mi4xNi4zNTUuMTc2LjU4MnoiIGZpbGw9IiNGRkYiLz48cGF0aCBkPSJNMTIuOTMgMjIuNDhjLS4xMS0uMDAzLS4yNDYtLjAwNy0uNDE0LS4wMDctLjIzIDAtLjQ1NC4wMjMtLjY2LjA3OC0uMjA4LjA1LS4zOTUuMTI5LS41NTUuMjM4LS4xNi4xMDYtLjI5My4yNDItLjM4Ny40MDZhMS4xMzUgMS4xMzUgMCAwIDAtLjE0NC41N2MwIC4yMi4wNDMuNDEuMTI1LjU2My4wNzguMTU2LjE5NS4yODUuMzQzLjM4Ny4xNDkuMTAxLjMzMi4xNzYuNTQzLjIxOS4yMTEuMDQzLjQ1LjA2Ni43MTEuMDY2LjI3NCAwIC41NDMtLjAyLjgwOS0uMDYzLjI2MS0uMDQyLjU4Mi0uMTAxLjY3Mi0uMTIuMDktLjAyLjE4Ny0uMDQ0LjE4Ny0uMDQ0LjA2Ny0uMDE1LjA1OS0uMDgyLjA1OS0uMDgydi0yLjI1N2MwLS40OTctLjE0NS0uODY0LS40MjItMS4wOTQtLjI4MS0uMjI3LS42OTUtLjM0LTEuMjI3LS4zNC0uMTk5IDAtLjUyLjAyMy0uNzE1LjA2MyAwIDAtLjU4Mi4xMDEtLjgyLjI3NyAwIDAtLjA1NS4wMzEtLjAyMy4wOThsLjE4Ny40NjhjLjAyNC4wNjMuMDg2LjA0My4wODYuMDQzcy4wMjQtLjAwOC4wNDctLjAyM2MuNTEyLS4yNTggMS4xNi0uMjUgMS4xNi0uMjUuMjkgMCAuNTEyLjA1NC42Ni4xNi4xNDUuMTA1LjIyLjI1OC4yMi41OXYuMTA1Yy0uMjMxLS4wMzEtLjQ0Mi0uMDUtLjQ0Mi0uMDVtLTEuMDYzIDEuNzM4YS41MzguNTM4IDAgMCAxLS4xNTItLjE0OS41Ny41NyAwIDAgMS0uMDc4LS4zMmMwLS4yMTkuMDc4LS4zNzEuMjM4LS40NzctLjAwNCAwIC4yMy0uMTg3Ljc3My0uMTguMzguMDA1LjcyMy4wNTUuNzIzLjA1NXYxLjEyNXMtLjM0LjA2Ny0uNzE5LjA4NmMtLjU0My4wMzItLjc4NS0uMTQtLjc4NS0uMTQiIGZpbGw9IiNGRkYiLz48cGF0aCBkPSJNMzQuNzYyIDIxLjE2OGMuMDItLjA1OS0uMDI0LS4wODItLjA0My0uMDlhMi41MjYgMi41MjYgMCAwIDAtLjQ0Ni0uMDc0Yy0uMzM2LS4wMi0uNTIuMDM1LS42ODcuMTA1LS4xNjguMDctLjM1Mi4xODgtLjQ1LjMybC0uMDAzLS4zMTJjMC0uMDQzLS4wMzEtLjA3OC0uMDc0LS4wNzhoLS42ODRhLjA3Ni4wNzYgMCAwIDAtLjA3OC4wNzh2My44MDVjMCAuMDQzLjAzOS4wNzguMDgyLjA3OGguN2EuMDguMDggMCAwIDAgLjA4MS0uMDc4di0xLjg5OWMwLS4yNTcuMDI4LS41MTEuMDg2LS42NzFhLjk2NC45NjQgMCAwIDEgLjIzNC0uMzc1Ljg2Ljg2IDAgMCAxIC4zMzMtLjE5MiAxLjM1IDEuMzUgMCAwIDEgLjM1NS0uMDQ3Yy4xNCAwIC4yOTMuMDM1LjI5My4wMzUuMDUuMDA0LjA3OC0uMDI3LjA5OC0uMDcuMDQ2LS4xMTMuMTc1LS40NjUuMjAzLS41MzUiIGZpbGw9IiNGRkYiLz48cGF0aCBkPSJNMjguMjAzIDE5LjEwNWExLjk1IDEuOTUgMCAwIDAtLjYyNS0uMDljLS40ODQgMC0uODYzLjEzNy0xLjEyOS40MDctLjI2NS4yNjUtLjQ0NS42NzYtLjUzOSAxLjIxbC0uMDQ3LjM2NGgtLjYwNXMtLjA3NC0uMDA0LS4wOS4wNzhsLS4wOTguNTU1Yy0uMDA4LjA1NS4wMTYuMDg2LjA4Ni4wODZoLjU5bC0uNTk4IDMuMzM2YTQuNDMgNC40MyAwIDAgMS0uMTYuNjYgMS40MjIgMS40MjIgMCAwIDEtLjE4Ny4zNzkuNTA1LjUwNSAwIDAgMS0uMjQyLjE4NyAxIDEgMCAwIDEtLjMxNy4wNDMuOTcuOTcgMCAwIDEtLjIxLS4wMjMuNTguNTggMCAwIDEtLjE0NS0uMDQzcy0uMDctLjAyNy0uMDk4LjA0M2MtLjAyMy4wNTUtLjE4LjQ4OC0uMTk1LjUzOS0uMDIuMDU1LjAwNC4wOTQuMDM5LjEwNS4wNzguMDMyLjEzNy4wNDcuMjQyLjA3NS4xNDguMDM1LjI3My4wMzUuMzkuMDM1LjI0NyAwIC40Ny0uMDM1LjY1Ny0uMTAyLjE4Ny0uMDY2LjM0OC0uMTgzLjQ5Mi0uMzQ0LjE1Ni0uMTcxLjI1NC0uMzUxLjM0OC0uNTkzLjA5LS4yNDYuMTY4LS41NDcuMjM0LS44OTlsLjU5OC0zLjM5OGguODc5cy4wNzQuMDA0LjA5LS4wNzhsLjA5Ny0uNTU1Yy4wMDgtLjA1LS4wMTUtLjA4Ni0uMDg2LS4wODZoLS44NTFjLjAwNC0uMDIuMDU4LS41MDQuMTU2LS43ODVhLjc4OC43ODggMCAwIDEgLjE4Ny0uMjg1LjU2Ni41NjYgMCAwIDEgLjIyMy0uMTQgMS4xNjUgMS4xNjUgMCAwIDEgLjUwNC0uMDJjLjA4Mi4wMi4xMTcuMDI3LjEzNy4wMzUuMDkuMDI3LjA5NyAwIC4xMTctLjA0M2wuMjAzLS41NTljLjAyMy0uMDU4LS4wMjctLjA4Ni0uMDQ3LS4wOTQiIGZpbGw9IiNGRkYiLz48cGF0aCBkPSJNMTUuODk4IDI0LjkxOGMwIC4wNDctLjAzLjA4Mi0uMDc0LjA4MmgtLjcwN2MtLjA0NyAwLS4wNzgtLjAzNS0uMDc4LS4wODJ2LTUuODM2YzAtLjA0Ny4wMzEtLjA4Mi4wNzgtLjA4MmguNzA3Yy4wNDMgMCAuMDc0LjA0LjA3NC4wODJ6IiBmaWxsPSIjRkZGIi8+PC9nPjxtZXRhZGF0YT48cmRmOlJERiB4bWxuczpyZGY9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkvMDIvMjItcmRmLXN5bnRheC1ucyMiIHhtbG5zOnJkZnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvMDEvcmRmLXNjaGVtYSMiIHhtbG5zOmRjPSJodHRwOi8vcHVybC5vcmcvZGMvZWxlbWVudHMvMS4xLyI+PHJkZjpEZXNjcmlwdGlvbiBhYm91dD0iaHR0cHM6Ly9pY29uc2NvdXQuY29tL2xlZ2FsI2xpY2Vuc2VzIiBkYzp0aXRsZT0ic2FsZXNmb3JjZSIgZGM6ZGVzY3JpcHRpb249InNhbGVzZm9yY2UiIGRjOnB1Ymxpc2hlcj0iSWNvbnNjb3V0IiBkYzpkYXRlPSIyMDE3LTEyLTE1IiBkYzpmb3JtYXQ9ImltYWdlL3N2Zyt4bWwiIGRjOmxhbmd1YWdlPSJlbiI+PGRjOmNyZWF0b3I+PHJkZjpCYWc+PHJkZjpsaT5JY29uczg8L3JkZjpsaT48L3JkZjpCYWc+PC9kYzpjcmVhdG9yPjwvcmRmOkRlc2NyaXB0aW9uPjwvcmRmOlJERj48L21ldGFkYXRhPjwvc3ZnPg=="
+    camel.apache.org/provider: "Apache Software Foundation"
+    camel.apache.org/kamelet.group: "Salesforce"
+    camel.apache.org/kamelet.namespace: "Salesforce"
+  labels:
+    camel.apache.org/kamelet.type: "source"
+spec:
+  definition:
+    title: "Salesforce Pub/Sub Source"
+    description: |-
+      Receive events from the Salesforce Pub/Sub API.
+
+      This is the gRPC based Pub/Sub API, not the older streaming API that salesforce-source uses. Subscribe to a channel such as /event/MyEvent__e, /topic/MyTopic or /data/AccountChangeEvent.
+
+      The Pub/Sub API is gRPC based and needs a protobuf-java new enough for the generated stubs in camel-salesforce. Under Camel JBang an older protobuf is resolved and the route fails to start with NoClassDefFoundError on com.google.protobuf.RuntimeVersion; adding protobuf-java as an explicit dependency resolves it.
+    required:
+      - topic
+      - clientId
+      - clientSecret
+      - userName
+      - password
+    type: object
+    properties:
+      topic:
+        title: Topic
+        description: The Pub/Sub channel to subscribe to.
+        type: string
+        example: "/event/BatchApexErrorEvent"
+      loginUrl:
+        title: Login URL
+        description: The Salesforce instance used to authenticate.
+        type: string
+        default: "https://login.salesforce.com"
+      clientId:
+        title: Consumer Key
+        description: The Salesforce application consumer key.
+        type: string
+        x-descriptors:
+        - urn:camel:group:credentials
+      clientSecret:
+        title: Consumer Secret
+        description: The Salesforce application consumer secret.
+        type: string
+        format: password
+        x-descriptors:
+        - urn:camel:group:credentials
+      userName:
+        title: Username
+        description: The Salesforce username.
+        type: string
+        x-descriptors:
+        - urn:camel:group:credentials
+      password:
+        title: Password
+        description: The Salesforce user password.
+        type: string
+        format: password
+        x-descriptors:
+        - urn:camel:group:credentials
+      deserializeType:
+        title: Deserialize Type
+        description: >-
+          How to deserialise the received events. This Kamelet defaults to JSON so the body is
+          usable downstream without further decoding; the component's own default is AVRO, which
+          emits binary. Use POJO together with pojoClass to deserialise into a generated class.
+        type: string
+        default: "JSON"
+        enum: ["AVRO", "SPECIFIC_RECORD", "GENERIC_RECORD", "POJO", "JSON"]
+      pojoClass:
+        title: POJO Class
+        description: The fully qualified class name to deserialise into. Only used when deserializeType is POJO.
+        type: string
+      replayPreset:
+        title: Replay Preset
+        description: Where to start reading the channel. LATEST receives only new events, EARLIEST replays from the retention window, CUSTOM starts from replayId.
+        type: string
+        default: "LATEST"
+        enum: ["LATEST", "EARLIEST", "CUSTOM"]
+      replayId:
+        title: Replay Id
+        description: The replay id to resume from. Only used when replayPreset is CUSTOM.
+        type: string
+      batchSize:
+        title: Batch Size
+        description: The number of events requested from the Pub/Sub API in a single fetch.
+        type: integer
+        default: 100
+  dependencies:
+    - "camel:core"
+    - "camel:salesforce"
+    - "camel:kamelet"
+  template:
+    beans:
+      - name: local-salesforce-pubsub
+        type: "#class:org.apache.camel.component.salesforce.SalesforceComponent"
+        properties:
+          clientId: "{{clientId}}"
+          clientSecret: "{{clientSecret}}"
+          userName: "{{userName}}"
+          password: "{{password}}"
+          loginUrl: "{{loginUrl}}"
+    from:
+      uri: "{{local-salesforce-pubsub}}:pubSubSubscribe:{{topic}}"
+      parameters:
+        pubSubDeserializeType: "{{deserializeType}}"
+        pubSubPojoClass: "{{?pojoClass}}"
+        replayPreset: "{{replayPreset}}"
+        pubSubReplayId: "{{?replayId}}"
+        pubSubBatchSize: "{{batchSize}}"
+      steps:
+      - to: "kamelet:sink"

--- a/library/camel-kamelets/src/main/resources/kamelets/salesforce-pubsub-source.kamelet.yaml
+++ b/library/camel-kamelets/src/main/resources/kamelets/salesforce-pubsub-source.kamelet.yaml
@@ -1,0 +1,134 @@
+# ---------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ---------------------------------------------------------------------------
+apiVersion: camel.apache.org/v1
+kind: Kamelet
+metadata:
+  name: salesforce-pubsub-source
+  annotations:
+    camel.apache.org/kamelet.support.level: "Preview"
+    camel.apache.org/catalog.version: "4.22.1-SNAPSHOT"
+    camel.apache.org/kamelet.icon: "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz48c3ZnIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHZpZXdCb3g9IjAgMCA0OCA0OCIgdmVyc2lvbj0iMS4xIj48ZyBpZD0ic3VyZmFjZTEiPjxwYXRoIGQ9Ik0zNi41IDEyYy0xLjMyNCAwLTIuNTkuMjU4LTMuNzU4LjcwM0E3Ljk5NCA3Ljk5NCAwIDAgMCAyNiA5Yy0yLjEwNSAwLTQuMDIuODItNS40NDUgMi4xNTJBOS40NjggOS40NjggMCAwIDAgMTMuNSA4QzguMjU0IDggNCAxMi4yNTQgNCAxNy41YzAgLjc5My4xMSAxLjU1OS4yOSAyLjI5M0E4LjQ3MiA4LjQ3MiAwIDAgMCAxIDI2LjVDMSAzMS4xOTUgNC44MDUgMzUgOS41IDM1Yy40MTQgMCAuODE2LS4wNCAxLjIxNS0uMDk4IDEuMzEyIDMgNC4zIDUuMDk4IDcuNzg1IDUuMDk4IDMuMTYgMCA1LjkxNC0xLjczIDcuMzc5LTQuMjkzQTcuOTIzIDcuOTIzIDAgMCAwIDI4IDM2YzIuNjIxIDAgNC45MzgtMS4yNjYgNi4zOTgtMy4yMS42OC4xMzYgMS4zODMuMjEgMi4xMDIuMjFDNDIuMyAzMyA0NyAyOC4zIDQ3IDIyLjVTNDIuMyAxMiAzNi41IDEyeiIgZmlsbD0iIzAzOUJFNSIvPjxwYXRoIGQ9Ik0xNS44MjQgMjVjLjA0MyAwIC4wNzQtLjAzNS4wNzQtLjA4MiAwIC4wNDctLjAzLjA4Mi0uMDc0LjA4MnoiIGZpbGw9IiNGRkYiLz48cGF0aCBkPSJNMjEuNTA0IDIzLjkzNHoiIGZpbGw9IiNGRkYiLz48cGF0aCBkPSJNNy4xMzcgMjMuOTNhLjExNi4xMTYgMCAwIDEgLjAwNCAwaC0uMDA0eiIgZmlsbD0iI0ZGRiIvPjxwYXRoIGQ9Ik0yNC4xMjUgMjEuOTFjLS4wMTYuMDQtLjA0Ny4wNDMtLjA3LjA0M2guMDA4Yy4wMjMgMCAuMDUtLjAwOC4wNjItLjA0M3oiIGZpbGw9IiNGRkYiLz48cGF0aCBkPSJNMTUuODI0IDE5Yy4wNDMgMCAuMDc0LjAzNS4wNzQuMDgyIDAtLjA0Ny0uMDMtLjA4Mi0uMDc0LS4wODJ6IiBmaWxsPSIjRkZGIi8+PHBhdGggZD0iTTIxLjM2IDIyLjE4NGMwIC40MS4yMS42NjQuNTAzLjgzNi0uMjkzLS4xNzItLjUwNC0uNDI2LS41MDQtLjgzNnoiIGZpbGw9IiNGRkYiLz48cGF0aCBkPSJNMzguMTI1IDI0LjczYy4wMjcuMDYtLjAzMS4wODYtLjAzMS4wODZzLjA1OC0uMDI3LjAzMS0uMDg2eiIgZmlsbD0iI0ZGRiIvPjxwYXRoIGQ9Ik04LjU1OSAyMXoiIGZpbGw9IiNGRkYiLz48cGF0aCBkPSJNOS43NjYgMjEuOTFjLS4wMi4wNC0uMDQ3LjA0My0uMDc1LjA0M0g5LjdjLjAyOCAwIC4wNTEtLjAwOC4wNjctLjA0M3oiIGZpbGw9IiNGRkYiLz48cGF0aCBkPSJNMzUuMTk1IDI0LjE2NHoiIGZpbGw9IiNGRkYiLz48cGF0aCBkPSJNMzcuODI4IDIxLjc5N2gtLjAyM3MuMDA4LjAwNC4wMjMuMDA0di0uMDA0eiIgZmlsbD0iI0ZGRiIvPjxwYXRoIGQ9Ik0zNy44MzIgMjQuMTg4cy4wMTYgMCAuMDM1LS4wMDRoLS4wMDRjLS4wMTUgMC0uMDMxLjAwMy0uMDMxLjAwM3oiIGZpbGw9IiNGRkYiLz48cGF0aCBkPSJNNi44ODcgMjQuNDZjLS4wMzIuMDcxLjAwOC4wODcuMDIuMDk5LjA4NS4wNTguMTcxLjA5Ny4yNjEuMTQ0LjQ2OS4yMy45MS4yOTcgMS4zNzUuMjk3Ljk0NSAwIDEuNTMxLS40NiAxLjUzMS0xLjIwN3YtLjAxNmMwLS42ODctLjY2NC0uOTM3LTEuMjg1LTEuMTE3bC0uMDc4LS4wMjNjLS40NjktLjE0LS44NzEtLjI2Mi0uODcxLS41NDd2LS4wMTZjMC0uMjQyLjIzNC0uNDIyLjYwMS0uNDIyLjQwNyAwIC44ODcuMTI1IDEuMi4yODUgMCAwIC4wOS4wNTUuMTI1LS4wMjcuMDE1LS4wNDMuMTc1LS40MzMuMTkxLS40NzYuMDItLjA0My0uMDE2LS4wNzktLjA0Ny0uMDk4QTIuODQ1IDIuODQ1IDAgMCAwIDguNTYgMjFoLS4wOTRjLS44NjMgMC0xLjQ2OS40OC0xLjQ2OSAxLjE3MnYuMDEyYzAgLjcyNi42NjQuOTY0IDEuMjkgMS4xMjhsLjEuMDI4Yy40NTQuMTI5Ljg0NC4yMzguODQ0LjUzMXYuMDE2YzAgLjI3LS4yNTMuNDcyLS42NjQuNDcyLS4xNiAwLS42NjgtLjAwNC0xLjIxNC0uMzI0YTIuNDUgMi40NSAwIDAgMS0uMTU3LS4wOWMtLjAyNy0uMDE1LS4wOTMtLjA0My0uMTI1LjA0eiIgZmlsbD0iI0ZGRiIvPjxwYXRoIGQ9Ik0yMS4yNDYgMjQuNDZjLS4wMjcuMDcxLjAxMi4wODcuMDIuMDk5LjA5LjA1OC4xNzUuMDk3LjI2MS4xNDQuNDcuMjMuOTE0LjI5NyAxLjM4LjI5Ny45NCAwIDEuNTI3LS40NiAxLjUyNy0xLjIwN3YtLjAxNmMwLS42ODctLjY2LS45MzctMS4yODItMS4xMTdsLS4wODItLjAyM2MtLjQ2NS0uMTQtLjg3LS4yNjItLjg3LS41NDd2LS4wMTZjMC0uMjQyLjIzOC0uNDIyLjYwNS0uNDIyLjQwNiAwIC44ODYuMTI1IDEuMTk5LjI4NSAwIDAgLjA5LjA1NS4xMjUtLjAyNy4wMTYtLjA0My4xNzItLjQzMy4xOTEtLjQ3Ni4wMTYtLjA0My0uMDE1LS4wNzktLjA0Ny0uMDk4QTIuODU3IDIuODU3IDAgMCAwIDIyLjkyMiAyMWgtLjA5OGMtLjg2MyAwLTEuNDY1LjQ4LTEuNDY1IDEuMTcydi4wMTJjMCAuNzI2LjY2NC45NjQgMS4yOSAxLjEyOGwuMDk3LjAyOGMuNDU3LjEyOS44NDguMjM4Ljg0OC41MzF2LjAxNmMwIC4yNy0uMjU0LjQ3Mi0uNjY0LjQ3Mi0uMTYgMC0uNjY4LS4wMDQtMS4yMTUtLjMyNGEyLjQ1IDIuNDUgMCAwIDEtLjE1Ni0uMDljLS4wMi0uMDA4LS4wOTgtLjAzOS0uMTI1LjA0eiIgZmlsbD0iI0ZGRiIvPjxwYXRoIGQ9Ik0zMS40NjUgMjIuMjE5YTEuNzE0IDEuNzE0IDAgMCAwLS4zNi0uNjMzIDEuNzQgMS43NCAwIDAgMC0uNjAxLS40MyAyLjE4NyAyLjE4NyAwIDAgMC0uODQ4LS4xNTZjLS4zMTYgMC0uNjAxLjA1NS0uODQzLjE1NmExLjY3IDEuNjcgMCAwIDAtLjYwMi40M2MtLjE2NC4xNzYtLjI4MS4zOS0uMzYuNjMzYTIuNTQ0IDIuNTQ0IDAgMCAwLS4xMTcuNzg1YzAgLjI3Ny4wNC41NDMuMTE4Ljc4NWExLjY5MSAxLjY5MSAwIDAgMCAuOTYgMS4wNTljLjI0My4wOTcuNTI4LjE1Mi44NDQuMTUyLjMyIDAgLjYwNi0uMDUuODQ4LS4xNTIuMjM4LS4xMDIuNDQxLS4yNDYuNjAxLS40MjIuMTYtLjE4LjI4Mi0uMzk1LjM2LS42MzcuMDc4LS4yNDIuMTE3LS41MDQuMTE3LS43ODVzLS4wMzktLjU0My0uMTE3LS43ODVtLS43OS43ODVjMCAuNDIyLS4wODEuNzU4LS4yNS45OTItLjE2Ny4yMzQtLjQxNy4zNDgtLjc2OS4zNDgtLjM0NyAwLS41OTctLjExNC0uNzYxLS4zNDgtLjE2OC0uMjM0LS4yNS0uNTctLjI1LS45OTIgMC0uNDIyLjA4NS0uNzU4LjI1LS45ODguMTY0LS4yMzUuNDE0LS4zNDQuNzYxLS4zNDQuMzUyIDAgLjYwMi4xMS43Ny4zNDQuMTY4LjIzLjI1LjU2Ni4yNS45ODgiIGZpbGw9IiNGRkYiLz48cGF0aCBkPSJNMzcuOTM0IDI0LjIzNGMtLjAyOC0uMDc0LS4xMDItLjA0Ny0uMTAyLS4wNDdhMS43NDMgMS43NDMgMCAwIDEtLjM2Ny4wOTggMi44OCAyLjg4IDAgMCAxLS40My4wMzFjLS4zODMgMC0uNjgzLS4xMDUtLjkwMi0uMzEyLS4yMTUtLjIxMS0uMzM2LS41NDctLjMzNi0xIDAtLjQxNC4xMS0uNzI3LjMtLjk2NS4xOTItLjIzNC40ODUtLjM1NS44NzYtLjM1NS4zMjQgMCAuNTc0LjAzNS44MzIuMTA5IDAgMCAuMDYyLjAyNy4wOS0uMDUuMDctLjE3Ny4xMi0uMzAyLjE5NS0uNDk3LjAyLS4wNTgtLjAzMS0uMDgyLS4wNS0uMDg2YTMuMjQgMy4yNCAwIDAgMC0uNTI0LS4xMjUgNC40MzUgNC40MzUgMCAwIDAtLjU5LS4wMzVjLS4zMzIgMC0uNjI1LjA1NS0uODguMTU2YTEuODQyIDEuODQyIDAgMCAwLS42MzYuNDI2Yy0uMTY4LjE4LS4yOTcuMzk1LS4zODMuNjM3YTIuMzE1IDIuMzE1IDAgMCAwLS4xMjkuNzg1YzAgLjYwNS4xNzYgMS4wOTQuNTI4IDEuNDUzLjM0Ny4zNi44Ny41NDMgMS41NTQuNTQzLjQwMyAwIC44MTctLjA3NCAxLjExNC0uMTg0IDAgMCAuMDU4LS4wMjcuMDM1LS4wODZ6IiBmaWxsPSIjRkZGIi8+PHBhdGggZD0iTTQxLjk2NSAyMi4wODJhMS41MiAxLjUyIDAgMCAwLS4zNDQtLjU3OCAxLjUxNiAxLjUxNiAwIDAgMC0uNTA0LS4zNiAyLjEwNSAyLjEwNSAwIDAgMC0uNzY1LS4xNDRjLS4zMzIgMC0uNjMzLjA1LS44OC4xNi0uMjQ1LjEwNi0uNDUyLjI1LS42MTMuNDM0LS4xNjQuMTgtLjI4NS4zOTgtLjM2My42NGEyLjYwNSAyLjYwNSAwIDAgMC0uMTE3Ljc5YzAgLjI4NS4wNDMuNTUuMTIxLjc5Mi4wODIuMjM5LjIxLjQ1NC4zODcuNjMuMTc1LjE3NS40MDIuMzEyLjY3Mi40MS4yNjUuMDk3LjU5My4xNDguOTY4LjE0NC43NyAwIDEuMTc2LS4xNiAxLjM0LS4yNDYuMDMxLS4wMTYuMDU5LS4wNDMuMDI0LS4xMTdsLS4xNzItLjQ1M2MtLjAyOC0uMDctLjEwMi0uMDQzLS4xMDItLjA0My0uMTkxLjA2Mi0uNDYuMTgzLTEuMDk0LjE4LS40MTQgMC0uNzIyLS4xMS0uOTE0LS4yOS0uMTk1LS4xOC0uMjkzLS40NDUtLjMwOC0uODJoMi42NjRzLjA3IDAgLjA3OC0uMDY2Yy4wMDQtLjAyOC4wOS0uNTA4LS4wNzgtMS4wNjNtLTIuNjUzLjUxNmMuMDM2LS4yMzUuMTA2LS40MzQuMjE1LS41ODIuMTY0LS4yMzUuNDEtLjM2Ljc2Mi0uMzYuMzUyIDAgLjU4Mi4xMjUuNzQ2LjM2LjExLjE1Mi4xNi4zNTUuMTguNTgyeiIgZmlsbD0iI0ZGRiIvPjxwYXRoIGQ9Ik0yMC40NTMgMjIuMDgyYTEuNTE3IDEuNTE3IDAgMCAwLS4zNC0uNTc4IDEuNDkgMS40OSAwIDAgMC0uNTA4LS4zNiAyLjA4MyAyLjA4MyAwIDAgMC0uNzYxLS4xNDRjLS4zMzIgMC0uNjM3LjA1LS44ODMuMTYtLjI0Mi4xMDYtLjQ1LjI1LS42MTMuNDM0YTEuNzggMS43OCAwIDAgMC0uMzYuNjQgMi42MDUgMi42MDUgMCAwIDAtLjExNy43OWMwIC4yODUuMDQuNTUuMTIxLjc5Mi4wNzguMjM5LjIxMS40NTQuMzg3LjYzLjE3Ni4xNzUuMzk4LjMxMi42NjguNDEuMjcuMDk3LjU5NC4xNDguOTY5LjE0NC43NyAwIDEuMTc1LS4xNiAxLjM0My0uMjQ2LjAzMi0uMDE2LjA1NS0uMDQzLjAyNC0uMTE3bC0uMTc2LS40NTNjLS4wMjctLjA3LS4xMDItLjA0My0uMTAyLS4wNDMtLjE5LjA2Mi0uNDYuMTgzLTEuMDkzLjE4LS40MTQgMC0uNzE5LS4xMS0uOTEtLjI5LS4yLS4xOC0uMjk3LS40NDUtLjMxMy0uODJoMi42NjhzLjA3IDAgLjA3OC0uMDY2YzAtLjAyOC4wOS0uNTA4LS4wODItMS4wNjNtLTIuNjUyLjUxNmMuMDM5LS4yMzUuMTEtLjQzNC4yMTUtLjU4Mi4xNjQtLjIzNS40MTQtLjM2Ljc2NS0uMzYuMzQ4IDAgLjU3OC4xMjUuNzQ2LjM2LjExLjE1Mi4xNi4zNTUuMTc2LjU4MnoiIGZpbGw9IiNGRkYiLz48cGF0aCBkPSJNMTIuOTMgMjIuNDhjLS4xMS0uMDAzLS4yNDYtLjAwNy0uNDE0LS4wMDctLjIzIDAtLjQ1NC4wMjMtLjY2LjA3OC0uMjA4LjA1LS4zOTUuMTI5LS41NTUuMjM4LS4xNi4xMDYtLjI5My4yNDItLjM4Ny40MDZhMS4xMzUgMS4xMzUgMCAwIDAtLjE0NC41N2MwIC4yMi4wNDMuNDEuMTI1LjU2My4wNzguMTU2LjE5NS4yODUuMzQzLjM4Ny4xNDkuMTAxLjMzMi4xNzYuNTQzLjIxOS4yMTEuMDQzLjQ1LjA2Ni43MTEuMDY2LjI3NCAwIC41NDMtLjAyLjgwOS0uMDYzLjI2MS0uMDQyLjU4Mi0uMTAxLjY3Mi0uMTIuMDktLjAyLjE4Ny0uMDQ0LjE4Ny0uMDQ0LjA2Ny0uMDE1LjA1OS0uMDgyLjA1OS0uMDgydi0yLjI1N2MwLS40OTctLjE0NS0uODY0LS40MjItMS4wOTQtLjI4MS0uMjI3LS42OTUtLjM0LTEuMjI3LS4zNC0uMTk5IDAtLjUyLjAyMy0uNzE1LjA2MyAwIDAtLjU4Mi4xMDEtLjgyLjI3NyAwIDAtLjA1NS4wMzEtLjAyMy4wOThsLjE4Ny40NjhjLjAyNC4wNjMuMDg2LjA0My4wODYuMDQzcy4wMjQtLjAwOC4wNDctLjAyM2MuNTEyLS4yNTggMS4xNi0uMjUgMS4xNi0uMjUuMjkgMCAuNTEyLjA1NC42Ni4xNi4xNDUuMTA1LjIyLjI1OC4yMi41OXYuMTA1Yy0uMjMxLS4wMzEtLjQ0Mi0uMDUtLjQ0Mi0uMDVtLTEuMDYzIDEuNzM4YS41MzguNTM4IDAgMCAxLS4xNTItLjE0OS41Ny41NyAwIDAgMS0uMDc4LS4zMmMwLS4yMTkuMDc4LS4zNzEuMjM4LS40NzctLjAwNCAwIC4yMy0uMTg3Ljc3My0uMTguMzguMDA1LjcyMy4wNTUuNzIzLjA1NXYxLjEyNXMtLjM0LjA2Ny0uNzE5LjA4NmMtLjU0My4wMzItLjc4NS0uMTQtLjc4NS0uMTQiIGZpbGw9IiNGRkYiLz48cGF0aCBkPSJNMzQuNzYyIDIxLjE2OGMuMDItLjA1OS0uMDI0LS4wODItLjA0My0uMDlhMi41MjYgMi41MjYgMCAwIDAtLjQ0Ni0uMDc0Yy0uMzM2LS4wMi0uNTIuMDM1LS42ODcuMTA1LS4xNjguMDctLjM1Mi4xODgtLjQ1LjMybC0uMDAzLS4zMTJjMC0uMDQzLS4wMzEtLjA3OC0uMDc0LS4wNzhoLS42ODRhLjA3Ni4wNzYgMCAwIDAtLjA3OC4wNzh2My44MDVjMCAuMDQzLjAzOS4wNzguMDgyLjA3OGguN2EuMDguMDggMCAwIDAgLjA4MS0uMDc4di0xLjg5OWMwLS4yNTcuMDI4LS41MTEuMDg2LS42NzFhLjk2NC45NjQgMCAwIDEgLjIzNC0uMzc1Ljg2Ljg2IDAgMCAxIC4zMzMtLjE5MiAxLjM1IDEuMzUgMCAwIDEgLjM1NS0uMDQ3Yy4xNCAwIC4yOTMuMDM1LjI5My4wMzUuMDUuMDA0LjA3OC0uMDI3LjA5OC0uMDcuMDQ2LS4xMTMuMTc1LS40NjUuMjAzLS41MzUiIGZpbGw9IiNGRkYiLz48cGF0aCBkPSJNMjguMjAzIDE5LjEwNWExLjk1IDEuOTUgMCAwIDAtLjYyNS0uMDljLS40ODQgMC0uODYzLjEzNy0xLjEyOS40MDctLjI2NS4yNjUtLjQ0NS42NzYtLjUzOSAxLjIxbC0uMDQ3LjM2NGgtLjYwNXMtLjA3NC0uMDA0LS4wOS4wNzhsLS4wOTguNTU1Yy0uMDA4LjA1NS4wMTYuMDg2LjA4Ni4wODZoLjU5bC0uNTk4IDMuMzM2YTQuNDMgNC40MyAwIDAgMS0uMTYuNjYgMS40MjIgMS40MjIgMCAwIDEtLjE4Ny4zNzkuNTA1LjUwNSAwIDAgMS0uMjQyLjE4NyAxIDEgMCAwIDEtLjMxNy4wNDMuOTcuOTcgMCAwIDEtLjIxLS4wMjMuNTguNTggMCAwIDEtLjE0NS0uMDQzcy0uMDctLjAyNy0uMDk4LjA0M2MtLjAyMy4wNTUtLjE4LjQ4OC0uMTk1LjUzOS0uMDIuMDU1LjAwNC4wOTQuMDM5LjEwNS4wNzguMDMyLjEzNy4wNDcuMjQyLjA3NS4xNDguMDM1LjI3My4wMzUuMzkuMDM1LjI0NyAwIC40Ny0uMDM1LjY1Ny0uMTAyLjE4Ny0uMDY2LjM0OC0uMTgzLjQ5Mi0uMzQ0LjE1Ni0uMTcxLjI1NC0uMzUxLjM0OC0uNTkzLjA5LS4yNDYuMTY4LS41NDcuMjM0LS44OTlsLjU5OC0zLjM5OGguODc5cy4wNzQuMDA0LjA5LS4wNzhsLjA5Ny0uNTU1Yy4wMDgtLjA1LS4wMTUtLjA4Ni0uMDg2LS4wODZoLS44NTFjLjAwNC0uMDIuMDU4LS41MDQuMTU2LS43ODVhLjc4OC43ODggMCAwIDEgLjE4Ny0uMjg1LjU2Ni41NjYgMCAwIDEgLjIyMy0uMTQgMS4xNjUgMS4xNjUgMCAwIDEgLjUwNC0uMDJjLjA4Mi4wMi4xMTcuMDI3LjEzNy4wMzUuMDkuMDI3LjA5NyAwIC4xMTctLjA0M2wuMjAzLS41NTljLjAyMy0uMDU4LS4wMjctLjA4Ni0uMDQ3LS4wOTQiIGZpbGw9IiNGRkYiLz48cGF0aCBkPSJNMTUuODk4IDI0LjkxOGMwIC4wNDctLjAzLjA4Mi0uMDc0LjA4MmgtLjcwN2MtLjA0NyAwLS4wNzgtLjAzNS0uMDc4LS4wODJ2LTUuODM2YzAtLjA0Ny4wMzEtLjA4Mi4wNzgtLjA4MmguNzA3Yy4wNDMgMCAuMDc0LjA0LjA3NC4wODJ6IiBmaWxsPSIjRkZGIi8+PC9nPjxtZXRhZGF0YT48cmRmOlJERiB4bWxuczpyZGY9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkvMDIvMjItcmRmLXN5bnRheC1ucyMiIHhtbG5zOnJkZnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvMDEvcmRmLXNjaGVtYSMiIHhtbG5zOmRjPSJodHRwOi8vcHVybC5vcmcvZGMvZWxlbWVudHMvMS4xLyI+PHJkZjpEZXNjcmlwdGlvbiBhYm91dD0iaHR0cHM6Ly9pY29uc2NvdXQuY29tL2xlZ2FsI2xpY2Vuc2VzIiBkYzp0aXRsZT0ic2FsZXNmb3JjZSIgZGM6ZGVzY3JpcHRpb249InNhbGVzZm9yY2UiIGRjOnB1Ymxpc2hlcj0iSWNvbnNjb3V0IiBkYzpkYXRlPSIyMDE3LTEyLTE1IiBkYzpmb3JtYXQ9ImltYWdlL3N2Zyt4bWwiIGRjOmxhbmd1YWdlPSJlbiI+PGRjOmNyZWF0b3I+PHJkZjpCYWc+PHJkZjpsaT5JY29uczg8L3JkZjpsaT48L3JkZjpCYWc+PC9kYzpjcmVhdG9yPjwvcmRmOkRlc2NyaXB0aW9uPjwvcmRmOlJERj48L21ldGFkYXRhPjwvc3ZnPg=="
+    camel.apache.org/provider: "Apache Software Foundation"
+    camel.apache.org/kamelet.group: "Salesforce"
+    camel.apache.org/kamelet.namespace: "Salesforce"
+  labels:
+    camel.apache.org/kamelet.type: "source"
+spec:
+  definition:
+    title: "Salesforce Pub/Sub Source"
+    description: |-
+      Receive events from the Salesforce Pub/Sub API.
+
+      This is the gRPC based Pub/Sub API, not the older streaming API that salesforce-source uses. Subscribe to a channel such as /event/MyEvent__e, /topic/MyTopic or /data/AccountChangeEvent.
+
+      The Pub/Sub API is gRPC based and needs a protobuf-java new enough for the generated stubs in camel-salesforce. Under Camel JBang an older protobuf is resolved and the route fails to start with NoClassDefFoundError on com.google.protobuf.RuntimeVersion; adding protobuf-java as an explicit dependency resolves it.
+    required:
+      - topic
+      - clientId
+      - clientSecret
+      - userName
+      - password
+    type: object
+    properties:
+      topic:
+        title: Topic
+        description: The Pub/Sub channel to subscribe to.
+        type: string
+        example: "/event/BatchApexErrorEvent"
+      loginUrl:
+        title: Login URL
+        description: The Salesforce instance used to authenticate.
+        type: string
+        default: "https://login.salesforce.com"
+      clientId:
+        title: Consumer Key
+        description: The Salesforce application consumer key.
+        type: string
+        x-descriptors:
+        - urn:camel:group:credentials
+      clientSecret:
+        title: Consumer Secret
+        description: The Salesforce application consumer secret.
+        type: string
+        format: password
+        x-descriptors:
+        - urn:camel:group:credentials
+      userName:
+        title: Username
+        description: The Salesforce username.
+        type: string
+        x-descriptors:
+        - urn:camel:group:credentials
+      password:
+        title: Password
+        description: The Salesforce user password.
+        type: string
+        format: password
+        x-descriptors:
+        - urn:camel:group:credentials
+      deserializeType:
+        title: Deserialize Type
+        description: >-
+          How to deserialise the received events. This Kamelet defaults to JSON so the body is
+          usable downstream without further decoding; the component's own default is AVRO, which
+          emits binary. Use POJO together with pojoClass to deserialise into a generated class.
+        type: string
+        default: "JSON"
+        enum: ["AVRO", "SPECIFIC_RECORD", "GENERIC_RECORD", "POJO", "JSON"]
+      pojoClass:
+        title: POJO Class
+        description: The fully qualified class name to deserialise into. Only used when deserializeType is POJO.
+        type: string
+      replayPreset:
+        title: Replay Preset
+        description: Where to start reading the channel. LATEST receives only new events, EARLIEST replays from the retention window, CUSTOM starts from replayId.
+        type: string
+        default: "LATEST"
+        enum: ["LATEST", "EARLIEST", "CUSTOM"]
+      replayId:
+        title: Replay Id
+        description: The replay id to resume from. Only used when replayPreset is CUSTOM.
+        type: string
+      batchSize:
+        title: Batch Size
+        description: The number of events requested from the Pub/Sub API in a single fetch.
+        type: integer
+        default: 100
+  dependencies:
+    - "camel:core"
+    - "camel:salesforce"
+    - "camel:kamelet"
+  template:
+    beans:
+      - name: local-salesforce-pubsub
+        type: "#class:org.apache.camel.component.salesforce.SalesforceComponent"
+        properties:
+          clientId: "{{clientId}}"
+          clientSecret: "{{clientSecret}}"
+          userName: "{{userName}}"
+          password: "{{password}}"
+          loginUrl: "{{loginUrl}}"
+    from:
+      uri: "{{local-salesforce-pubsub}}:pubSubSubscribe:{{topic}}"
+      parameters:
+        pubSubDeserializeType: "{{deserializeType}}"
+        pubSubPojoClass: "{{?pojoClass}}"
+        replayPreset: "{{replayPreset}}"
+        pubSubReplayId: "{{?replayId}}"
+        pubSubBatchSize: "{{batchSize}}"
+      steps:
+      - to: "kamelet:sink"


### PR DESCRIPTION
Fixes #2263. Also covers the first half of #1546, which asks for the same thing — I have left that one open and commented there rather than closing it, because its second question about keystore authentication is separate and still unanswered.

## The API has been there; the catalog had not caught up

`camel-salesforce` in 4.22 carries both Pub/Sub operations:

```
operationName enum -> [..., 'subscribe', 'pubSubSubscribe', 'pubSubPublish']
```

along with `pubSubBatchSize`, `pubSubDeserializeType`, `pubSubPojoClass`, `pubSubReplayId`, `replayPreset`, and host/port options. The catalog only had `salesforce-source`, which uses the **older streaming API** (`subscribe`, topics, `notifyForOperation*`). This adds a source for the gRPC one.

I did the source rather than both halves: #2263 asks about consuming, and a `pubSubPublish` sink is a clean follow-up rather than something to bundle here.

## One default deliberately differs from the component

`deserializeType` defaults to **JSON**, where the component defaults to **AVRO**.

A Kamelet emits to `kamelet:sink`, and AVRO puts binary on the body that the next step has to decode before it is useful. JSON is usable as-is, which is the point of a Kamelet. All five values remain available, and the property description states plainly that AVRO is the component's own default so nobody is surprised.

## A runtime caveat worth knowing about

Verifying this turned up something users will hit. Under Camel JBang the resolved `protobuf-java` is older than the generated gRPC stubs in `camel-salesforce` expect, and the route dies during class loading:

```
java.lang.NoClassDefFoundError: com/google/protobuf/RuntimeVersion$RuntimeDomain
```

That is before any endpoint is built, so it looks nothing like a configuration problem. Adding protobuf explicitly fixes it:

```
camel run route.yaml --dep=com.google.protobuf:protobuf-java:4.35.1
```

I put this in the Kamelet description rather than leaving it to be rediscovered.

**I did not add it to `spec.dependencies`.** It would work, and protobuf is BSD-3 so the licence is fine, but every pinned `mvn:` version in this catalog is managed from the root pom by the `UpdateKamelets` step — `artemis-jakarta-client-all` is the model. Hardcoding `4.35.1` here would drift from Camel the first time it moves. Wiring a managed `protobuf-version` property is the correct fix and is a maintainer decision about version coupling, so I have flagged it rather than made it. Say the word and I will do it properly.

## Verification

`script/validator` reports no errors, `script/generator` adds the `nav.adoc` entry, `mvn clean install` passes **with tests** from the repository root.

With protobuf pinned, the Kamelet reaches a real login attempt and fails only on the deliberately invalid host:

```
Failed to start component local-salesforce-pubsub-1 because of
  SalesforceException: Unexpected login error: login.salesforce.invalid
Caused by: java.net.UnknownHostException
```

Every parameter binds and the gRPC path is exercised — the failure is the network, not the configuration.

**No Citrus test**: this needs a real Salesforce org, which no emulator provides. Ships `Preview` without `kamelet.verified=true`.

---
_Claude Code on behalf of Andrea Cosentino_
